### PR TITLE
Make import_po work without iterating it

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -674,9 +674,10 @@ class Translation(models.Model):
         Imports translations from a PO file.
         """
         seen_translation_ids = set()
+        warnings = []
 
         if 'X-WagtailLocalize-TranslationID' in po.metadata and po.metadata['X-WagtailLocalize-TranslationID'] != str(self.uuid):
-            return
+            return []
 
         for index, entry in enumerate(po):
             try:
@@ -689,7 +690,7 @@ class Translation(models.Model):
 
                 # Ignore if the string doesn't appear in this context, and if there is not an obsolete StringTranslation
                 if not StringSegment.objects.filter(string=string, context=context).exists() and not StringTranslation.objects.filter(translation_of=string, context=context).exists():
-                    yield StringNotUsedInContext(index, entry.msgid, entry.msgctxt)
+                    warnings.append(StringNotUsedInContext(index, entry.msgid, entry.msgctxt))
                     continue
 
                 string_translation, created = string.translations.get_or_create(
@@ -711,14 +712,16 @@ class Translation(models.Model):
                         string_translation.save()
 
             except TranslationContext.DoesNotExist:
-                yield UnknownContext(index, entry.msgctxt)
+                warnings.append(UnknownContext(index, entry.msgctxt))
 
             except String.DoesNotExist:
-                yield UnknownString(index, entry.msgid)
+                warnings.append(UnknownString(index, entry.msgid))
 
         # Delete any translations that weren't mentioned
         if delete:
             StringTranslation.objects.filter(context__object_id=self.source.object_id, locale=self.target_locale).exclude(id__in=seen_translation_ids).delete()
+
+        return warnings
 
     def save_target(self, user=None, publish=True):
         """

--- a/wagtail_localize/tests/test_translation_model.py
+++ b/wagtail_localize/tests/test_translation_model.py
@@ -259,7 +259,7 @@ class TestImportPO(TestCase):
             )
         )
 
-        warnings = list(self.translation.import_po(po))
+        warnings = self.translation.import_po(po)
         self.assertEqual(warnings, [])
 
         translation = StringTranslation.objects.get(translation_of__data="This is some test content")
@@ -297,7 +297,7 @@ class TestImportPO(TestCase):
             "X-WagtailLocalize-TranslationID": str(self.translation.uuid),
         }
 
-        warnings = list(self.translation.import_po(po, delete=True))
+        warnings = self.translation.import_po(po, delete=True)
         self.assertEqual(warnings, [])
 
         # Should delete both the translations
@@ -320,7 +320,7 @@ class TestImportPO(TestCase):
             )
         )
 
-        warnings = list(self.translation.import_po(po))
+        warnings = self.translation.import_po(po)
         self.assertEqual(warnings, [])
 
         # Should delete both the translations
@@ -361,7 +361,7 @@ class TestImportPO(TestCase):
             )
         )
 
-        warnings = list(self.translation.import_po(po))
+        warnings = self.translation.import_po(po)
 
         self.assertEqual(warnings, [
             StringNotUsedInContext(0, "This string exists in the database but isn't relevant to this object", "test_charfield"),


### PR DESCRIPTION
import_po is currently a generator of warnings. If you're not interested in warnings though, it will stop running when it first encounters one.

This is quite annoying so I've changed it so that it is just a regular function that returns a list of warnings when it's all done.