### PR TITLE
Remove paragraph indices from content paths

### DIFF
--- a/wagtail_localize/segments/extract.py
+++ b/wagtail_localize/segments/extract.py
@@ -27,8 +27,7 @@ class StreamFieldSegmentExtractor:
             template, texts = extract_html_segments(block_value.source)
 
             return [TemplateValue("", "html", template, len(texts))] + [
-                SegmentValue.from_html(str(position), text)
-                for position, text in enumerate(texts)
+                SegmentValue.from_html("", text) for text in texts
             ]
 
         elif isinstance(block_type, (ImageChooserBlock, SnippetChooserBlock)):
@@ -113,8 +112,7 @@ def extract_segments(instance):
             template, texts = extract_html_segments(field.value_from_object(instance))
 
             field_segments = [TemplateValue("", "html", template, len(texts))] + [
-                SegmentValue.from_html(str(position), text)
-                for position, text in enumerate(texts)
+                SegmentValue.from_html("", text) for text in texts
             ]
 
             segments.extend(segment.wrap(field.name) for segment in field_segments)

--- a/wagtail_localize/segments/ingest.py
+++ b/wagtail_localize/segments/ingest.py
@@ -15,20 +15,14 @@ from .html import restore_html_segments
 
 
 def organise_template_segments(segments):
-    template = None
-    segments_by_position = {}
-
-    for segment in segments:
-        if isinstance(segment, TemplateValue):
-            template = segment
-        else:
-            segments_by_position[int(segment.path)] = segment
-
-    segments = []
-    for position in range(template.segment_count):
-        segments.append(segments_by_position[position].html)
-
-    return template.format, template.template, segments
+    # The first segment is always the template, followed by the texts in order of their position
+    segments.sort(key=lambda segment: segment.order)
+    template = segments[0]
+    return (
+        template.format,
+        template.template,
+        [segment.html for segment in segments[1:]],
+    )
 
 
 def handle_related_object(related_object, src_locale, tgt_locale, segments):

--- a/wagtail_localize/segments/tests/test_segment_extraction.py
+++ b/wagtail_localize/segments/tests/test_segment_extraction.py
@@ -26,14 +26,14 @@ RICH_TEXT_TEST_OUTPUT = [
         '<h1><text position="0"></text></h1><p><text position="1"></text></p><ul><li><text position="2"></text></li></ul>',
         3,
     ),
-    SegmentValue("0", "This is a heading", html_elements=[]),
+    SegmentValue("", "This is a heading", html_elements=[]),
     SegmentValue(
-        "1",
+        "",
         "This is a paragraph. <foo> Bold text",
         html_elements=[SegmentValue.HTMLElement(27, 36, "b1", ("b", {}))],
     ),
     SegmentValue(
-        "2",
+        "",
         "This is a link.",
         html_elements=[
             SegmentValue.HTMLElement(0, 14, "a1", ("a", {"href": "http://example.com"}))
@@ -266,10 +266,8 @@ class TestSegmentExtractionWithStreamField(TestCase):
         self.assertEqual(
             segments,
             [
-                SegmentValue(f"test_streamfield.{block_id}.0", "Test content"),
-                SegmentValue(
-                    f"test_streamfield.{block_id}.1", "Some more test content"
-                ),
+                SegmentValue(f"test_streamfield.{block_id}", "Test content"),
+                SegmentValue(f"test_streamfield.{block_id}", "Some more test content"),
             ],
         )
 

--- a/wagtail_localize/segments/tests/test_segment_ingestion.py
+++ b/wagtail_localize/segments/tests/test_segment_ingestion.py
@@ -27,19 +27,22 @@ RICH_TEXT_TEST_FRENCH_SEGMENTS = [
         "html",
         '<h1><text position="0"></text></h1><p><text position="1"></text></p><ul><li><text position="2"></text></li></ul>',
         3,
+        order=9,
     ),
-    SegmentValue("0", "Ceci est une rubrique", html_elements=[]),
+    SegmentValue("", "Ceci est une rubrique", html_elements=[], order=10),
     SegmentValue(
-        "1",
+        "",
         "Ceci est un paragraphe. <foo> Texte en gras",
         html_elements=[SegmentValue.HTMLElement(30, 43, "b1", ("b", {}))],
+        order=11,
     ),
     SegmentValue(
-        "2",
+        "",
         "Ceci est un lien",
         html_elements=[
             SegmentValue.HTMLElement(0, 16, "a1", ("a", {"href": "http://example.com"}))
         ],
+        order=12,
     ),
 ]
 
@@ -510,9 +513,11 @@ class TestSegmentExtractionWithStreamField(TestCase):
             self.src_locale,
             self.locale,
             [
-                SegmentValue(f"test_streamfield.{block_id}.0", "Tester le contenu"),
                 SegmentValue(
-                    f"test_streamfield.{block_id}.1", "Encore du contenu de test"
+                    f"test_streamfield.{block_id}", "Tester le contenu", order=0
+                ),
+                SegmentValue(
+                    f"test_streamfield.{block_id}", "Encore du contenu de test", order=1
                 ),
             ],
         )


### PR DESCRIPTION
These aren't stable between revisions. Removing them would allow us to use the content path as segment context as it would no longer change whenever a new paragraph is added.