### PR TITLE
Disabling and enabling translations

### DIFF
--- a/wagtail_localize/__init__.py
+++ b/wagtail_localize/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail_localize.apps.WagtailLocalizeAppConfig'

--- a/wagtail_localize/apps.py
+++ b/wagtail_localize/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class WagtailLocalizeAppConfig(AppConfig):
+    name = 'wagtail_localize'
+    label = 'wagtail_localize'
+    verbose_name = _("Wagtail localize")
+
+    def ready(self):
+        from .models import register_post_delete_signal_handlers
+        register_post_delete_signal_handlers()

--- a/wagtail_localize/static_src/editor/components/TranslationEditor/footer.tsx
+++ b/wagtail_localize/static_src/editor/components/TranslationEditor/footer.tsx
@@ -15,10 +15,19 @@ const EditorFooter: FunctionComponent<EditorProps> = ({
     locale
 }) => {
     let actions = [
-        <a className="button action-secondary" href="#">
-            <Icon name="cross" />
-            {gettext('Disable')}
-        </a>
+        <form method="POST" action={links.stopTranslationUrl}>
+            <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
+            <input type="hidden" name="next" value={window.location.href} />
+
+            <button
+                type="submit"
+                className="button action-secondary"
+                aria-label={gettext('Stop translation')}
+            >
+                <Icon name="cross" />
+                {gettext('Stop translation')}
+            </button>
+        </form>
     ];
 
     if (perms.canDelete) {

--- a/wagtail_localize/static_src/editor/components/TranslationEditor/index.tsx
+++ b/wagtail_localize/static_src/editor/components/TranslationEditor/index.tsx
@@ -104,6 +104,7 @@ export interface EditorProps {
         lockUrl: string;
         unlockUrl: string;
         deleteUrl: string;
+        stopTranslationUrl: string;
     };
     previewModes: PreviewMode[];
     machineTranslator: {

--- a/wagtail_localize/test/settings.py
+++ b/wagtail_localize/test/settings.py
@@ -163,7 +163,7 @@ WAGTAIL_SITE_NAME = "Wagtail localize test project"
 
 WAGTAIL_I18N_ENABLED = True
 
-LANGUAGES = WAGTAIL_CONTENT_LANGUAGES = [("en", "English"), ("fr", "French")]
+LANGUAGES = WAGTAIL_CONTENT_LANGUAGES = [("en", "English"), ("fr", "French"), ("es", "Spanish")]
 
 WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
     'CLASS': 'wagtail_localize.machine_translators.dummy.DummyTranslator',

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 import tempfile
+import unittest
 
 import polib
 from django import VERSION as DJANGO_VERSION
@@ -21,6 +22,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from wagtail_localize.models import String, StringTranslation, Translation, TranslationContext, TranslationLog, TranslationSource
 from wagtail_localize.test.models import TestPage, TestSnippet
+from wagtail_localize.wagtail_hooks import SNIPPET_RESTART_TRANSLATION_ENABLED
 
 
 RICH_TEXT_DATA = '<h1>This is a heading</h1><p>This is a paragraph. &lt;foo&gt; <b>Bold text</b></p><ul><li><a href="http://example.com">This is a link</a>.</li><li>Special characters: \'"!? セキレイ</li></ul>'
@@ -575,6 +577,7 @@ class TestRestartTranslationButton(EditTranslationTestData, TestCase):
 
         self.assertNotContains(response, "Restart translation")
 
+    @unittest.skipUnless(SNIPPET_RESTART_TRANSLATION_ENABLED, "wagtail.snippets.action_menu module doesn't exist. See: https://github.com/wagtail/wagtail/pull/6384")
     def test_snippet(self):
         self.snippet_translation.enabled = False
         self.snippet_translation.save()
@@ -583,6 +586,7 @@ class TestRestartTranslationButton(EditTranslationTestData, TestCase):
 
         self.assertContains(response, "Restart translation")
 
+    @unittest.skipUnless(SNIPPET_RESTART_TRANSLATION_ENABLED, "wagtail.snippets.action_menu module doesn't exist. See: https://github.com/wagtail/wagtail/pull/6384")
     def test_doesnt_show_when_no_translation_for_snippet(self):
         self.snippet_translation.delete()
 
@@ -590,6 +594,7 @@ class TestRestartTranslationButton(EditTranslationTestData, TestCase):
 
         self.assertNotContains(response, "Restart translation")
 
+    @unittest.skipUnless(SNIPPET_RESTART_TRANSLATION_ENABLED, "wagtail.snippets.action_menu module doesn't exist. See: https://github.com/wagtail/wagtail/pull/6384")
     def test_doesnt_show_on_create_for_snippet(self):
         response = self.client.get(reverse('wagtailsnippets:add', args=[TestSnippet._meta.app_label, TestSnippet._meta.model_name]))
         self.assertNotContains(response, "Restart translation")

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -425,6 +425,23 @@ def stop_translation(request, translation_id):
     return redirect(next_url)
 
 
+@require_POST
+def restart_translation(request, translation, instance):
+    # This view is hooked in using the before_edit_page hook so we don't need to check for edit permission
+    translation.enabled = True
+    translation.save(update_fields=['enabled'])
+
+    messages.success(
+        request,
+        _("Translation has been restarted.")
+    )
+
+    if isinstance(instance, Page):
+        return redirect('wagtailadmin_pages:edit', instance.id)
+    else:
+        return redirect('wagtailsnippets:edit', instance._meta.app_label, instance._meta.model_name, quote(instance.pk))
+
+
 @api_view(['PUT', 'DELETE'])
 def edit_string_translation(request, translation_id, string_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -338,6 +338,7 @@ def edit_translation(request, translation, instance):
                 'lockUrl': reverse('wagtailadmin_pages:lock', args=[instance.id]) if isinstance(instance, Page) else None,
                 'unlockUrl': reverse('wagtailadmin_pages:unlock', args=[instance.id]) if isinstance(instance, Page) else None,
                 'deleteUrl': reverse('wagtailadmin_pages:delete', args=[instance.id]) if isinstance(instance, Page) else reverse('wagtailsnippets:delete', args=[instance._meta.app_label, instance._meta.model_name, quote(instance.pk)]),
+                'stopTranslationUrl': reverse('wagtail_localize:stop_translation', args=[translation.id]),
             },
             'previewModes': [
                 {
@@ -398,6 +399,30 @@ def preview_translation(request, translation_id, mode=None):
     translation = translation.source.get_ephemeral_translated_instance(translation.target_locale, string_translation_fallback_to_source=True)
 
     return translation.make_preview_request(request, mode)
+
+
+@require_POST
+def stop_translation(request, translation_id):
+    translation = get_object_or_404(Translation, id=translation_id)
+
+    instance = translation.get_target_instance()
+    if not user_can_edit_instance(request.user, instance):
+        raise PermissionDenied
+
+    translation.enabled = False
+    translation.save(update_fields=['enabled'])
+
+    next_url = get_valid_next_url_from_request(request)
+    if not next_url:
+        # Note: You should always provide a next URL when using this view!
+        next_url = reverse('wagtailadmin_home')
+
+    messages.success(
+        request,
+        _("Translation has been stopped.")
+    )
+
+    return redirect(next_url)
 
 
 @api_view(['PUT', 'DELETE'])

--- a/wagtail_localize/views/submit_translations.py
+++ b/wagtail_localize/views/submit_translations.py
@@ -88,17 +88,21 @@ class TranslationCreator:
 
         # Set up translation records
         for target_locale in self.target_locales:
-            # Create translation if it doesn't exist yet
-            translation, created = Translation.objects.get_or_create(
+            # Create translation if it doesn't exist yet, re-enable if translation was disabled
+            # Note that the form won't show this locale as an option if the translation existed
+            # in this langauge, so this shouldn't overwrite any unmanaged translations.
+            translation, created = Translation.objects.update_or_create(
                 source=source,
                 target_locale=target_locale,
+                defaults={
+                    'enabled': True
+                }
             )
 
-            if created:
-                try:
-                    translation.save_target(user=self.user)
-                except ValidationError:
-                    pass
+            try:
+                translation.save_target(user=self.user)
+            except ValidationError:
+                pass
 
 
 class SubmitTranslationView(SingleObjectMixin, TemplateView):

--- a/wagtail_localize/views/update_translations.py
+++ b/wagtail_localize/views/update_translations.py
@@ -72,7 +72,7 @@ class UpdateTranslationsView(SingleObjectMixin, TemplateView):
                     "locale": translation.target_locale,
                     "edit_url": self.get_edit_url(translation.get_target_instance()),
                 }
-                for translation in self.object.translations.select_related("target_locale")
+                for translation in self.object.translations.filter(enabled=True).select_related("target_locale")
             ],
             "form": self.get_form(),
             "next_url": self.get_success_url(),
@@ -88,7 +88,7 @@ class UpdateTranslationsView(SingleObjectMixin, TemplateView):
                 self.object.update_from_db()
 
                 if form.cleaned_data['publish_translations']:
-                    for translation in self.object.translations.select_related("target_locale"):
+                    for translation in self.object.translations.filter(enabled=True).select_related("target_locale"):
                         try:
                             translation.save_target(user=request.user, publish=True)
                         except ValidationError:

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -7,8 +7,10 @@ from django.utils.translation import gettext as _
 from django.views.i18n import JavaScriptCatalog
 
 from wagtail.admin import widgets as wagtailadmin_widgets
+from wagtail.admin.action_menu import ActionMenuItem as PageActionMenuItem
 from wagtail.core import hooks
 from wagtail.core.models import Locale, TranslatableMixin
+from wagtail.snippets.action_menu import ActionMenuItem as SnippetActionMenuItem
 from wagtail.snippets.widgets import SnippetListingButton
 
 from .models import Translation, TranslationSource
@@ -111,6 +113,15 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
 
 @hooks.register("before_edit_page")
 def before_edit_page(request, page):
+    # Check if the user has clicked the "Restart Translation" menu item
+    if request.method == 'POST' and 'localize-restart-translation' in request.POST:
+        try:
+            translation = Translation.objects.get(source__object_id=page.translation_key, target_locale_id=page.locale_id, enabled=False)
+        except Translation.DoesNotExist:
+            pass
+        else:
+            return edit_translation.restart_translation(request, translation, page)
+
     # Overrides the edit page view if the page is the target of a translation
     try:
         translation = Translation.objects.get(source__object_id=page.translation_key, target_locale_id=page.locale_id, enabled=True)
@@ -120,13 +131,69 @@ def before_edit_page(request, page):
         pass
 
 
+class RestartTranslationPageActionMenuItem(PageActionMenuItem):
+    label = _("Restart translation")
+    name = "localize-restart-translation"
+    icon_name = "undo"
+    classname = 'action-secondary'
+
+    def is_shown(self, request, context):
+        # Only show this menu item on the edit view where there was a previous translation record
+        if context['view'] != 'edit':
+            return False
+
+        return Translation.objects.filter(
+            source__object_id=context['page'].translation_key,
+            target_locale_id=context['page'].locale_id,
+            enabled=False
+        ).exists()
+
+
+@hooks.register("register_page_action_menu_item")
+def register_restart_translation_page_action_menu_item():
+    return RestartTranslationPageActionMenuItem(order=0)
+
+
 @hooks.register("before_edit_snippet")
 def before_edit_snippet(request, instance):
-    # Overrides the edit snippet view if the snippet is translatable and the target of a translation
     if isinstance(instance, TranslatableMixin):
+        # Check if the user has clicked the "Restart Translation" menu item
+        if request.method == 'POST' and 'localize-restart-translation' in request.POST:
+            try:
+                translation = Translation.objects.get(source__object_id=instance.translation_key, target_locale_id=instance.locale_id, enabled=False)
+            except Translation.DoesNotExist:
+                pass
+            else:
+                return edit_translation.restart_translation(request, translation, instance)
+
+        # Overrides the edit snippet view if the snippet is translatable and the target of a translation
         try:
             translation = Translation.objects.get(source__object_id=instance.translation_key, target_locale_id=instance.locale_id, enabled=True)
             return edit_translation.edit_translation(request, translation, instance)
 
         except Translation.DoesNotExist:
             pass
+
+
+class RestartTranslationSnippetActionMenuItem(SnippetActionMenuItem):
+    label = _("Restart translation")
+    name = "localize-restart-translation"
+    icon_name = "undo"
+    classname = 'action-secondary'
+
+    def is_shown(self, request, context):
+        # Only show this menu item on the edit view where there was a previous translation record
+        if context['view'] != 'edit':
+            return False
+
+        return Translation.objects.filter(
+            source__object_id=context['instance'].translation_key,
+            target_locale_id=context['instance'].locale_id,
+            enabled=False
+        ).exists()
+
+
+@hooks.register("register_snippet_action_menu_item")
+def register_restart_translation_snippet_action_menu_item(model):
+    if issubclass(model, TranslatableMixin):
+        return RestartTranslationSnippetActionMenuItem(order=0)

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -66,7 +66,7 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
 
         # If the page is the source for translations, show "Update translations" button
         source = TranslationSource.objects.get_for_instance_or_none(page)
-        if source is not None:
+        if source is not None and source.translations.filter(enabled=True).exists():
             url = reverse("wagtail_localize:update_translations", args=[source.id])
             if next_url is not None:
                 url += '?' + urlencode({'next': next_url})
@@ -98,7 +98,7 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
 
         # If the snippet is the source for translations, show "Update translations" button
         source = TranslationSource.objects.get_for_instance_or_none(snippet)
-        if source is not None:
+        if source is not None and source.translations.filter(enabled=True).exists():
             url = reverse('wagtail_localize:update_translations', args=[source.id])
             if next_url is not None:
                 url += '?' + urlencode({'next': next_url})

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -28,6 +28,7 @@ def register_admin_urls():
         path("translate/<int:translation_id>/machine_translate/", edit_translation.machine_translate, name="machine_translate"),
         path("translate/<int:translation_id>/preview/", edit_translation.preview_translation, name="preview_translation"),
         path("translate/<int:translation_id>/preview/<str:mode>/", edit_translation.preview_translation, name="preview_translation"),
+        path("translate/<int:translation_id>/disable/", edit_translation.stop_translation, name="stop_translation"),
     ]
 
     return [


### PR DESCRIPTION
Adds a "Stop translation" button into the action menu. This disables the translation record allowing the translated page/snippet to be edited manually.

There is also a "Restart translation" button that appears after translation has been stopped. This undoes "Stop translation".

The "Restart translation" button will only appear on snippets when the https://github.com/wagtail/wagtail/pull/6384 is merged. I've added some code in that allows it to run without crashing on Wagtail master (without that button) so this PR can get merged in.