### PR TITLE
Split out HTML handling logic from SegmentValue into a new class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2
+
+jobs:
+  backend:
+    docker:
+      - image: circleci/python:3.6.4
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - pip-packages-v1-{{ .Branch }}
+            - pip-packages-v1-
+      - run: pipenv install flake8
+      - save_cache:
+          paths:
+            - ~/.local/
+          key: pip-package-v1-{{ .Branch }}
+      - run: pipenv run flake8 wagtail_localize
+      - run: pipenv install -e .[testing]
+      - run: pipenv run python testmanage.py test
+
+  nightly-wagtail-test:
+    docker:
+      - image: circleci/python:3.7.3
+    steps:
+      - checkout
+      - run: git clone git@github.com:wagtail/wagtail.git
+      - run: pipenv install -e .[testing] -e ./wagtail
+      - run: pipenv run python testmanage.py test
+
+workflows:
+    version: 2
+    test:
+      jobs:
+        - backend
+
+    nightly:
+      jobs:
+        - nightly-wagtail-test
+      triggers:
+        - schedule:
+            cron: "0 0 * * *"
+            filters:
+              branches:
+                only:
+                  - master

--- a/.circleci/trigger-nightly-build.sh
+++ b/.circleci/trigger-nightly-build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Triggers a test run against the master version of Wagtail
+
+# This job will is scheduled in the config.yml, this script is here to help test the job
+
+curl -u ${CIRCLE_API_USER_TOKEN}: \
+     -d build_parameters[CIRCLE_JOB]=nightly-wagtail-test \
+     https://circleci.com/api/v1.1/project/github/wagtail/wagtail-localize/tree/master

--- a/wagtail_localize/admin_views.py
+++ b/wagtail_localize/admin_views.py
@@ -1,6 +1,3 @@
-from collections import defaultdict
-
-from django.conf import settings
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 

--- a/wagtail_localize/bootstrap.py
+++ b/wagtail_localize/bootstrap.py
@@ -1,9 +1,6 @@
 import uuid
 
-from django.conf import settings
 from django.db import migrations
-
-from .compat import get_supported_language_variant
 
 
 def bootstrap_translatable_model(model, locale):

--- a/wagtail_localize/management/commands/bootstrap_translatable_models.py
+++ b/wagtail_localize/management/commands/bootstrap_translatable_models.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from wagtail_localize.bootstrap import bootstrap_translatable_model
 from wagtail_localize.models import BootstrapTranslatableMixin, get_translatable_models

--- a/wagtail_localize/management/commands/sync_languages.py
+++ b/wagtail_localize/management/commands/sync_languages.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from wagtail_localize.models import Locale
 

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -3,19 +3,18 @@ import uuid
 
 from django.apps import apps
 from django.conf import settings
+from django.core.files.base import ContentFile
 from django.db import models, transaction
-from django.db.models import Exists, OuterRef, Q
-from django.db.models.signals import pre_save, post_save, m2m_changed
+from django.db.models import Q
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils import translation
 from modelcluster.fields import ParentalKey
 from wagtail.core.models import Page
-from wagtail.core.signals import page_published
 from wagtail.images.models import AbstractImage
 
 from .compat import get_languages, get_supported_language_variant
-from .edit_handlers import filter_edit_handler_on_instance_bound
-from .fields import TranslatableField, SynchronizedField
+from .fields import TranslatableField
 from .utils import find_available_slug
 
 

--- a/wagtail_localize/test/migrations/0007_more_synchronized_fields.py
+++ b/wagtail_localize/test/migrations/0007_more_synchronized_fields.py
@@ -134,6 +134,6 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"ordering": ["sort_order"], "abstract": False,},
+            options={"ordering": ["sort_order"], "abstract": False},
         ),
     ]

--- a/wagtail_localize/test/models.py
+++ b/wagtail_localize/test/models.py
@@ -41,7 +41,7 @@ class CustomStructBlock(blocks.StructBlock):
     def restore_translated_segments(self, value, segments):
         for segment in segments:
             if segment.path == "foo":
-                field_a, field_b = segment.text.split("/")
+                field_a, field_b = segment.translation.text.split("/")
                 value["field_a"] = field_a.strip()
                 value["field_b"] = field_b.strip()
 

--- a/wagtail_localize/tests/test_mixins.py
+++ b/wagtail_localize/tests/test_mixins.py
@@ -3,14 +3,11 @@ from unittest.mock import Mock, patch
 from django.conf import settings
 from django.test import TestCase
 
-from wagtail.core.models import Page
-
 from wagtail_localize.models import Locale
 from wagtail_localize.test.models import (
     InheritedTestModel,
     TestChildObject,
     TestModel,
-    TestPage,
 )
 from wagtail_localize.tests.test_locale_model import make_test_page
 

--- a/wagtail_localize/translation/migrations/0001_initial.py
+++ b/wagtail_localize/translation/migrations/0001_initial.py
@@ -37,7 +37,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"unique_together": {("language", "text_id")},},
+            options={"unique_together": {("language", "text_id")}},
         ),
         migrations.CreateModel(
             name="SegmentTranslationContext",
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"unique_together": {("content_type", "translation_key")},},
+            options={"unique_together": {("content_type", "translation_key")}},
         ),
         migrations.CreateModel(
             name="TranslatableRevision",
@@ -209,7 +209,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={"abstract": False},
         ),
         migrations.AddField(
             model_name="segmenttranslationcontext",
@@ -257,7 +257,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={"abstract": False},
         ),
         migrations.CreateModel(
             name="RelatedObjectLocation",
@@ -295,7 +295,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={"abstract": False},
         ),
         migrations.AlterUniqueTogether(
             name="segmenttranslationcontext", unique_together={("object", "path_id")},
@@ -341,6 +341,6 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"unique_together": {("language", "translation_of", "context")},},
+            options={"unique_together": {("language", "translation_of", "context")}},
         ),
     ]

--- a/wagtail_localize/translation/migrations/0003_change_language_to_locale_2.py
+++ b/wagtail_localize/translation/migrations/0003_change_language_to_locale_2.py
@@ -7,6 +7,7 @@ from django.db import migrations
 
 
 def migrate_to_locale(apps, schema_editor):
