### PR TITLE
Use npm install instead of npm ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - type: cache-restore
         key: node-modules
 
-      - run: npm ci
+      - run: npm install
       - run: npm run lint
 
       - type: cache-save


### PR DESCRIPTION
I mistakenly thought this command was some CI specific install command.

It actually means "clean install" and prevents the cache from working.