### PR TITLE
CircleCI and Flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2
+
+jobs:
+  backend:
+    docker:
+      - image: circleci/python:3.6.4
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - pip-packages-v1-{{ .Branch }}
+            - pip-packages-v1-
+      - run: pipenv install flake8
+      - save_cache:
+          paths:
+            - ~/.local/
+          key: pip-package-v1-{{ .Branch }}
+      - run: pipenv run flake8 wagtail_localize
+      - run: pipenv install -e .[testing]
+      - run: pipenv run python testmanage.py test
+
+  nightly-wagtail-test:
+    docker:
+      - image: circleci/python:3.7.3
+    steps:
+      - checkout
+      - run: git clone git@github.com:wagtail/wagtail.git
+      - run: pipenv install -e .[testing] -e ./wagtail
+      - run: pipenv run python testmanage.py test
+
+workflows:
+    version: 2
+    test:
+      jobs:
+        - backend
+
+    nightly:
+      jobs:
+        - nightly-wagtail-test
+      triggers:
+        - schedule:
+            cron: "0 0 * * *"
+            filters:
+              branches:
+                only:
+                  - master

--- a/.circleci/trigger-nightly-build.sh
+++ b/.circleci/trigger-nightly-build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Triggers a test run against the master version of Wagtail
+
+# This job will is scheduled in the config.yml, this script is here to help test the job
+
+curl -u ${CIRCLE_API_USER_TOKEN}: \
+     -d build_parameters[CIRCLE_JOB]=nightly-wagtail-test \
+     https://circleci.com/api/v1.1/project/github/wagtail/wagtail-localize/tree/master

--- a/wagtail_localize/admin_views.py
+++ b/wagtail_localize/admin_views.py
@@ -1,6 +1,3 @@
-from collections import defaultdict
-
-from django.conf import settings
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 

--- a/wagtail_localize/bootstrap.py
+++ b/wagtail_localize/bootstrap.py
@@ -1,9 +1,6 @@
 import uuid
 
-from django.conf import settings
 from django.db import migrations
-
-from .compat import get_supported_language_variant
 
 
 def bootstrap_translatable_model(model, locale):

--- a/wagtail_localize/management/commands/bootstrap_translatable_models.py
+++ b/wagtail_localize/management/commands/bootstrap_translatable_models.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from wagtail_localize.bootstrap import bootstrap_translatable_model
 from wagtail_localize.models import BootstrapTranslatableMixin, get_translatable_models

--- a/wagtail_localize/management/commands/sync_languages.py
+++ b/wagtail_localize/management/commands/sync_languages.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from wagtail_localize.models import Locale
 

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -3,19 +3,18 @@ import uuid
 
 from django.apps import apps
 from django.conf import settings
+from django.core.files.base import ContentFile
 from django.db import models, transaction
-from django.db.models import Exists, OuterRef, Q
-from django.db.models.signals import pre_save, post_save, m2m_changed
+from django.db.models import Q
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils import translation
 from modelcluster.fields import ParentalKey
 from wagtail.core.models import Page
-from wagtail.core.signals import page_published
 from wagtail.images.models import AbstractImage
 
 from .compat import get_languages, get_supported_language_variant
-from .edit_handlers import filter_edit_handler_on_instance_bound
-from .fields import TranslatableField, SynchronizedField
+from .fields import TranslatableField
 from .utils import find_available_slug
 
 

--- a/wagtail_localize/test/migrations/0007_more_synchronized_fields.py
+++ b/wagtail_localize/test/migrations/0007_more_synchronized_fields.py
@@ -134,6 +134,6 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"ordering": ["sort_order"], "abstract": False,},
+            options={"ordering": ["sort_order"], "abstract": False},
         ),
     ]

--- a/wagtail_localize/tests/test_mixins.py
+++ b/wagtail_localize/tests/test_mixins.py
@@ -3,14 +3,11 @@ from unittest.mock import Mock, patch
 from django.conf import settings
 from django.test import TestCase
 
-from wagtail.core.models import Page
-
 from wagtail_localize.models import Locale
 from wagtail_localize.test.models import (
     InheritedTestModel,
     TestChildObject,
     TestModel,
-    TestPage,
 )
 from wagtail_localize.tests.test_locale_model import make_test_page
 

