### PR TITLE
Make locale components optional

### DIFF
--- a/wagtail_localize/locales/components.py
+++ b/wagtail_localize/locales/components.py
@@ -5,9 +5,16 @@ def get_locale_components():
     return LOCALE_COMPONENTS
 
 
-def register_locale_component(model):
-    if model not in LOCALE_COMPONENTS:
-        LOCALE_COMPONENTS.append(model)
-        LOCALE_COMPONENTS.sort(key=lambda x: x._meta.verbose_name)
+def register_locale_component(*, required=False):
+    def _wrapper(model):
+        if model not in LOCALE_COMPONENTS:
+            LOCALE_COMPONENTS.append({
+                'required': required,
+                'model': model,
+                'slug': model._meta.db_table,
+            })
+            LOCALE_COMPONENTS.sort(key=lambda x: x['model']._meta.verbose_name)
 
-    return model
+        return model
+
+    return _wrapper

--- a/wagtail_localize/locales/components.py
+++ b/wagtail_localize/locales/components.py
@@ -5,10 +5,12 @@ def get_locale_components():
     return LOCALE_COMPONENTS
 
 
-def register_locale_component(*, required=False):
+def register_locale_component(*, heading, help_text=None, required=False):
     def _wrapper(model):
         if model not in LOCALE_COMPONENTS:
             LOCALE_COMPONENTS.append({
+                'heading': heading,
+                'help_text': help_text,
                 'required': required,
                 'model': model,
                 'slug': model._meta.db_table,

--- a/wagtail_localize/locales/templates/wagtaillocales/create.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/create.html
@@ -13,7 +13,7 @@
         {% block hidden_fields %}
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
 
-            {% for component_model, component_instance, component_form in components %}
+            {% for component, component_instance, component_form in components %}
                 {% for field in component_form.hidden_fields %}
                     {{ field }}
                 {% endfor %}
@@ -27,7 +27,7 @@
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}
 
-                    {% for component_model, component_instance, component_form in components %}
+                    {% for component, component_instance, component_form in components %}
                         {% for field in component_form.visible_fields %}
                             {% include "wagtailadmin/shared/field_as_li.html" %}
                         {% endfor %}

--- a/wagtail_localize/locales/templates/wagtaillocales/create.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/create.html
@@ -28,6 +28,9 @@
                     {% endfor %}
 
                     {% for component, component_instance, component_form in components %}
+                        <h3>{{ component.heading }}</h3>
+                        <p>{{ component.help_text }}</p>
+
                         {% for field in component_form.visible_fields %}
                             {% include "wagtailadmin/shared/field_as_li.html" %}
                         {% endfor %}

--- a/wagtail_localize/locales/templates/wagtaillocales/create.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/create.html
@@ -1,61 +1,8 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "./edit.html" %}
 {% load i18n %}
 
 {% block titletag %}{{ view.page_title }}{% endblock %}
 
-{% block content %}
-
-    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon %}
-
-    <form action="{{ view.get_add_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
-        {% csrf_token %}
-
-        {% block hidden_fields %}
-            {% for field in form.hidden_fields %}{{ field }}{% endfor %}
-
-            {% for component, component_instance, component_form in components %}
-                {% for field in component_form.hidden_fields %}
-                    {{ field }}
-                {% endfor %}
-            {% endfor %}
-        {% endblock %}
-
-        <div class="nice-padding">
-            <ul class="fields">
-                {% block visible_fields %}
-                    {% for field in form.visible_fields %}
-                        {% include "wagtailadmin/shared/field_as_li.html" %}
-                    {% endfor %}
-
-                    {% for component, component_instance, component_form in components %}
-                        <h3>{{ component.heading }}</h3>
-                        <p>{{ component.help_text }}</p>
-
-                        {% for field in component_form.visible_fields %}
-                            {% include "wagtailadmin/shared/field_as_li.html" %}
-                        {% endfor %}
-                    {% endfor %}
-                {% endblock %}
-                <li><input type="submit" value="{% trans 'Save' %}" class="button" /></li>
-            </ul>
-        </div>
-    </form>
-{% endblock %}
-
-{% block extra_js %}
-    {{ block.super }}
-    {{ form.media.js }}
-
-    {% for component_model, component_instance, component_form in components %}
-        {{ component_form.media.js }}
-    {% endfor %}
-{% endblock %}
-
-{% block extra_css %}
-    {{ block.super }}
-    {{ form.media.css }}
-
-    {% for component_model, component_instance, component_form in components %}
-        {{ component_form.media.css }}
-    {% endfor %}
+{% block actions %}
+    <input type="submit" value="{% trans 'Save' %}" class="button" />
 {% endblock %}

