### PR TITLE
Make TranslatableMixin for snippets not required

### DIFF
--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -208,8 +208,15 @@ if SNIPPET_RESTART_TRANSLATION_ENABLED:
                 target_locale_id=context['instance'].locale_id,
                 enabled=False
             ).exists()
+    
+    
+    class DisabledTranslationSnippetActionMenuItem():
+        def is_shown(self, request, context):
+            return False
 
+    
     @hooks.register("register_snippet_action_menu_item")
     def register_restart_translation_snippet_action_menu_item(model):
         if issubclass(model, TranslatableMixin):
             return RestartTranslationSnippetActionMenuItem(order=0)
+        return DisabledTranslationSnippetActionMenuItem()

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -203,20 +203,15 @@ if SNIPPET_RESTART_TRANSLATION_ENABLED:
             if context['view'] != 'edit':
                 return False
 
+            if not issubclass(context['model'], TranslatableMixin):
+                return False
+
             return Translation.objects.filter(
                 source__object_id=context['instance'].translation_key,
                 target_locale_id=context['instance'].locale_id,
                 enabled=False
             ).exists()
-    
-    
-    class DisabledTranslationSnippetActionMenuItem():
-        def is_shown(self, request, context):
-            return False
 
-    
     @hooks.register("register_snippet_action_menu_item")
     def register_restart_translation_snippet_action_menu_item(model):
-        if issubclass(model, TranslatableMixin):
-            return RestartTranslationSnippetActionMenuItem(order=0)
-        return DisabledTranslationSnippetActionMenuItem()
+        return RestartTranslationSnippetActionMenuItem(order=0)


### PR DESCRIPTION
The snippets that do not have the TranslatableMixin or any translation features on it do not work due to an error message (see image below)
This update fixes the **"Nonetype" object has no attribute is_shown** error.
Here is an error message - 
![image](https://user-images.githubusercontent.com/26556210/99802134-d025bc00-2b3f-11eb-9a65-ed1525ec5d53.png)