--- a/wagtail_localize/translation/migrations/0001_initial.py
+++ b/wagtail_localize/translation/migrations/0001_initial.py
@@ -37,7 +37,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"unique_together": {("language", "text_id")},},
+            options={"unique_together": {("language", "text_id")}},
         ),
         migrations.CreateModel(
             name="SegmentTranslationContext",
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"unique_together": {("content_type", "translation_key")},},
+            options={"unique_together": {("content_type", "translation_key")}},
         ),
         migrations.CreateModel(
             name="TranslatableRevision",
@@ -209,7 +209,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={"abstract": False},
         ),
         migrations.AddField(
             model_name="segmenttranslationcontext",
@@ -257,7 +257,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={"abstract": False},
         ),
         migrations.CreateModel(
             name="RelatedObjectLocation",
@@ -295,7 +295,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={"abstract": False},
         ),
         migrations.AlterUniqueTogether(
             name="segmenttranslationcontext", unique_together={("object", "path_id")},
@@ -341,6 +341,6 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"unique_together": {("language", "translation_of", "context")},},
+            options={"unique_together": {("language", "translation_of", "context")}},
         ),
     ]

--- a/wagtail_localize/translation/migrations/0003_change_language_to_locale_2.py
+++ b/wagtail_localize/translation/migrations/0003_change_language_to_locale_2.py
@@ -7,6 +7,7 @@ from django.db import migrations
 
 
 def migrate_to_locale(apps, schema_editor):
+    Locale = apps.get_model("wagtail_localize.Locale")
     Segment = apps.get_model("wagtail_localize_translation.Segment")
     SegmentTranslation = apps.get_model(
         "wagtail_localize_translation.SegmentTranslation"

--- a/wagtail_localize/translation/segments/extract.py
+++ b/wagtail_localize/translation/segments/extract.py
@@ -3,7 +3,6 @@ from django.db import models
 from modelcluster.fields import ParentalKey
 from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
-from wagtail.core.rich_text import RichText
 from wagtail.embeds.blocks import EmbedBlock
 
 from wagtail_localize.models import TranslatableMixin

--- a/wagtail_localize/translation/segments/html.py
+++ b/wagtail_localize/translation/segments/html.py
@@ -11,7 +11,7 @@ def lstrip_keep(text):
     """
     text_length = len(text)
     new_text = text.lstrip()
-    prefix = text[0 : (text_length - len(new_text))]
+    prefix = text[0:(text_length - len(new_text))]
     return new_text, prefix
 
 
@@ -22,7 +22,7 @@ def rstrip_keep(text):
     text_length = len(text)
     new_text = text.rstrip()
     if text_length != len(new_text):
-        suffix = text[-(text_length - len(new_text)) :]
+        suffix = text[-(text_length - len(new_text)):]
     else:
         suffix = ""
     return new_text, suffix
@@ -278,7 +278,7 @@ def restore_html_elements(text, elements):
     for i, element in enumerate(elements):
         if cursor < element[0]:
             # Output text and advance cursor
-            current_element.append(text[cursor : element[0]])
+            current_element.append(text[cursor:element[0]])
             cursor = element[0]
 
         stack.append((element[1], current_element))

--- a/wagtail_localize/translation/segments/ingest.py
+++ b/wagtail_localize/translation/segments/ingest.py
@@ -6,9 +6,6 @@ from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.rich_text import RichText
 
-from wagtail_localize.models import TranslatableMixin
-from wagtail_localize.translation.segments import TemplateValue
-
 from .html import restore_html_segments
 
 

--- a/wagtail_localize/translation/segments/tests/test_segment_ingestion.py
+++ b/wagtail_localize/translation/segments/tests/test_segment_ingestion.py
@@ -13,7 +13,6 @@ from wagtail_localize.translation.segments import (
     TemplateValue,
     RelatedObjectValue,
 )
-from wagtail_localize.translation.segments.extract import extract_segments
 from wagtail_localize.translation.segments.ingest import ingest_segments
 
 

--- a/wagtail_localize/translation/tests/test_translationsource.py
+++ b/wagtail_localize/translation/tests/test_translationsource.py
@@ -338,7 +338,7 @@ class TestCreateOrUpdateTranslationForPage(TestCase):
         )
 
     def test_update(self):
-        translated = self.page.copy_for_translation(self.dest_locale)
+        self.page.copy_for_translation(self.dest_locale)
 
         new_page, created = self.source.create_or_update_translation(self.dest_locale)
 


### PR DESCRIPTION
This PR adds CircleCI config. CircleCI will be used for the following:

 - A fast-responding unit tester (TravisCI has a large matrix so takes a while to respond).
 - Flake8
 - Testing against Wagtail master on a nightly basis (so we can pick up incompatibilities as soon as they happen)