### PR TITLE
Update translation view

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -124,10 +124,16 @@ class TranslationSourceQuerySet(models.QuerySet):
         object = TranslatableObject.objects.get_for_instance(
             instance
         )
-        return self.filter(
+        return self.get(
             object=object,
             locale=instance.locale,
         )
+
+    def get_for_instance_or_none(self, instance):
+        try:
+            return self.get_for_instance(instance)
+        except (TranslationSource.DoesNotExist, TranslatableObject.DoesNotExist):
+            return None
 
 
 class TranslationSource(models.Model):

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -542,6 +542,12 @@ class Translation(models.Model):
             ('source', 'target_locale'),
         ]
 
+    def get_target_instance(self):
+        """
+        Fetches the translated instance from the database.
+        """
+        return self.source.get_translated_instance(self.target_locale)
+
     def get_progress(self):
         """
         Returns the current progress of translating this Translation.

--- a/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
@@ -1,0 +1,77 @@
+
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+{% block titletag %}{{ view.get_title }} {{ view.get_subtitle }}{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=view.get_title subtitle=view.get_subtitle icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+        <p>{% trans "You are about to update the following translations:" %}</p>
+        <ul>
+            {% for translation in translations %}
+                <li>
+                    {{ translation.locale.get_display_name }}
+                    {% if translation.edit_url %}
+                        (<a href="{{ translation.edit_url }}" target="_blank"/>{{ translation.title }}</a>)
+                    {% else %}
+                        ({{ translation.title }})
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+        <form method="POST">
+            {% csrf_token %}
+
+            {% if next_url %}
+                <input type="hidden" name="next" value="{{ next_url }}">
+            {% endif %}
+
+            {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+
+            <ul class="fields">
+                {% block visible_fields %}
+                    {% for field in form.visible_fields %}
+                        {% if field.name == 'publish_translations' %}
+                            <li class="publish-translations-field">
+                                <div class="field boolean_field checkbox_input">
+                                    <div class="field-content">
+                                        <div class="input">
+                                            <input type="checkbox" name="{{ field.name }}" id="{{ field.auto_id }}">
+                                            <label class="publish-translations-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                                        </div>
+                                    </div>
+                                </div>
+                                <p class="help">{{ field.help_text }}</p>
+                            </li>
+                        {% else %}
+                            {% include "wagtailadmin/shared/field_as_li.html" %}
+                        {% endif %}
+                    {% endfor %}
+                {% endblock %}
+                <li><input type="submit" value="{% trans 'Submit' %}" class="button" />{% if back_url %} <a href="{{ back_url }}" class="button button-secondary">{% trans "Go back" %}</a>{% endif %}</li>
+            </ul>
+        </form>
+    </div>
+{% endblock %}
+
+
+{% block extra_css %}
+    {{ block.super }}
+
+    <style>
+        .publish-translations-field {
+            margin-top: 30px;
+            margin-bottom: 20px;
+        }
+
+        .publish-translations-field > p.help {
+            margin-top: 10px;
+        }
+
+        .publish-translations-label {
+            float: unset;
+            font-weight: normal;
+        }
+    </style>
+{% endblock %}

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -1,0 +1,338 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from wagtail.core.models import Page, Locale
+from wagtail.tests.utils import WagtailTestUtils
+
+from wagtail_localize.models import Translation, TranslationSource
+from wagtail_localize.test.models import TestPage, TestSnippet, NonTranslatableSnippet
+
+
+def make_test_page(parent, cls=None, **kwargs):
+    cls = cls or TestPage
+    kwargs.setdefault("title", "Test page")
+    return parent.add_child(instance=cls(**kwargs))
+
+
+def strip_user_perms():
+    """
+    Removes user permissions so they can still access admin and edit pages but can't submit anything for translation.
+    """
+    editors_group = Group.objects.get(name="Editors")
+    editors_group.permissions.filter(codename='submit_translation').delete()
+
+    for permission in Permission.objects.filter(content_type=ContentType.objects.get_for_model(TestSnippet)):
+        editors_group.permissions.add(permission)
+
+    for permission in Permission.objects.filter(content_type=ContentType.objects.get_for_model(NonTranslatableSnippet)):
+        editors_group.permissions.add(permission)
+
+    user = get_user_model().objects.get()
+    user.is_superuser = False
+    user.groups.add(editors_group)
+    user.save()
+
+
+@override_settings(
+    LANGUAGES=[
+        ('en', "English"),
+        ('fr', "French"),
+        ('de', "German"),
+        ('es', "Spanish"),
+    ],
+    WAGTAIL_CONTENT_LANGUAGES=[
+        ('en', "English"),
+        ('fr', "French"),
+        ('de', "German"),
+        ('es', "Spanish"),
+    ],
+)
+class TestPageUpdateTranslationsListingButton(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+        self.en_locale = Locale.objects.get()
+        self.fr_locale = Locale.objects.create(language_code="fr")
+        self.de_locale = Locale.objects.create(language_code="de")
+
+        self.en_homepage = Page.objects.get(depth=2)
+        self.fr_homepage = self.en_homepage.copy_for_translation(self.fr_locale)
+        self.de_homepage = self.en_homepage.copy_for_translation(self.de_locale)
+
+        self.en_blog_index = make_test_page(self.en_homepage, title="Blog", slug="blog")
+
+        self.source, created = TranslationSource.get_or_create_from_instance(self.en_blog_index)
+        self.translation = Translation.objects.create(
+            source=self.source,
+            target_locale=self.fr_locale
+        )
+
+    def test(self):
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+        )
+
+        self.assertContains(response, (
+            f'<a href="/admin/localize/update/{self.source.id}/?next=%2Fadmin%2Fpages%2F{self.en_homepage.id}%2F" aria-label="" class="u-link is-live ">\n'
+            '                    Update translations\n                </a>'
+        ))
+
+    def test_hides_if_page_hasnt_got_translations(self):
+        self.source.delete()
+
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+        )
+
+        self.assertNotContains(response, "Update translations")
+
+    def test_hides_if_user_doesnt_have_permission(self):
+        strip_user_perms()
+
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+        )
+
+        self.assertNotContains(response, "Update translations")
+
+
+@override_settings(
+    LANGUAGES=[
+        ('en', "English"),
+        ('fr', "French"),
+        ('de', "German"),
+        ('es', "Spanish"),
+    ],
+    WAGTAIL_CONTENT_LANGUAGES=[
+        ('en', "English"),
+        ('fr', "French"),
+        ('de', "German"),
+        ('es', "Spanish"),
+    ],
+)
+class TestSnippetUpdateTranslationsListingButton(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+        self.en_locale = Locale.objects.get()
+        self.fr_locale = Locale.objects.create(language_code="fr")
+        self.de_locale = Locale.objects.create(language_code="de")
+
+        self.en_snippet = TestSnippet.objects.create(field="Test snippet")
+        self.fr_snippet = self.en_snippet.copy_for_translation(self.fr_locale)
+        self.fr_snippet.save()
+
+        self.source, created = TranslationSource.get_or_create_from_instance(self.en_snippet)
+        self.translation = Translation.objects.create(
+            source=self.source,
+            target_locale=self.fr_locale
+        )
+
+    def test(self):
+        response = self.client.get(
+            reverse("wagtailsnippets:list", args=['wagtail_localize_test', 'testsnippet'])
+        )
+
+        self.assertContains(response, (
+            f'href="/admin/localize/update/{self.source.id}/?next=%2Fadmin%2Fsnippets%2Fwagtail_localize_test%2Ftestsnippet%2F">Update translations</a>'
+        ))
+
+    def test_hides_if_snippet_hasnt_got_translations(self):
+        self.source.delete()
+
+        response = self.client.get(
+            reverse("wagtailsnippets:list", args=['wagtail_localize_test', 'testsnippet'])
+        )
+
+        self.assertNotContains(response, "Update translations")
+
+    def test_hides_if_user_doesnt_have_permission(self):
+        strip_user_perms()
+
+        response = self.client.get(
+            reverse("wagtailsnippets:list", args=['wagtail_localize_test', 'testsnippet'])
+        )
+
+        self.assertNotContains(response, "Update translations")
+
+
+@override_settings(
+    LANGUAGES=[
+        ('en', "English"),
+        ('fr', "French"),
+        ('de', "German"),
+        ('es', "Spanish"),
+    ],
+    WAGTAIL_CONTENT_LANGUAGES=[
+        ('en', "English"),
+        ('fr', "French"),
+        ('de', "German"),
+        ('es', "Spanish"),
+    ],
+)
+class TestUpdateTranslations(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+        self.en_locale = Locale.objects.get()
+        self.fr_locale = Locale.objects.create(language_code="fr")
+        self.de_locale = Locale.objects.create(language_code="de")
+
+        self.en_homepage = Page.objects.get(depth=2)
+        self.fr_homepage = self.en_homepage.copy_for_translation(self.fr_locale)
+        self.de_homepage = self.en_homepage.copy_for_translation(self.de_locale)
+
+        self.en_blog_index = make_test_page(self.en_homepage, title="Blog", slug="blog")
+        self.en_blog_post = make_test_page(
+            self.en_blog_index, title="Blog post", slug="blog-post", test_charfield="Test content"
+        )
+
+        self.en_snippet = TestSnippet.objects.create(field="Test snippet")
+
+        # Create translation of page. This creates the FR version
+        self.page_source, created = TranslationSource.get_or_create_from_instance(self.en_blog_post)
+        self.page_translation = Translation.objects.create(
+            source=self.page_source,
+            target_locale=self.fr_locale
+        )
+        self.page_translation.save_target(publish=True)
+        self.fr_blog_post = self.en_blog_post.get_translation(self.fr_locale)
+
+        # Create translation of snippet. This creates the FR version
+        self.snippet_source, created = TranslationSource.get_or_create_from_instance(self.en_snippet)
+        self.snippet_translation = Translation.objects.create(
+            source=self.snippet_source,
+            target_locale=self.fr_locale
+        )
+        self.snippet_translation.save_target(publish=True)
+        self.fr_snippet = self.en_snippet.get_translation(self.fr_locale)
+
+    def test_get_update_page_translation(self):
+        response = self.client.get(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.context['translations'],
+            [
+                {
+                    'title': 'Blog post',
+                    'locale': self.fr_locale,
+                    'edit_url': reverse('wagtailadmin_pages:edit', args=[self.fr_blog_post.id])
+                }
+            ]
+        )
+
+    def test_get_update_snippet_translation(self):
+        response = self.client.get(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.snippet_source.id],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.context['translations'],
+            [
+                {
+                    'title': str(self.fr_snippet),
+                    'locale': self.fr_locale,
+                    'edit_url': reverse('wagtailsnippets:edit', args=['wagtail_localize_test', 'testsnippet', self.fr_snippet.id]),
+                }
+            ]
+        )
+
+    def test_get_without_permission(self):
+        strip_user_perms()
+
+        response = self.client.get(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            )
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_post_update_page_translation(self):
+        self.en_blog_post.test_charfield = "Edited blog post"
+        self.en_blog_post.save_revision().publish()
+
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            )
+        )
+
+        self.assertRedirects(response, reverse('wagtailadmin_explore', args=[self.en_blog_index.id]))
+
+        # The FR version shouldn't be updated yet
+        self.fr_blog_post.refresh_from_db()
+        self.assertEqual(self.fr_blog_post.test_charfield, "Test content")
+
+    def test_post_update_page_translation_with_publish_translations(self):
+        self.en_blog_post.test_charfield = "Edited blog post"
+        self.en_blog_post.save_revision().publish()
+
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+            {
+                'publish_translations': 'on'
+            }
+        )
+
+        self.assertRedirects(response, reverse('wagtailadmin_explore', args=[self.en_blog_index.id]))
+
+        # The FR version should be updated
+        self.fr_blog_post.refresh_from_db()
+        self.assertEqual(self.fr_blog_post.test_charfield, "Edited blog post")
+
+    def test_post_update_snippet_translation(self):
+        self.en_snippet.field = "Edited snippet"
+        self.en_snippet.save()
+
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.snippet_source.id],
+            )
+        )
+
+        self.assertRedirects(response, reverse('wagtailsnippets:edit', args=['wagtail_localize_test', 'testsnippet', self.en_snippet.id]))
+
+        # The FR version shouldn't be updated yet
+        self.fr_snippet.refresh_from_db()
+        self.assertEqual(self.fr_snippet.field, "Test snippet")
+
+    def test_post_update_snippet_translation_with_publish_translations(self):
+        self.en_snippet.field = "Edited snippet"
+        self.en_snippet.save()
+
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.snippet_source.id],
+            ),
+            {
+                'publish_translations': 'on'
+            }
+        )
+
+        self.assertRedirects(response, reverse('wagtailsnippets:edit', args=['wagtail_localize_test', 'testsnippet', self.en_snippet.id]))
+
+        # The FR version should be updated
+        self.fr_snippet.refresh_from_db()
+        self.assertEqual(self.fr_snippet.field, "Edited snippet")

--- a/wagtail_localize/views/update_translations.py
+++ b/wagtail_localize/views/update_translations.py
@@ -1,0 +1,109 @@
+from django import forms
+
+from django.contrib import messages
+from django.contrib.admin.utils import quote
+from django.core.exceptions import PermissionDenied
+from django.db import transaction
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as __
+from django.views.generic import TemplateView
+from django.views.generic.detail import SingleObjectMixin
+from wagtail.admin.views.pages import get_valid_next_url_from_request
+from wagtail.core.models import Page
+
+from wagtail_localize.models import TranslationSource
+
+
+class UpdateTranslationsForm(forms.Form):
+    publish_translations = forms.BooleanField(
+        label=__("Publish immediately"),
+        help_text=__("This will apply the updates and publish immediately, before any new translations happen."),
+        required=False,
+    )
+
+
+class UpdateTranslationsView(SingleObjectMixin, TemplateView):
+    template_name = "wagtail_localize/admin/update_translations.html"
+    title = __("Update existing translations")
+
+    def get_object(self):
+        return get_object_or_404(TranslationSource, id=self.kwargs['translation_source_id'])
+
+    def get_title(self):
+        return self.title
+
+    def get_subtitle(self):
+        return self.object.object_repr
+
+    def get_form(self):
+        if self.request.method == 'POST':
+            return UpdateTranslationsForm(self.request.POST)
+        else:
+            return UpdateTranslationsForm()
+
+    def get_success_message(self):
+        return _("Successfully updated translations for '{object}'").format(object=self.object.object_repr)
+
+    def get_success_url(self):
+        return get_valid_next_url_from_request(self.request)
+
+    def get_default_success_url(self):
+        instance = self.object.get_source_instance()
+
+        if isinstance(instance, Page):
+            return reverse("wagtailadmin_explore", args=[instance.get_parent().id])
+        else:
+            return reverse("wagtailsnippets:edit", args=[instance._meta.app_label, instance._meta.model_name, quote(instance.pk)])
+
+    def get_edit_url(self, instance):
+        if isinstance(instance, Page):
+            return reverse("wagtailadmin_pages:edit", args=[instance.id])
+        else:
+            return reverse("wagtailsnippets:edit", args=[instance._meta.app_label, instance._meta.model_name, quote(instance.pk)])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update({
+            "translations": [
+                {
+                    "title": str(translation.get_target_instance()),
+                    "locale": translation.target_locale,
+                    "edit_url": self.get_edit_url(translation.get_target_instance()),
+                }
+                for translation in self.object.translations.select_related("target_locale")
+            ],
+            "form": self.get_form(),
+            "next_url": self.get_success_url(),
+            "back_url": self.get_success_url() or self.get_default_success_url(),
+        })
+        return context
+
+    def post(self, request, **kwargs):
+        form = self.get_form()
+
+        if form.is_valid():
+            with transaction.atomic():
+                self.object.update_from_db()
+
+                if form.cleaned_data['publish_translations']:
+                    for translation in self.object.translations.select_related("target_locale"):
+                        translation.save_target(user=request.user, publish=True)
+
+                # TODO: Button that links to page in translations report when we have it
+                messages.success(
+                    self.request, self.get_success_message()
+                )
+
+                return redirect(self.get_success_url() or self.get_default_success_url())
+
+        context = self.get_context_data(**kwargs)
+        return self.render_to_response(context)
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.has_perms(['wagtail_localize.submit_translation']):
+            raise PermissionDenied
+
+        self.object = self.get_object()
+        return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
A view that lets you update existing translations for pages that are used as a source for any translations.

Any pages that are used as a source get a new item in the more menu "Update translations". This pushes all changes to that page to be translated into all the languages that page is currently translated into.

See it in action here (with older styling): https://localize-workflow-develop.herokuapp.com/admin/localize/update/1/?next=%2Fadmin%2Fpages%2F60%2F