### PR TITLE
Drop support for Django 2.11 and 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,8 @@ services:
 
 matrix:
   include:
-   - env: TOXENV=py37-dj22-wamaster-postgres
+   - env: TOXENV=py37-dj31-wamaster-postgres
      python: 3.7
-
-   - env: TOXENV=py38-dj22-wamaster-postgres
-     python: 3.8
-
-   - env: TOXENV=py38-dj22-wamaster-sqlite
-     python: 3.8
-
-   - env: TOXENV=py37-dj30-wamaster-postgres
-     python: 3.7
-
-   - env: TOXENV=py38-dj30-wamaster-postgres
-     python: 3.8
 
    - env: TOXENV=py38-dj31-wamaster-postgres
      python: 3.8

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Supported versions:
 
 Python: 3.7 and 3.8
-Django: 2.2, 3.0 and 3.1
+Django: 3.1
 Wagtail: 2.11
 
 ## Installation and setup

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    install_requires=["Django>=2.2,<3.2", "Wagtail>=2.10,<2.11", "polib>=1.1,<2.0"],
+    install_requires=["Django>=3.1,<3.2", "Wagtail>=2.10,<2.11", "polib>=1.1,<2.0"],
     extras_require={
         "testing": ["dj-database-url==0.5.0", "freezegun==0.3.15"],
         "google_translate": ["googletrans>=2.4,<3.0",],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{37,38}-dj{22,30,31,master}-wa{211,master}-{sqlite,postgres}
+envlist = py{37,38}-dj{31,master}-wa{211,master}-{sqlite,postgres}
 
 [flake8]
 # E501: Line too long
@@ -21,8 +21,6 @@ basepython =
 deps =
     coverage
 
-    dj22: Django>=2.2,<2.3
-    dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     djmaster: git+https://github.com/django/django.git@master#egg=Django
     djmaster: git+https://github.com/wagtail/django-modelcluster.git


### PR DESCRIPTION
I'd like to use the new generic JSONField in https://github.com/wagtail/wagtail-localize/pull/179

But also, since this is a new app, I'd like to drop these before the release so we don't have to deprecate them properly later!