### PR TITLE
Feature/18 sync languages output

### DIFF
--- a/wagtail_localize/management/commands/sync_languages.py
+++ b/wagtail_localize/management/commands/sync_languages.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.db.models import signals
 
 from wagtail_localize.models import Locale
 
@@ -11,12 +12,14 @@ class Command(BaseCommand):
         language_codes = dict(settings.LANGUAGES).keys()
 
         for language_code in language_codes:
-            Locale.objects.update_or_create(
+            obj, created = Locale.objects.update_or_create(
                 language_code=language_code, defaults={"is_active": True}
             )
+            self.stdout.write("Activated locale: " + obj)
 
         for deactivated_languages in Locale.objects.exclude(
             language_code__in=language_codes
         ).filter(is_active=True):
             deactivated_languages.is_active = False
             deactivated_languages.save()
+            self.stdout.write("Deactivated locale: " + deactivated_languages)

--- a/wagtail_localize/signals.py
+++ b/wagtail_localize/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+language_activated = Signal(providing_args=["locale"])
+language_deactivated = Signal(providing_args=["locale"])


### PR DESCRIPTION
For https://github.com/wagtail/wagtail-localize/issues/18

Ideally we want to make use of the Locale `language_activated` and `language_deactivated` signals to display the output for the `sync_languages` command. But not sure how to implement a receiver in the context of a management command. Any suggestions?