+    Locale = apps.get_model("wagtail_localize.Locale")
     Segment = apps.get_model("wagtail_localize_translation.Segment")
     SegmentTranslation = apps.get_model(
         "wagtail_localize_translation.SegmentTranslation"

--- a/wagtail_localize/translation/segments/__init__.py
+++ b/wagtail_localize/translation/segments/__init__.py
@@ -1,10 +1,6 @@
-from collections import Counter
-
 from django.contrib.contenttypes.models import ContentType
-from django.forms.utils import flatatt
-from django.utils.html import escape
 
-from .html import extract_html_elements, restore_html_elements
+from .html import HTMLSnippet
 
 
 class BaseValue:
@@ -64,162 +60,39 @@ class BaseValue:
 
 
 class SegmentValue(BaseValue):
-    class HTMLElement:
-        """
-        Represents the position of an inline element within an HTML segment value.
+    def __init__(self, path, source, translation=None, **kwargs):
+        if isinstance(source, str):
+            source = HTMLSnippet.from_plaintext(source)
 
-        These are used to track how inline elements such as text formatting
-        and links should be moved in translated versions of a segment.
+        if isinstance(translation, str):
+            translation = HTMLSnippet.from_plaintext(translation)
 
-        The parameters are as follows:
-
-        - start/end are the character offsets in the original text that this element appears
-        they may be equal but end must not be less than start.
-        For example, to select just the first character, the start and end offsets with be 0,1
-        respectively.
-        - identifier is a number that is generated from the segment extractor. It must be conserved
-        by translation engines as it is used to work out where elements have moved during translation.
-        """
-
-        def __init__(self, start, end, identifier, element=None):
-            self.start = start
-            self.end = end
-            self.identifier = identifier
-            self.element = element
-
-        @property
-        def element_tag(self):
-            return f"<{self.element[0]}{flatatt(self.element[1])}>"
-
-        def __eq__(self, other):
-            if not isinstance(other, SegmentValue.HTMLElement):
-                return False
-
-            return (
-                self.start == other.start
-                and self.end == other.end
-                and self.identifier == other.identifier
-                and self.element == other.element
-            )
-
-        def __repr__(self):
-            return f"<SegmentValue.HTMLElement {self.identifier} '{self.element_tag}' at [{self.start}:{self.end}]>"
-
-    def __init__(self, path, text, html_elements=None, **kwargs):
-        self.text = text
-        self.html_elements = html_elements
+        self.source = source
+        self.translation = translation
 
         super().__init__(path, **kwargs)
 
     def clone(self):
         return SegmentValue(
-            self.path, self.text, html_elements=self.html_elements, order=self.order
+            self.path, self.source, translation=self.translation, order=self.order
         )
-
-    @classmethod
-    def from_html(cls, path, html):
-        text, elements = extract_html_elements(html)
-
-        html_elements = []
-        counter = Counter()
-        for start, end, element_type, element_attrs in elements:
-            counter[element_type] += 1
-            identifier = element_type + str(counter[element_type])
-
-            html_elements.append(
-                cls.HTMLElement(start, end, identifier, (element_type, element_attrs))
-            )
-
-        return cls(path, text, html_elements)
-
-    @property
-    def html(self):
-        if not self.html_elements:
-            return escape(self.text)
-
-        return restore_html_elements(
-            self.text,
-            [(e.start, e.end, e.element[0], e.element[1]) for e in self.html_elements],
-        )
-
-    @property
-    def html_with_ids(self):
-        if not self.html_elements:
-            return escape(self.text)
-
-        return restore_html_elements(
-            self.text,
-            [
-                (
-                    e.start,
-                    e.end,
-                    e.element[0],
-                    {"id": e.identifier} if e.element[1] else {},
-                )
-                for e in self.html_elements
-            ],
-        )
-
-    def get_html_attrs(self):
-        """
-        Returns a mapping of html element identifiers to their attributes.
-
-        For example, running this on the following segment:
-
-            <b>Foo <a id="a1" href="https://mysite.com">Bar</a></b>
-
-        Would return the following dictionary:
-
-            {
-                "a#a1": {"href": "https://mysite.com"}
-            }
-        """
-        return {
-            f"{e.element[0]}#{e.identifier}": e.element[1]
-            for e in self.html_elements or []
-            if e.element[1]
-        }
-
-    def replace_html_attrs(self, attrs_map):
-        """
-        Replaces the attributes of the HTML elements in this segment with
-        attributes in the provided mapping.
-
-        This is used to overwrite any HTML attribute changes made to
-        translated segments so they are guarenteed to not be altered by
-        translators.
-
-        For example, running this on the following segment:
-
-            <b>Foo <a id="a1" href="https://badsite.com">Bar</a></b>
-
-        With the following attrs_map:
-
-            {
-                "a#a1": {"href": "https://mysite.com"}
-            }
-
-        Would return the following segment:
-
-            <b>Foo <a id="a1" href="https://mysite.com">Bar</a></b>
-        """
-        for e in self.html_elements:
-            key = f"{e.element[0]}#{e.identifier}"
-            if key in attrs_map:
-                e.element = (e.element[0], attrs_map[key])
 
     def is_empty(self):
-        return self.html in ["", None]
+        return self.source.html in ["", None]
 
     def __eq__(self, other):
         return (
             isinstance(other, SegmentValue)
             and self.path == other.path
-            and self.html == other.html
+            and self.source == other.source
+            and self.translation == other.translation
         )
 
     def __repr__(self):
-        return '<SegmentValue {} "{}">'.format(self.path, self.html)
+        if self.translation:
+            return '<SegmentValue {} "{}" "{}">'.format(self.path, self.source.html, self.translation.html)
+        else:
+            return '<SegmentValue {} "{}">'.format(self.path, self.source.html)
 
 
 class TemplateValue(BaseValue):

--- a/wagtail_localize/translation/segments/extract.py
+++ b/wagtail_localize/translation/segments/extract.py
@@ -12,7 +12,7 @@ from wagtail_localize.translation.segments import (
     RelatedObjectValue,
 )
 
-from .html import extract_html_segments
+from .html import extract_html_snippets
 
 
 class StreamFieldSegmentExtractor:
@@ -27,10 +27,10 @@ class StreamFieldSegmentExtractor:
             return [SegmentValue("", block_value)]
 
         elif isinstance(block_type, blocks.RichTextBlock):
-            template, texts = extract_html_segments(block_value.source)
+            template, snippets = extract_html_snippets(block_value.source)
 
-            return [TemplateValue("", "html", template, len(texts))] + [
-                SegmentValue.from_html("", text) for text in texts
+            return [TemplateValue("", "html", template, len(snippets))] + [
+                SegmentValue("", snippet) for snippet in snippets
             ]
 
         elif isinstance(block_type, blocks.ChooserBlock):
@@ -112,10 +112,10 @@ def extract_segments(instance):
             )
 
         elif isinstance(field, RichTextField):
-            template, texts = extract_html_segments(field.value_from_object(instance))
+            template, snippets = extract_html_snippets(field.value_from_object(instance))
 
-            field_segments = [TemplateValue("", "html", template, len(texts))] + [
-                SegmentValue.from_html("", text) for text in texts
+            field_segments = [TemplateValue("", "html", template, len(snippets))] + [
+                SegmentValue("", snippet) for snippet in snippets
             ]
 
             segments.extend(segment.wrap(field.name) for segment in field_segments)

--- a/wagtail_localize/translation/segments/extract.py
+++ b/wagtail_localize/translation/segments/extract.py
@@ -3,7 +3,6 @@ from django.db import models
 from modelcluster.fields import ParentalKey
 from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
-from wagtail.core.rich_text import RichText
 from wagtail.embeds.blocks import EmbedBlock
 
 from wagtail_localize.models import TranslatableMixin

--- a/wagtail_localize/translation/segments/html.py
+++ b/wagtail_localize/translation/segments/html.py
@@ -1,7 +1,11 @@
+from collections import Counter
+
 from bs4 import BeautifulSoup, NavigableString
+from django.forms.utils import flatatt
+from django.utils.html import escape
 
 
-# List of tags that are allowed in segments
+# List of tags that are allowed in HTML snippets
 INLINE_TAGS = ["a", "abbr", "acronym", "b", "code", "em", "i", "strong", "br"]
 
 
@@ -28,9 +32,9 @@ def rstrip_keep(text):
     return new_text, suffix
 
 
-def extract_html_segments(html):
+def extract_html_snippets(html):
     """
-    This function extracts translatable segments from an HTML fragment.
+    This function extracts translatable snippets from an HTML fragment.
 
     Inline elements and visible text are extracted together.
 
@@ -55,9 +59,9 @@ def extract_html_segments(html):
         </p>
 
         [
-            "Foo",
-            "Bar",
-            "<b>Baz</b>",
+            HTMLSnippet("Foo"),
+            HTMLSnippet("Bar"),
+            HTMLSnippet("<b>Baz</b>"),
         ]
     """
     soup = BeautifulSoup(html, "html.parser")
@@ -76,7 +80,7 @@ def extract_html_segments(html):
             return
 
         # If there is a single element and that is an inline tag, wrap just the contents.
-        # We only care about inline tags that wrap only part of a segment
+        # We only care about inline tags that wrap only part of a snippet
         if (
             len(elements) == 1
             and not isinstance(elements[0], NavigableString)
@@ -193,8 +197,8 @@ def extract_html_segments(html):
 
     walk(soup)
 
-    # Now extract segments from the <text> tags
-    segments = []
+    # Now extract snippets from the <text> tags
+    snippets = []
     for element in soup.descendants:
         if element.name == "text":
             text = element.attrs.pop("value")
@@ -205,8 +209,8 @@ def extract_html_segments(html):
             text, prefix = lstrip_keep(text)
             text, suffix = rstrip_keep(text)
 
-            element.attrs["position"] = len(segments)
-            segments.append(text.strip())
+            element.attrs["position"] = len(snippets)
+            snippets.append(HTMLSnippet.from_html(text.strip()))
 
             if prefix:
                 element.insert_before(prefix)
@@ -214,96 +218,251 @@ def extract_html_segments(html):
             if suffix:
                 element.insert_after(suffix)
 
-    return str(soup), segments
+    return str(soup), snippets
 
 
-def restore_html_segments(template, segments):
+def restore_html_snippets(template, snippets):
     soup = BeautifulSoup(template, "html.parser")
 
     for text_element in soup.findAll("text"):
-        value = segments[int(text_element.get("position"))]
-        text_element.replaceWith(BeautifulSoup(value.strip(), "html.parser"))
+        snippet = snippets[int(text_element.get("position"))]
+        text_element.replaceWith(BeautifulSoup(snippet.html, "html.parser"))
 
     return str(soup)
 
 
-def extract_html_elements(html):
-    """
-    Extracts HTML elements from a fragment. Returns the plain text representation
-    of the HTML document and an array of elements including their span, type and attributes.
+class HTMLSnippet:
+    class Entity:
+        """
+        Represents the position of an inline entity in a HTML snippet
 
-    For example:
+        These are used to track how inline elements such as text formatting
+        and links should be moved in translated versions of a snippet.
 
-    text, elements = extract_html_elements("This is a paragraph. <b>This is some bold <i>and now italic</i></b> text")
+        The parameters are as follows:
 
-    text == "This is a paragraph. This is some bold and now italic text"
-    elements == [(39, 53, 'i', {}), (21, 53, 'b', {})]
-    """
-    soup = BeautifulSoup(html, "html.parser")
+        - start/end are the character offsets in the original text that this element appears
+        they may be equal but end must not be less than start.
+        For example, to select just the first character, the start and end offsets with be 0,1
+        respectively.
+        - identifier is a number that is generated from the snippet extractor. It must be conserved
+        by translation engines as it is used to work out where elements have moved during translation.
+        """
 
-    texts = []
-    cursor = {"current": 0}
-    elements = []
+        def __init__(self, start, end, identifier, element=None):
+            self.start = start
+            self.end = end
+            self.identifier = identifier
+            self.element = element
 
-    def walk(soup):
-        for element in soup.children:
-            if isinstance(element, NavigableString):
-                texts.append(element)
-                cursor["current"] += len(element)
+        @property
+        def element_tag(self):
+            return f"<{self.element[0]}{flatatt(self.element[1])}>"
 
-            else:
-                start = cursor["current"]
-                walk(element)
-                end = cursor["current"]
+        def __eq__(self, other):
+            if not isinstance(other, HTMLSnippet.Entity):
+                return False
 
-                elements.append((start, end, element.name, element.attrs.copy()))
+            return (
+                self.start == other.start
+                and self.end == other.end
+                and self.identifier == other.identifier
+                and self.element == other.element
+            )
 
-    walk(soup)
+        def __repr__(self):
+            return f"<HTMLSnippet.Entity {self.identifier} '{self.element_tag}' at [{self.start}:{self.end}]>"
 
-    return "".join(texts), elements
+    @staticmethod
+    def _extract_html_entities(html):
+        """
+        Extracts HTML elements from a snippet. Returns the plain text representation
+        of the HTML document and an array of elements including their span, type and attributes.
 
+        For example:
 
-def restore_html_elements(text, elements):
-    """
-    Inserts elements into a plain text string returning a HTML document.
-    """
-    soup = BeautifulSoup("", "html.parser")
-    stack = []
-    cursor = 0
-    current_element = soup
+        text, elements = extract_html_entities("This is a paragraph. <b>This is some bold <i>and now italic</i></b> text")
 
-    # Sort elements by start position
-    elements.sort(key=lambda element: element[0])
+        text == "This is a paragraph. This is some bold and now italic text"
+        elements == [(39, 53, 'i', {}), (21, 53, 'b', {})]
+        """
+        soup = BeautifulSoup(html, "html.parser")
 
-    for i, element in enumerate(elements):
-        if cursor < element[0]:
-            # Output text and advance cursor
-            current_element.append(text[cursor:element[0]])
-            cursor = element[0]
+        texts = []
+        cursor = {"current": 0}
+        elements = []
 
-        stack.append((element[1], current_element))
-        new_element = soup.new_tag(element[2], **element[3])
-        current_element.append(new_element)
-        current_element = new_element
+        def walk(soup):
+            for element in soup.children:
+                if isinstance(element, NavigableString):
+                    texts.append(element)
+                    cursor["current"] += len(element)
 
-        # Close existing elements before going to the next element
-        while stack:
-            if i < len(elements) - 1:
-                if stack[len(stack) - 1][0] > elements[i + 1][0]:
-                    # New element created before this one closes.
-                    # Go to next element
-                    break
+                else:
+                    start = cursor["current"]
+                    walk(element)
+                    end = cursor["current"]
 
-            element_end, previous_element = stack.pop()
+                    elements.append((start, end, element.name, element.attrs.copy()))
 
-            if cursor < element_end:
+        walk(soup)
+
+        return "".join(texts), elements
+
+    @staticmethod
+    def _restore_html_entities(text, elements):
+        """
+        Inserts elements into a plain text string returning a HTML document.
+        """
+        soup = BeautifulSoup("", "html.parser")
+        stack = []
+        cursor = 0
+        current_element = soup
+
+        # Sort elements by start position
+        elements.sort(key=lambda element: element[0])
+
+        for i, element in enumerate(elements):
+            if cursor < element[0]:
                 # Output text and advance cursor
-                current_element.append(text[cursor:element_end])
-                cursor = element_end
+                current_element.append(text[cursor:element[0]])
+                cursor = element[0]
 
-            current_element = previous_element
+            stack.append((element[1], current_element))
+            new_element = soup.new_tag(element[2], **element[3])
+            current_element.append(new_element)
+            current_element = new_element
 
-    if cursor < len(text):
-        current_element.append(text[cursor:])
+            # Close existing elements before going to the next element
+            while stack:
+                if i < len(elements) - 1:
+                    if stack[len(stack) - 1][0] > elements[i + 1][0]:
+                        # New element created before this one closes.
+                        # Go to next element
+                        break
 
-    return str(soup)
+                element_end, previous_element = stack.pop()
+
+                if cursor < element_end:
+                    # Output text and advance cursor
+                    current_element.append(text[cursor:element_end])
+                    cursor = element_end
+
+                current_element = previous_element
+
+        if cursor < len(text):
+            current_element.append(text[cursor:])
+
+        return str(soup)
+
+    def __init__(self, text, entities=None):
+        self.text = text
+        self.entities = entities
+
+    @classmethod
+    def from_plaintext(cls, text):
+        return cls(text)
+
+    @classmethod
+    def from_html(cls, html):
+        text, elements = cls._extract_html_entities(html)
+
+        entities = []
+        counter = Counter()
+        for start, end, element_type, element_attrs in elements:
+            counter[element_type] += 1
+            identifier = element_type + str(counter[element_type])
+
+            entities.append(
+                cls.Entity(start, end, identifier, (element_type, element_attrs))
+            )
+
+        return cls(text, entities)
+
+    @property
+    def html(self):
+        if not self.entities:
+            return escape(self.text)
+
+        return self._restore_html_entities(
+            self.text,
+            [(e.start, e.end, e.element[0], e.element[1]) for e in self.entities],
+        )
+
+    @property
+    def html_with_ids(self):
+        if not self.entities:
+            return escape(self.text)
+
+        return self._restore_html_entities(
+            self.text,
+            [
+                (
+                    e.start,
+                    e.end,
+                    e.element[0],
+                    {"id": e.identifier} if e.element[1] else {},
+                )
+                for e in self.entities
+            ],
+        )
+
+    def get_html_attrs(self):
+        """
+        Returns a mapping of html element identifiers to their attributes.
+
+        For example, running this on the following snippet:
+
+            <b>Foo <a id="a1" href="https://mysite.com">Bar</a></b>
+
+        Would return the following dictionary:
+
+            {
+                "a#a1": {"href": "https://mysite.com"}
+            }
+        """
+        return {
+            f"{e.element[0]}#{e.identifier}": e.element[1]
+            for e in self.entities or []
+            if e.element[1]
+        }
+
+    def replace_html_attrs(self, attrs_map):
+        """
+        Replaces the attributes of the HTML elements in this snippet with
+        attributes in the provided mapping.
+
+        This is used to overwrite any HTML attribute changes made to
+        translated snippets so they are guarenteed to not be altered by
+        translators.
+
+        For example, running this on the following snippet:
+
+            <b>Foo <a id="a1" href="https://badsite.com">Bar</a></b>
+
+        With the following attrs_map:
+
+            {
+                "a#a1": {"href": "https://mysite.com"}
+            }
+
+        Would return the following snippet:
+
+            <b>Foo <a id="a1" href="https://mysite.com">Bar</a></b>
+        """
+        for e in self.entities:
+            key = f"{e.element[0]}#{e.identifier}"
+            if key in attrs_map:
+                e.element = (e.element[0], attrs_map[key])
+
+    def is_empty(self):
+        return self.html in ["", None]
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, HTMLSnippet)
+            and self.html == other.html
+        )
+
+    def __repr__(self):
+        return '<HTMLSnippet "{}">'.format(self.html)

--- a/wagtail_localize/translation/segments/html.py
+++ b/wagtail_localize/translation/segments/html.py
@@ -11,7 +11,7 @@ def lstrip_keep(text):
     """
     text_length = len(text)
     new_text = text.lstrip()
-    prefix = text[0 : (text_length - len(new_text))]
+    prefix = text[0:(text_length - len(new_text))]
     return new_text, prefix
 
 
@@ -22,7 +22,7 @@ def rstrip_keep(text):
     text_length = len(text)
     new_text = text.rstrip()
     if text_length != len(new_text):
-        suffix = text[-(text_length - len(new_text)) :]
+        suffix = text[-(text_length - len(new_text)):]
     else:
         suffix = ""
     return new_text, suffix
@@ -278,7 +278,7 @@ def restore_html_elements(text, elements):
     for i, element in enumerate(elements):
         if cursor < element[0]:
             # Output text and advance cursor
-            current_element.append(text[cursor : element[0]])
+            current_element.append(text[cursor:element[0]])
             cursor = element[0]
 
         stack.append((element[1], current_element))

--- a/wagtail_localize/translation/segments/ingest.py
+++ b/wagtail_localize/translation/segments/ingest.py
@@ -6,9 +6,6 @@ from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.rich_text import RichText
 
-from wagtail_localize.models import TranslatableMixin
-from wagtail_localize.translation.segments import TemplateValue
-
 from .html import restore_html_segments
 
 

--- a/wagtail_localize/translation/segments/ingest.py
+++ b/wagtail_localize/translation/segments/ingest.py
@@ -6,7 +6,7 @@ from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.rich_text import RichText
 
-from .html import restore_html_segments
+from .html import restore_html_snippets
 
 
 def organise_template_segments(segments):
@@ -16,7 +16,7 @@ def organise_template_segments(segments):
     return (
         template.format,
         template.template,
-        [segment.html for segment in segments[1:]],
+        [segment.translation for segment in segments[1:]],
     )
 
 
@@ -37,12 +37,12 @@ class StreamFieldSegmentsWriter:
             return block_type.restore_translated_segments(block_value, segments)
 
         elif isinstance(block_type, (blocks.CharBlock, blocks.TextBlock)):
-            return segments[0].text
+            return segments[0].translation.text
 
         elif isinstance(block_type, blocks.RichTextBlock):
-            format, template, segments = organise_template_segments(segments)
+            format, template, snippets = organise_template_segments(segments)
             assert format == "html"
-            return RichText(restore_html_segments(template, segments))
+            return RichText(restore_html_snippets(template, snippets))
 
         elif isinstance(block_type, blocks.ChooserBlock):
             return self.handle_related_object_block(block_value, segments)
@@ -133,11 +133,11 @@ def ingest_segments(original_obj, translated_obj, src_locale, tgt_locale, segmen
         elif isinstance(field, RichTextField):
             format, template, segments = organise_template_segments(field_segments)
             assert format == "html"
-            html = restore_html_segments(template, segments)
+            html = restore_html_snippets(template, segments)
             setattr(translated_obj, field_name, html)
 
         elif isinstance(field, (models.TextField, models.CharField)):
-            setattr(translated_obj, field_name, field_segments[0].text)
+            setattr(translated_obj, field_name, field_segments[0].translation.text)
 
         elif isinstance(field, models.ForeignKey):
             related_original = getattr(original_obj, field_name)

--- a/wagtail_localize/translation/segments/tests/test_html_snippets.py
+++ b/wagtail_localize/translation/segments/tests/test_html_snippets.py
@@ -1,17 +1,15 @@
 from django.test import TestCase
 
-from wagtail_localize.translation.segments import SegmentValue
 from wagtail_localize.translation.segments.html import (
-    extract_html_segments,
-    restore_html_segments,
-    extract_html_elements,
-    restore_html_elements,
+    extract_html_snippets,
+    restore_html_snippets,
+    HTMLSnippet,
 )
 
 
-class TestExtractHTMLSegment(TestCase):
-    def test_extract_segments(self):
-        template, segments = extract_html_segments(
+class TestExtractHTMLSnippets(TestCase):
+    def test_extract_snippets(self):
+        template, snippets = extract_html_snippets(
             """
             <p><b>Bread</b>\xa0is a\xa0<a href="https://en.wikipedia.org/wiki/Staple_food">staple food</a>\xa0prepared from a\xa0<a href="https://en.wikipedia.org/wiki/Dough">dough</a>\xa0of\xa0<a href="https://en.wikipedia.org/wiki/Flour">flour</a>\xa0and\xa0<a href="https://en.wikipedia.org/wiki/Water">water</a>, usually by\xa0<a href="https://en.wikipedia.org/wiki/Baking">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\xa0<a href="https://en.wikipedia.org/wiki/Agriculture#History">agriculture</a>.</p>
             <p>Proportions of types of flour and other ingredients vary widely, as do modes of preparation. As a result, types, shapes, sizes, and textures of breads differ around the world. Bread may be\xa0<a href="https://en.wikipedia.org/wiki/Leaven">leavened</a>\xa0by processes such as reliance on naturally occurring\xa0<a href="https://en.wikipedia.org/wiki/Sourdough">sourdough</a>\xa0microbes, chemicals, industrially produced yeast, or high-pressure aeration. Some bread is cooked before it can leaven, including for traditional or religious reasons. Non-cereal ingredients such as fruits, nuts and fats may be included. Commercial bread commonly contains additives to improve flavor, texture, color, shelf life, and ease of manufacturing.</p>
@@ -27,15 +25,15 @@ class TestExtractHTMLSegment(TestCase):
         )
 
         self.assertEqual(
-            segments,
+            snippets,
             [
-                '<b>Bread</b>\xa0is a\xa0<a href="https://en.wikipedia.org/wiki/Staple_food">staple food</a>\xa0prepared from a\xa0<a href="https://en.wikipedia.org/wiki/Dough">dough</a>\xa0of\xa0<a href="https://en.wikipedia.org/wiki/Flour">flour</a>\xa0and\xa0<a href="https://en.wikipedia.org/wiki/Water">water</a>, usually by\xa0<a href="https://en.wikipedia.org/wiki/Baking">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\xa0<a href="https://en.wikipedia.org/wiki/Agriculture#History">agriculture</a>.',
-                'Proportions of types of flour and other ingredients vary widely, as do modes of preparation. As a result, types, shapes, sizes, and textures of breads differ around the world. Bread may be\xa0<a href="https://en.wikipedia.org/wiki/Leaven">leavened</a>\xa0by processes such as reliance on naturally occurring\xa0<a href="https://en.wikipedia.org/wiki/Sourdough">sourdough</a>\xa0microbes, chemicals, industrially produced yeast, or high-pressure aeration. Some bread is cooked before it can leaven, including for traditional or religious reasons. Non-cereal ingredients such as fruits, nuts and fats may be included. Commercial bread commonly contains additives to improve flavor, texture, color, shelf life, and ease of manufacturing.',
+                HTMLSnippet.from_html('<b>Bread</b>\xa0is a\xa0<a href="https://en.wikipedia.org/wiki/Staple_food">staple food</a>\xa0prepared from a\xa0<a href="https://en.wikipedia.org/wiki/Dough">dough</a>\xa0of\xa0<a href="https://en.wikipedia.org/wiki/Flour">flour</a>\xa0and\xa0<a href="https://en.wikipedia.org/wiki/Water">water</a>, usually by\xa0<a href="https://en.wikipedia.org/wiki/Baking">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\xa0<a href="https://en.wikipedia.org/wiki/Agriculture#History">agriculture</a>.'),
+                HTMLSnippet.from_html('Proportions of types of flour and other ingredients vary widely, as do modes of preparation. As a result, types, shapes, sizes, and textures of breads differ around the world. Bread may be\xa0<a href="https://en.wikipedia.org/wiki/Leaven">leavened</a>\xa0by processes such as reliance on naturally occurring\xa0<a href="https://en.wikipedia.org/wiki/Sourdough">sourdough</a>\xa0microbes, chemicals, industrially produced yeast, or high-pressure aeration. Some bread is cooked before it can leaven, including for traditional or religious reasons. Non-cereal ingredients such as fruits, nuts and fats may be included. Commercial bread commonly contains additives to improve flavor, texture, color, shelf life, and ease of manufacturing.'),
             ],
         )
 