--- a/wagtail_localize/locales/templates/wagtaillocales/edit.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/edit.html
@@ -20,7 +20,7 @@
             {% block hidden_fields %}
                 {% for field in form.hidden_fields %}{{ field }}{% endfor %}
 
-                {% for component_model, component_instance, component_form in components %}
+                {% for component, component_instance, component_form in components %}
                     {% for field in component_form.hidden_fields %}
                         {{ field }}
                     {% endfor %}
@@ -33,7 +33,7 @@
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}
 
-                    {% for component_model, component_instance, component_form in components %}
+                    {% for component, component_instance, component_form in components %}
                         {% for field in component_form.visible_fields %}
                             {% include "wagtailadmin/shared/field_as_li.html" %}
                         {% endfor %}

--- a/wagtail_localize/locales/templates/wagtaillocales/edit.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/edit.html
@@ -34,6 +34,9 @@
                     {% endfor %}
 
                     {% for component, component_instance, component_form in components %}
+                        <h3>{{ component.heading }}</h3>
+                        <p>{{ component.help_text }}</p>
+
                         {% for field in component_form.visible_fields %}
                             {% include "wagtailadmin/shared/field_as_li.html" %}
                         {% endfor %}

--- a/wagtail_localize/locales/templates/wagtaillocales/edit.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/edit.html
@@ -7,14 +7,13 @@
     {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
 
     <div class="nice-padding">
-
-        {% if not locale.language_code_is_valid %}
+        {% if locale and not locale.language_code_is_valid %}
             <p class="help-block help-warning">
                 {% trans "This locale's current language code is not supported. Please choose a new language or delete this locale." %}
             </p>
         {% endif %}
 
-        <form action="{{ view.get_edit_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+        <form method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
             {% csrf_token %}
 
             {% block hidden_fields %}
@@ -44,10 +43,12 @@
                 {% endblock %}
 
                 <li>
-                    <input type="submit" value="{% trans 'Save' %}" class="button" />
-                    {% if can_delete %}
-                        <a href="{{ view.get_delete_url }}" class="button button-secondary no">{{ view.delete_item_label }}</a>
-                    {% endif %}
+                    {% block actions %}
+                        <input type="submit" value="{% trans 'Save' %}" class="button" />
+                        {% if can_delete %}
+                            <a href="{{ view.get_delete_url }}" class="button button-secondary no">{{ view.delete_item_label }}</a>
+                        {% endif %}
+                    {% endblock %}
                 </li>
             </ul>
         </form>
@@ -57,9 +58,17 @@
 {% block extra_js %}
     {{ block.super }}
     {{ form.media.js }}
+
+    {% for component_model, component_instance, component_form in components %}
+        {{ component_form.media.js }}
+    {% endfor %}
 {% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
     {{ form.media.css }}
+
+    {% for component_model, component_instance, component_form in components %}
+        {{ component_form.media.css }}
+    {% endfor %}
 {% endblock %}

--- a/wagtail_localize/locales/templates/wagtaillocales/edit.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/edit.html
@@ -31,17 +31,28 @@
                     {% for field in form.visible_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}
-
-                    {% for component, component_instance, component_form in components %}
-                        <h3>{{ component.heading }}</h3>
-                        <p>{{ component.help_text }}</p>
-
-                        {% for field in component_form.visible_fields %}
-                            {% include "wagtailadmin/shared/field_as_li.html" %}
-                        {% endfor %}
-                    {% endfor %}
                 {% endblock %}
+            </ul>
 
+            {% for component, component_instance, component_form in components %}
+                <section class="component-form{% if component.required %} component-form--required{% endif %} {% if not component.required and not component_form.enabled.value %} component-form--disabled{% endif %}">
+                    <h3>{{ component.heading }}</h3>
+                    <p>{{ component.help_text }}</p>
+
+                    <ul class="fields component-form__fields">
+                        {% for field in component_form.visible_fields %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with li_classes="component-form__fieldname-"|add:field.name %}
+                        {% endfor %}
+                    </ul>
+
+                    {% if not component.required %}
+                        <button type="button" class="button button-small component-form__enable-button">{% trans "Enable "%}</button>
+                        <button type="button" class="button button-small no component-form__disable-button">{% trans "Disable "%}</button>
+                    {% endif %}
+                </section>
+            {% endfor %}
+
+            <ul class="fields">
                 <li>
                     {% block actions %}
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
@@ -62,6 +73,28 @@
     {% for component_model, component_instance, component_form in components %}
         {{ component_form.media.js }}
     {% endfor %}
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Component enable buttons
+            document.querySelectorAll('.component-form__enable-button').forEach(function (enableButton) {
+                enableButton.addEventListener('click', function () {
+                    var componentForm = enableButton.closest('.component-form');
+                    componentForm.classList.remove('component-form--disabled');
+                    componentForm.querySelector('.component-form__fieldname-enabled input').checked = true;
+                });
+            });
+
+            // Component disable buttons
+            document.querySelectorAll('.component-form__disable-button').forEach(function (disableButton) {
+                disableButton.addEventListener('click', function () {
+                    var componentForm = disableButton.closest('.component-form');
+                    componentForm.classList.add('component-form--disabled');
+                    componentForm.querySelector('.component-form__fieldname-enabled input').checked = false;
+                });
+            });
+        });
+    </script>
 {% endblock %}
 
 {% block extra_css %}
