### PR TITLE
Support internationalised Streamfield block names

### DIFF
--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -151,7 +151,7 @@ def get_segment_location_info(source_instance, tab_helper, segment):
 
         return {
             'tab': tab,
-            'field': capfirst(block_type.label),
+            'field': capfirst(str(block_type.label)),
             'blockId': block_id,
             'fieldHelpText': '',
             'subField': block_field,


### PR DESCRIPTION
This adds support for a Streamfield block with a label marked for translation.

```python
paragraph = blocks.RichTextBlock(label=_("Paragraph"))
```

I haven't added any tests, as I couldn't get the test suite to work locally.