-    def test_extract_segments_2(self):
-        template, segments = extract_html_segments(
+    def test_extract_snippets_2(self):
+        template, snippets = extract_html_snippets(
             """
             <h1>Foo bar baz</h1>
             <p>This is a paragraph. <b>This is some bold <i>and now italic</i></b> text</p>
@@ -63,87 +61,69 @@ class TestExtractHTMLSegment(TestCase):
         )
 
         self.assertEqual(
-            segments,
+            snippets,
             [
-                "Foo bar baz",
-                "This is a paragraph. <b>This is some bold <i>and now italic</i></b> text",
-                "&lt;script&gt; this should be interpreted as text.",
-                "List item one",
-                "List item two",
+                HTMLSnippet.from_html("Foo bar baz"),
+                HTMLSnippet.from_html("This is a paragraph. <b>This is some bold <i>and now italic</i></b> text"),
+                HTMLSnippet.from_html("&lt;script&gt; this should be interpreted as text."),
+                HTMLSnippet.from_html("List item one"),
+                HTMLSnippet.from_html("List item two"),
             ],
         )
 
     def test_block_tag_in_inline_tag(self):
         # If an inline tag contains a block tag. The inline tag must be in the template.
         # Testing for issue https://github.com/mozilla/donate-wagtail/issues/586
-        template, segments = extract_html_segments("<p><i>Foo <p>Bar</p></i></p>")
+        template, snippets = extract_html_snippets("<p><i>Foo <p>Bar</p></i></p>")
 
         self.assertHTMLEqual(
             template,
             '<p><i><text position="0"></text> <p><text position="1"></text></p></i></p>',
         )
 
-        self.assertEqual(segments, ["Foo", "Bar"])
+        self.assertEqual(snippets, [HTMLSnippet.from_html("Foo"), HTMLSnippet.from_html("Bar")])
 
     def test_br_tag_is_treated_as_inline_tag(self):
-        template, segments = extract_html_segments(
+        template, snippets = extract_html_snippets(
             "<p><b>Foo <i>Bar<br/>Baz</i></b></p>"
         )
 
         self.assertHTMLEqual(template, '<p><b><text position="0"></text></b></p>')
 
-        self.assertEqual(segments, ["Foo <i>Bar<br/>Baz</i>"])
+        self.assertEqual(snippets, [HTMLSnippet.from_html("Foo <i>Bar<br/>Baz</i>")])
 
     def test_br_tag_is_removed_when_it_appears_at_beginning_of_segment(self):
-        template, segments = extract_html_segments("<p><i><br/>Foo</i></p>")
+        template, snippets = extract_html_snippets("<p><i><br/>Foo</i></p>")
 
         self.assertHTMLEqual(template, '<p><i><br/><text position="0"></text></i></p>')
 
-        self.assertEqual(segments, ["Foo"])
+        self.assertEqual(snippets, [HTMLSnippet.from_html("Foo")])
 
     def test_br_tag_is_removed_when_it_appears_at_end_of_segment(self):
-        template, segments = extract_html_segments("<p><i>Foo</i><br/></p>")
+        template, snippets = extract_html_snippets("<p><i>Foo</i><br/></p>")
 
         self.assertHTMLEqual(template, '<p><i><text position="0"></text></i><br/></p>')
 
-        self.assertEqual(segments, ["Foo"])
+        self.assertEqual(snippets, [HTMLSnippet.from_html("Foo")])
 
     def test_empty_inline_tag(self):
-        template, segments = extract_html_segments("<p><i></i>Foo</p>")
+        template, snippets = extract_html_snippets("<p><i></i>Foo</p>")
 
         self.assertHTMLEqual(template, '<p><i></i><text position="0"></text></p>')
 
-        self.assertEqual(segments, ["Foo"])
+        self.assertEqual(snippets, [HTMLSnippet.from_html("Foo")])
 
 
-class TestExtractHTMLElements(TestCase):
-    def test_extract_html_elements(self):
-        text, elements = extract_html_elements(
-            "This is a paragraph. <b>This is some bold <i>and now italic</i></b> text"
-        )
-
-        self.assertEqual(
-            text, "This is a paragraph. This is some bold and now italic text"
-        )
-        self.assertEqual(elements, [(39, 53, "i", {}), (21, 53, "b", {})])
-
-    def test_special_chars_unescaped(self):
-        text, elements = extract_html_elements("<b>foo</b><i> &amp; bar</i>")
-
-        self.assertEqual(text, "foo & bar")
-        self.assertEqual(elements, [(0, 3, "b", {}), (3, 9, "i", {})])
-
-
-class TestRestoreHTMLSegments(TestCase):
-    def test_restore_segments(self):
-        html = restore_html_segments(
+class TestRestoreHTMLSnippets(TestCase):
+    def test_restore_snippets(self):
+        html = restore_html_snippets(
             """
             <p><text position="0"></text></p>
             <p><text position="1"></text></p>
             """,
             [
-                '<b>Bread</b>\xa0is a\xa0<a href="https://en.wikipedia.org/wiki/Staple_food">staple food</a>\xa0prepared from a\xa0<a href="https://en.wikipedia.org/wiki/Dough">dough</a>\xa0of\xa0<a href="https://en.wikipedia.org/wiki/Flour">flour</a>\xa0and\xa0<a href="https://en.wikipedia.org/wiki/Water">water</a>, usually by\xa0<a href="https://en.wikipedia.org/wiki/Baking">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\xa0<a href="https://en.wikipedia.org/wiki/Agriculture#History">agriculture</a>.',
-                'Proportions of types of flour and other ingredients vary widely, as do modes of preparation. As a result, types, shapes, sizes, and textures of breads differ around the world. Bread may be\xa0<a href="https://en.wikipedia.org/wiki/Leaven">leavened</a>\xa0by processes such as reliance on naturally occurring\xa0<a href="https://en.wikipedia.org/wiki/Sourdough">sourdough</a>\xa0microbes, chemicals, industrially produced yeast, or high-pressure aeration. Some bread is cooked before it can leaven, including for traditional or religious reasons. Non-cereal ingredients such as fruits, nuts and fats may be included. Commercial bread commonly contains additives to improve flavor, texture, color, shelf life, and ease of manufacturing.',
+                HTMLSnippet.from_html('<b>Bread</b>\xa0is a\xa0<a href="https://en.wikipedia.org/wiki/Staple_food">staple food</a>\xa0prepared from a\xa0<a href="https://en.wikipedia.org/wiki/Dough">dough</a>\xa0of\xa0<a href="https://en.wikipedia.org/wiki/Flour">flour</a>\xa0and\xa0<a href="https://en.wikipedia.org/wiki/Water">water</a>, usually by\xa0<a href="https://en.wikipedia.org/wiki/Baking">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\xa0<a href="https://en.wikipedia.org/wiki/Agriculture#History">agriculture</a>.'),
+                HTMLSnippet.from_html('Proportions of types of flour and other ingredients vary widely, as do modes of preparation. As a result, types, shapes, sizes, and textures of breads differ around the world. Bread may be\xa0<a href="https://en.wikipedia.org/wiki/Leaven">leavened</a>\xa0by processes such as reliance on naturally occurring\xa0<a href="https://en.wikipedia.org/wiki/Sourdough">sourdough</a>\xa0microbes, chemicals, industrially produced yeast, or high-pressure aeration. Some bread is cooked before it can leaven, including for traditional or religious reasons. Non-cereal ingredients such as fruits, nuts and fats may be included. Commercial bread commonly contains additives to improve flavor, texture, color, shelf life, and ease of manufacturing.'),
             ],
         )
 
@@ -156,7 +136,7 @@ class TestRestoreHTMLSegments(TestCase):
         )
 
     def test_restore_segments_2(self):
-        html = restore_html_segments(
+        html = restore_html_snippets(
             """
             <h1><text position="0"></text></h1>
             <p><text position="1"></text></p>
@@ -168,11 +148,11 @@ class TestRestoreHTMLSegments(TestCase):
             <img alt="This bit isn\'t translatable" src="foo">
             """,
             [
-                "Foo bar baz",
-                "This is a paragraph. <b>This is some bold <i>and now italic</i></b> text",
-                "&lt;script&gt; this should be interpreted as text.",
-                "List item one",
-                "<b>List item two</b>",
+                HTMLSnippet.from_html("Foo bar baz"),
+                HTMLSnippet.from_html("This is a paragraph. <b>This is some bold <i>and now italic</i></b> text"),
+                HTMLSnippet.from_html("&lt;script&gt; this should be interpreted as text."),
+                HTMLSnippet.from_html("List item one"),
+                HTMLSnippet.from_html("<b>List item two</b>"),
             ],
         )
 
@@ -191,9 +171,25 @@ class TestRestoreHTMLSegments(TestCase):
         )
 
 
-class TestRestoreHTMLElements(TestCase):
-    def test_restore_html_elements(self):
-        html = restore_html_elements(
+class TestHTMLSnippet(TestCase):
+    def test_extract_html_entities(self):
+        text, elements = HTMLSnippet._extract_html_entities(
+            "This is a paragraph. <b>This is some bold <i>and now italic</i></b> text"
+        )
+
+        self.assertEqual(
+            text, "This is a paragraph. This is some bold and now italic text"
+        )
+        self.assertEqual(elements, [(39, 53, "i", {}), (21, 53, "b", {})])
+
+    def test_special_chars_unescaped(self):
+        text, elements = HTMLSnippet._extract_html_entities("<b>foo</b><i> &amp; bar</i>")
+
+        self.assertEqual(text, "foo & bar")
+        self.assertEqual(elements, [(0, 3, "b", {}), (3, 9, "i", {})])
+
+    def test_restore_html_entities(self):
+        html = HTMLSnippet._restore_html_entities(
             "This is a paragraph. This is some bold and now italic text",
             [(39, 53, "i", {}), (21, 53, "b", {})],
         )
@@ -204,37 +200,44 @@ class TestRestoreHTMLElements(TestCase):
         )
 
     def test_special_chars_escaped(self):
-        html = restore_html_elements("foo & bar", [(0, 3, "b", {}), (3, 9, "i", {})])
+        html = HTMLSnippet._restore_html_entities("foo & bar", [(0, 3, "b", {}), (3, 9, "i", {})])
 
         self.assertEqual(html, "<b>foo</b><i> &amp; bar</i>")
 
-
-class TestHTMLSegmentValue(TestCase):
     def test_text(self):
-        segment = SegmentValue.from_html(
-            "foo",
+        snippet = HTMLSnippet.from_html(
             "This is a paragraph. <b>This is some bold <i>and now italic</i></b> text",
         )
         self.assertEqual(
-            segment.text, "This is a paragraph. This is some bold and now italic text"
+            snippet.text, "This is a paragraph. This is some bold and now italic text"
         )
 
     def test_html(self):
-        segment = SegmentValue.from_html(
-            "foo",
+        snippet = HTMLSnippet.from_html(
             "This is a paragraph. <b>This is some bold <i>and now italic</i></b> text",
         )
         self.assertEqual(
-            segment.html,
+            snippet.html,
             "This is a paragraph. <b>This is some bold <i>and now italic</i></b> text",
         )
 
     def test_html_with_ids(self):
-        segment = SegmentValue.from_html(
-            "foo",
+        snippet = HTMLSnippet.from_html(
             '<b>Bread</b>\xa0is a\xa0<a href="https://en.wikipedia.org/wiki/Staple_food">staple food</a>\xa0prepared from a\xa0<a href="https://en.wikipedia.org/wiki/Dough">dough</a>\xa0of\xa0<a href="https://en.wikipedia.org/wiki/Flour">flour</a>\xa0and\xa0<a href="https://en.wikipedia.org/wiki/Water">water</a>, usually by\xa0<a href="https://en.wikipedia.org/wiki/Baking">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\xa0<a href="https://en.wikipedia.org/wiki/Agriculture#History">agriculture</a>.',
         )
         self.assertEqual(
-            segment.html_with_ids,
+            snippet.html_with_ids,
             '<b>Bread</b> is a <a id="a1">staple food</a> prepared from a <a id="a2">dough</a> of <a id="a3">flour</a> and <a id="a4">water</a>, usually by <a id="a5">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of <a id="a6">agriculture</a>.',
+        )
+
+    def test_replace_html_attrs(self):
+        snippet = HTMLSnippet.from_html(
+            'This is some text. &lt;foo&gt; <b>Bold text</b> <a id="a1">A link and some more <b>Bold text</b></a>',
+        )
+
+        snippet.replace_html_attrs({"a#a1": {"href": "http://changed-example.com"}})
+
+        self.assertEqual(
+            snippet.html,
+            'This is some text. &lt;foo&gt; <b>Bold text</b> <a href="http://changed-example.com">A link and some more <b>Bold text</b></a>',
         )

--- a/wagtail_localize/translation/segments/tests/test_segment_extraction.py
+++ b/wagtail_localize/translation/segments/tests/test_segment_extraction.py
@@ -18,6 +18,7 @@ from wagtail_localize.translation.segments import (
     RelatedObjectValue,
 )
 from wagtail_localize.translation.segments.extract import extract_segments
+from wagtail_localize.translation.segments.html import HTMLSnippet
 
 
 def make_test_page(**kwargs):
@@ -35,18 +36,16 @@ RICH_TEXT_TEST_OUTPUT = [
         '<h1><text position="0"></text></h1><p><text position="1"></text></p><ul><li><text position="2"></text></li></ul>',
         3,
     ),
-    SegmentValue("", "This is a heading", html_elements=[]),
+    SegmentValue("", "This is a heading"),
     SegmentValue(
         "",
-        "This is a paragraph. <foo> Bold text",
-        html_elements=[SegmentValue.HTMLElement(27, 36, "b1", ("b", {}))],
+        HTMLSnippet("This is a paragraph. <foo> Bold text", entities=[HTMLSnippet.Entity(27, 36, "b1", ("b", {}))]),
     ),
     SegmentValue(
         "",
-        "This is a link.",
-        html_elements=[
-            SegmentValue.HTMLElement(0, 14, "a1", ("a", {"href": "http://example.com"}))
-        ],
+        HTMLSnippet("This is a link.", entities=[
+            HTMLSnippet.Entity(0, 14, "a1", ("a", {"href": "http://example.com"}))
+        ]),
     ),
 ]
 

--- a/wagtail_localize/translation/segments/tests/test_segment_ingestion.py
+++ b/wagtail_localize/translation/segments/tests/test_segment_ingestion.py
@@ -13,6 +13,7 @@ from wagtail_localize.translation.segments import (
     TemplateValue,
     RelatedObjectValue,
 )
+from wagtail_localize.translation.segments.html import HTMLSnippet
 from wagtail_localize.translation.segments.ingest import ingest_segments
 
 
@@ -32,19 +33,21 @@ RICH_TEXT_TEST_FRENCH_SEGMENTS = [
         3,
         order=9,
     ),
-    SegmentValue("", "Ceci est une rubrique", html_elements=[], order=10),
+    SegmentValue("", "This is a heading", "Ceci est une rubrique", order=10),
     SegmentValue(
         "",
-        "Ceci est un paragraphe. <foo> Texte en gras",
-        html_elements=[SegmentValue.HTMLElement(30, 43, "b1", ("b", {}))],
+        HTMLSnippet("This is a paragraph. <foo> Bold text", entities=[HTMLSnippet.Entity(27, 36, "b1", ("b", {}))]),
+        HTMLSnippet("Ceci est un paragraphe. <foo> Texte en gras", entities=[HTMLSnippet.Entity(30, 43, "b1", ("b", {}))]),
         order=11,
     ),
     SegmentValue(
         "",
-        "Ceci est un lien",
-        html_elements=[
-            SegmentValue.HTMLElement(0, 16, "a1", ("a", {"href": "http://example.com"}))
-        ],
+        HTMLSnippet("This is a link.", entities=[
+            HTMLSnippet.Entity(0, 14, "a1", ("a", {"href": "http://example.com"}))
+        ]),
+        HTMLSnippet("Ceci est un lien", entities=[
+            HTMLSnippet.Entity(0, 16, "a1", ("a", {"href": "http://example.com"}))
+        ]),
         order=12,
     ),
 ]
@@ -66,7 +69,7 @@ class TestSegmentIngestion(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue("test_charfield", "Tester le contenu")],
+            [SegmentValue("test_charfield", "Test content", "Tester le contenu")],
         )
 
         self.assertEqual(translated_page.test_charfield, "Tester le contenu")
@@ -80,7 +83,7 @@ class TestSegmentIngestion(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue("test_textfield", "Tester le contenu")],
+            [SegmentValue("test_textfield", "Test content", "Tester le contenu")],
         )
 
         self.assertEqual(translated_page.test_textfield, "Tester le contenu")
@@ -94,7 +97,7 @@ class TestSegmentIngestion(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue("test_emailfield", "test@example.fr")],
+            [SegmentValue("test_emailfield", "test@example.com", "test@example.fr")],
         )
 
         self.assertEqual(translated_page.test_emailfield, "test@example.fr")
@@ -108,7 +111,7 @@ class TestSegmentIngestion(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue("test_slugfield", "tester-le-contenu")],
+            [SegmentValue("test_slugfield", "test-content", "tester-le-contenu")],
         )
 
         self.assertEqual(translated_page.test_slugfield, "tester-le-contenu")
@@ -122,7 +125,7 @@ class TestSegmentIngestion(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue("test_urlfield", "http://test-content.fr/foo")],
+            [SegmentValue("test_urlfield", "http://test-content.com/foo", "http://test-content.fr/foo")],
         )
 
         self.assertEqual(translated_page.test_urlfield, "http://test-content.fr/foo")
@@ -155,7 +158,7 @@ class TestSegmentIngestion(TestCase):
             translated_snippet,
             self.src_locale,
             self.locale,
-            [SegmentValue("field", "Tester le contenu")],
+            [SegmentValue("field", "Test content", "Tester le contenu")],
         )
 
         translated_snippet.save()
@@ -202,6 +205,7 @@ class TestSegmentIngestion(TestCase):
             [
                 SegmentValue(
                     f"test_childobjects.{child_translation_key}.field",
+                    "Test content",
                     "Tester le contenu",
                 )
             ],
@@ -229,7 +233,7 @@ class TestSegmentIngestion(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue("test_customfield.foo", "Tester le contenu")],
+            [SegmentValue("test_customfield.foo", "Test content", "Tester le contenu")],
         )
 
         self.assertEqual(translated_page.test_customfield, "Tester le contenu")
@@ -246,7 +250,7 @@ def make_test_page_with_streamfield_block(block_id, block_type, block_value, **k
     )
 
 
-class TestSegmentExtractionWithStreamField(TestCase):
+class TestSegmentIngestionWithStreamField(TestCase):
     def setUp(self):
         self.src_locale = Locale.objects.default()
         self.locale = Locale.objects.create(language_code="fr")
@@ -264,7 +268,7 @@ class TestSegmentExtractionWithStreamField(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue(f"test_streamfield.{block_id}", "Tester le contenu")],
+            [SegmentValue(f"test_streamfield.{block_id}", "Test content", "Tester le contenu")],
         )
 
         translated_page.save()
@@ -294,7 +298,7 @@ class TestSegmentExtractionWithStreamField(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue(f"test_streamfield.{block_id}", "Tester le contenu")],
+            [SegmentValue(f"test_streamfield.{block_id}", "Test content", "Tester le contenu")],
         )
 
         translated_page.save()
@@ -325,7 +329,7 @@ class TestSegmentExtractionWithStreamField(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue(f"test_streamfield.{block_id}", "test@example.fr")],
+            [SegmentValue(f"test_streamfield.{block_id}", "test@example.com", "test@example.fr")],
         )
 
         translated_page.save()
@@ -358,7 +362,7 @@ class TestSegmentExtractionWithStreamField(TestCase):
             self.locale,
             [
                 SegmentValue(
-                    f"test_streamfield.{block_id}", "http://test-content.fr/foo"
+                    f"test_streamfield.{block_id}", "http://test-content.com/foo", "http://test-content.fr/foo"
                 )
             ],
         )
@@ -457,7 +461,7 @@ class TestSegmentExtractionWithStreamField(TestCase):
             translated_page,
             self.src_locale,
             self.locale,
-            [SegmentValue(f"test_streamfield.{block_id}", "Tester le contenu")],
+            [SegmentValue(f"test_streamfield.{block_id}", "Test content", "Tester le contenu")],
         )
 
         translated_page.save()
@@ -491,10 +495,10 @@ class TestSegmentExtractionWithStreamField(TestCase):
             self.locale,
             [
                 SegmentValue(
-                    f"test_streamfield.{block_id}.field_a", "Tester le contenu"
+                    f"test_streamfield.{block_id}.field_a", "Test content", "Tester le contenu"
                 ),
                 SegmentValue(
-                    f"test_streamfield.{block_id}.field_b", "Encore du contenu de test"
+                    f"test_streamfield.{block_id}.field_b", "Some more test content", "Encore du contenu de test"
                 ),
             ],
         )
@@ -532,10 +536,10 @@ class TestSegmentExtractionWithStreamField(TestCase):
             self.locale,
             [
                 SegmentValue(
-                    f"test_streamfield.{block_id}", "Tester le contenu", order=0
+                    f"test_streamfield.{block_id}", "Test content", "Tester le contenu", order=0
                 ),
                 SegmentValue(
-                    f"test_streamfield.{block_id}", "Encore du contenu de test", order=1
+                    f"test_streamfield.{block_id}", "Some more test content", "Encore du contenu de test", order=1
                 ),
             ],
         )
@@ -573,6 +577,7 @@ class TestSegmentExtractionWithStreamField(TestCase):
             [
                 SegmentValue(
                     f"test_streamfield.{block_id}.{nested_block_id}",
+                    "Test content",
                     "Tester le contenu",
                 )
             ],
@@ -616,6 +621,7 @@ class TestSegmentExtractionWithStreamField(TestCase):
             [
                 SegmentValue(
                     f"test_streamfield.{block_id}.foo",
+                    "Test content / Some more test content",
                     "Tester le contenu / Encore du contenu de test",
                 )
             ],

--- a/wagtail_localize/translation/segments/tests/test_segment_ingestion.py
+++ b/wagtail_localize/translation/segments/tests/test_segment_ingestion.py
@@ -13,7 +13,6 @@ from wagtail_localize.translation.segments import (
     TemplateValue,
     RelatedObjectValue,
 )
-from wagtail_localize.translation.segments.extract import extract_segments
 from wagtail_localize.translation.segments.ingest import ingest_segments
 
 

--- a/wagtail_localize/translation/tests/test_translationsource.py
+++ b/wagtail_localize/translation/tests/test_translationsource.py
@@ -338,7 +338,7 @@ class TestCreateOrUpdateTranslationForPage(TestCase):
         )
 
     def test_update(self):
-        translated = self.page.copy_for_translation(self.dest_locale)
+        self.page.copy_for_translation(self.dest_locale)
 
         new_page, created = self.source.create_or_update_translation(self.dest_locale)
 


### PR DESCRIPTION
This PR introduces a new class called `HTMLSnippet`. This is required in order to allow us to have two HTML snippets per `SegmentValue` so we can have both the source and translation available.

``HTMLSnippet`` represents a snippet of HTML that only includes inline tags.