@@ -71,4 +104,49 @@
     {% for component_model, component_instance, component_form in components %}
         {{ component_form.media.css }}
     {% endfor %}
+
+    <style>
+        /* Put a box around component forms */
+        .component-form {
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            padding: 10px;
+            margin-top: 10px;
+            margin-bottom: 20px;
+        }
+
+        /* Align component form buttons to the right */
+        .component-form button {
+            float: right;
+        }
+        .component-form::after {
+            content: ' ';
+            display: table;
+            clear: both;
+        }
+
+        /* Hide the enabled checkbox */
+        .component-form__fieldname-enabled {
+            display: none;
+        }
+
+        /* Hide fields if the form is disabled */
+        .component-form--disabled .component-form__fields {
+            display: none;
+        }
+
+        /* Show enabled button if the form is disabled */
+        .component-form__enable-button {
+            display: none;
+        }
+
+        .component-form--disabled .component-form__enable-button {
+            display: block;
+        }
+
+        /* Hide disabled button if the form is disabled */
+        .component-form--disabled .component-form__disable-button {
+            display: none;
+        }
+    </style>
 {% endblock %}

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -26,7 +26,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.text import capfirst, slugify
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 from modelcluster.models import (
     ClusterableModel,
     get_serializable_data_for_fields,
@@ -1400,7 +1400,7 @@ def register_post_delete_signal_handlers():
         post_delete.connect(disable_translation_on_delete, sender=model)
 
 
-@register_locale_component
+@register_locale_component()
 class LocaleSynchronization(models.Model):
     locale = models.OneToOneField('wagtailcore.Locale', on_delete=models.CASCADE, related_name='+')
     sync_from = models.ForeignKey('wagtailcore.Locale', on_delete=models.CASCADE, related_name='+')

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -1400,7 +1400,14 @@ def register_post_delete_signal_handlers():
         post_delete.connect(disable_translation_on_delete, sender=model)
 
 
-@register_locale_component()
+@register_locale_component(
+    heading=gettext_lazy("Synchronise content from another locale"),
+    help_text=gettext_lazy(
+        "Choose a locale to synchronise content from. "
+        "Any existing and future content authored in the selected locale will "
+        "be automatically copied to this one."
+    ),
+)
 class LocaleSynchronization(models.Model):
     locale = models.OneToOneField('wagtailcore.Locale', on_delete=models.CASCADE, related_name='+')
     sync_from = models.ForeignKey('wagtailcore.Locale', on_delete=models.CASCADE, related_name='+')


### PR DESCRIPTION
Fixes #316

This PR allows locale components to be enabled/disabled as a whole, allowing the locale components themselves to still have required fields if they are enabled.

![image](https://user-images.githubusercontent.com/1093808/108066834-d3a1e400-7057-11eb-9386-bae5eb5e7211.png)

![image](https://user-images.githubusercontent.com/1093808/108066749-abb28080-7057-11eb-93b5-fd93d2d9ee8c.png)

The form is always expanded for required components:
![image](https://user-images.githubusercontent.com/1093808/108067253-6e9abe00-7058-11eb-9b5e-609a79cabebd.png)