### PR TITLE
WIP: Workaround streamfield blocks without ids for extraction

### DIFF
--- a/wagtail_localize/translation/segments/extract.py
+++ b/wagtail_localize/translation/segments/extract.py
@@ -83,7 +83,7 @@ class StreamFieldSegmentExtractor:
 
         for block in stream_block:
             segments.extend(
-                segment.wrap(block.id)
+                segment.wrap(block.id or 'noid')
                 for segment in self.handle_block(block.block, block.value)
             )
 


### PR DESCRIPTION
On older sites, streamfield blocks don't have IDs

TODO:
 - [ ] Handle ingestion