### PR TITLE
Check for invaid id on <a> while submitting translations

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -41,7 +41,7 @@ from .locales.components import register_locale_component
 from .segments import StringSegmentValue, TemplateSegmentValue, RelatedObjectSegmentValue, OverridableSegmentValue
 from .segments.extract import extract_segments
 from .segments.ingest import ingest_segments
-from .strings import StringValue
+from .strings import StringValue, validate_translation_links
 
 
 def pk(obj):
@@ -1027,8 +1027,10 @@ class StringTranslation(models.Model):
         # if any strings are invalid so we don't use them on a page.
         updating_data = update_fields is None or 'data' in update_fields
         if updating_data and not self.has_error:
+
             try:
                 StringValue.from_translated_html(self.data)
+                validate_translation_links(self.translation_of.data, self.data)
             except ValueError:
                 self.has_error = True
                 self.save(update_fields=['has_error'])
@@ -1054,6 +1056,7 @@ class StringTranslation(models.Model):
         # Check for HTML validation errors
         try:
             StringValue.from_translated_html(self.data)
+            validate_translation_links(self.translation_of.data, self.data)
         except ValueError as e:
             return e.args[0]
 

--- a/wagtail_localize/strings.py
+++ b/wagtail_localize/strings.py
@@ -389,3 +389,28 @@ def restore_strings(template, strings):
         text_element.replaceWith(string.render_soup(attrs))
 
     return str(soup)
+
+
+
+def extract_ids(template):
+    """Extract link ids from one template string and return it in a set."""
+    soup = BeautifulSoup(template, "html.parser")
+    ids = set()
+    for element in soup.descendants:
+        if not isinstance(element, Tag):
+            continue
+
+        if element.name == 'a':
+            if 'id' in element.attrs:
+                ids.add(element.attrs['id'])
+
+    return ids
+
+
+def validate_translation_links(translation_of, data):
+    """Check that the link id in a translation are present in its source."""
+    id1s, id2s = extract_ids(translation_of), extract_ids(data)
+    new_ids = id2s - id1s
+    if new_ids:
+        ids = ", ".join(sorted(new_ids))
+        raise ValueError(_("Unrecognised id found in an <a> tag: {}").format(ids))


### PR DESCRIPTION
Adding this request to fix the issues I've open this morning:

https://github.com/wagtail/wagtail-localize/issues/294

Now, when I have an error that flash:

![image](https://user-images.githubusercontent.com/447396/103416191-e33b9b00-4b85-11eb-82c2-6d154aff4efc.png)

Unfortunatly, because the error is saved in the database, existing errors that are not marked in the database cannot
be found, but I this it is ok like that. I guess error are saved for performance reason and it is fine for me.


Hope its helps :smiley: 
