### PR TITLE
Synchronise child relations before translation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
       - run: pipenv install -e .[testing]
       - run: git clone git@github.com:kaedroho/wagtail.git -b internationalisation
       - run: pipenv install -e ./wagtail
+      - run: git clone git@github.com:kaedroho/django-modelcluster.git -b copy-child-relation
+      - run: pipenv install -e ./django-modelcluster
       - run: cd wagtail && git status 
       - run: pipenv run flake8 wagtail_localize
       - run: pipenv run python testmanage.py test

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ basepython =
 
 deps =
     coverage
+    git+https://github.com/kaedroho/django-modelcluster.git@copy-child-relation
 
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1

--- a/wagtail_localize/fields.py
+++ b/wagtail_localize/fields.py
@@ -1,4 +1,7 @@
+from django.db import models
+from modelcluster.fields import ParentalKey
 from wagtail.core.fields import StreamField
+from wagtail.core.models import TranslatableMixin
 
 
 class BaseTranslatableField:
@@ -41,8 +44,14 @@ class TranslatableField(BaseTranslatableField):
         return True
 
     def is_synchronized(self, obj):
+        field = self.get_field(obj.__class__)
+
+        # Child relations should all be synchronised before translation
+        if isinstance(field, (models.ManyToOneRel)) and isinstance(field.remote_field, ParentalKey):
+            return True
+
         # Streamfields need to be re-synchronised before translation so the structure and non-translatable content is copied over
-        return isinstance(self.get_field(obj.__class__), StreamField)
+        return isinstance(field, StreamField)
 
 
 class SynchronizedField(BaseTranslatableField):
@@ -52,3 +61,47 @@ class SynchronizedField(BaseTranslatableField):
 
     def is_synchronized(self, obj):
         return self.is_editable(obj)
+
+
+def copy_synchronised_fields(source, target):
+    """
+    Copies data in synchronised fields from the source object to the target object.
+    """
+    for translatable_field in getattr(source, 'translatable_fields', []):
+        if translatable_field.is_synchronized(source):
+            field = translatable_field.get_field(target.__class__)
+
+            if isinstance(field, (models.ManyToOneRel)) and isinstance(field.remote_field, ParentalKey):
+                # Use modelcluster's copy_child_relation for child relations
+
+                if issubclass(field.related_model, TranslatableMixin):
+                    # Get a list of the primary keys for the existing child objects
+                    existing_pks_by_translation_key = {
+                        child_object.translation_key: child_object.pk
+                        for child_object in getattr(target, field.name).all()
+                    }
+
+                    # Copy the new child objects across (note this replaces existing ones)
+                    child_object_map = source.copy_child_relation(field.name, target)
+
+                    # Update locale of each child object and recycle PK
+                    for (child_relation, source_pk), child_objects in child_object_map.items():
+                        if source_pk is None:
+                            # This is a list of the child objects that were never saved
+                            for child_object in child_objects:
+                                child_object.pk = existing_pks_by_translation_key.get(child_object.translation_key)
+                                child_object.locale = target.locale
+                        else:
+                            child_object = child_objects
+
+                            child_object.pk = existing_pks_by_translation_key.get(child_object.translation_key)
+                            child_object.locale = target.locale
+
+                else:
+                    source.copy_child_relation(field.name, target)
+
+            else:
+                # For all other fields, just set the attribute
+                setattr(
+                    target, field.attname, getattr(source, field.attname)
+                )

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -30,6 +30,7 @@ from modelcluster.models import (
 )
 from wagtail.core.models import Page
 
+from .fields import copy_synchronised_fields
 from .segments import StringSegmentValue, TemplateSegmentValue, RelatedObjectSegmentValue
 from .segments.extract import extract_segments
 from .segments.ingest import ingest_segments
@@ -396,13 +397,7 @@ class TranslationSource(models.Model):
 
             created = True
 
-        # Copy synchronised fields
-        for field in getattr(translation, 'translatable_fields', []):
-            if field.is_synchronized(original):
-                # TODO: Use Django to set the field so the attname is correct
-                setattr(
-                    translation, field.field_name, getattr(original, field.field_name)
-                )
+        copy_synchronised_fields(original, translation)
 
         # Fetch all translated segments
         string_segments = (

--- a/wagtail_localize/segments/ingest.py
+++ b/wagtail_localize/segments/ingest.py
@@ -157,18 +157,14 @@ def ingest_segments(original_obj, translated_obj, src_locale, tgt_locale, segmen
                 segments_by_child[child_translation_key].append(segment)
 
             for child_translation_key, child_segments in segments_by_child.items():
-                original_child_object = original_manager.filter(
+                # The child objects must be synchronised before calling this function, so we
+                # can assume that both exist
+                original_child_object = original_manager.get(
                     translation_key=child_translation_key
-                ).first()
-                translated_child_object = translated_manager.filter(
+                )
+                translated_child_object = translated_manager.get(
                     translation_key=child_translation_key
-                ).first()
-
-                if not translated_child_object:
-                    # TODO: Here, we expect that the inline child to already exist as Wagtail copies it
-                    # when creating the translated page. When we add editing, we will need to support
-                    # adding new inline objects manually.
-                    continue
+                )
 
                 ingest_segments(
                     original_child_object,
@@ -177,4 +173,3 @@ def ingest_segments(original_obj, translated_obj, src_locale, tgt_locale, segmen
                     tgt_locale,
                     child_segments,
                 )
-                translated_child_object.save()

--- a/wagtail_localize/segments/tests/test_segment_ingestion.py
+++ b/wagtail_localize/segments/tests/test_segment_ingestion.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from wagtail.core.blocks import StreamValue
 from wagtail.core.models import Page, Locale
 
+from wagtail_localize.fields import copy_synchronised_fields
 from wagtail_localize.segments import (
     StringSegmentValue,
     TemplateSegmentValue,
@@ -192,6 +193,8 @@ class TestSegmentIngestion(TestCase):
         child_translation_key = TestChildObject.objects.get().translation_key
 
         translated_page = page.copy_for_translation(self.locale)
+
+        copy_synchronised_fields(page, translated_page)
 
         ingest_segments(
             page,

--- a/wagtail_localize/test/models.py
+++ b/wagtail_localize/test/models.py
@@ -124,7 +124,7 @@ class TestPage(Page):
         SynchronizedField("test_synchronized_richtextfield"),
         SynchronizedField("test_synchronized_streamfield"),
         SynchronizedField("test_synchronized_snippet"),
-        # FIXME SynchronizedField("test_synchronized_childobjects"),
+        SynchronizedField("test_synchronized_childobjects"),
         SynchronizedField("test_synchronized_customfield"),
     ]
 
@@ -165,9 +165,10 @@ class TestSynchronizedChildObject(Orderable):
     translatable_fields = [TranslatableField("field")]
 
 
+# FIXME: Rename me
 class TestNonParentalChildObject(TranslatableMixin, Orderable):
     page = models.ForeignKey(
-        TestPage, on_delete=models.CASCADE, related_name="test_nonparentalchildobjects"
+        TestPage, on_delete=models.CASCADE, related_name="test_nonparentalchildobjects"  # FIXME: inconsistent related_name
     )
     field = models.TextField()
 


### PR DESCRIPTION
This PR adds support for synchronising child relations. We also no longer save child relations in `ingest_segments` in order to allow previews to be generated without altering data (the save is done by model cluster later on at the point of saving the page).

This relies on a new modelcluster feature https://github.com/wagtail/django-modelcluster/pull/128