### PR TITLE
Prevent crash when a homepage is created in a synchronised locale source

### DIFF
--- a/wagtail_localize/synctree.py
+++ b/wagtail_localize/synctree.py
@@ -197,6 +197,14 @@ def on_page_saved(sender, instance, **kwargs):
     if not kwargs['created']:
         return
 
+    # We can't handle creations at the root, this is because Treebeard calls
+    # the post_save signal before it updates the numchild of the parent page
+    # Which is a problem here because we're about to add another child which
+    # needs that value to be set correctly in order to get a unique path.
+    # TODO(someday): Find a nicer solution for this
+    if instance.depth == 2:
+        return
+
     # Check if the source tree needs to be synchronised into any other trees
     from .models import LocaleSynchronization
     locales_to_sync_to = Locale.objects.filter(


### PR DESCRIPTION
Fixes #245.

This just works around the crash by disabling the auto-creation of homepages when a new homepage is created in a locale that is set in the "sync from" field of another.

The problem is that Treebeard calls the post_save signal before it's set the `numchild` attribute of the parent. This isn't a problem in most cases as the translations are created underneath other parent pages. But for homepages, we need the parent `numchild` to be up to date because translations of homepages are created as siblings.

Without the correct `numchild`, Treebeard/Wagtail attempts to create those siblings with the same path which results in a crash.