### PR TITLE
Don't show option to translate alias when alias has the same language

### DIFF
--- a/wagtail_localize/templates/wagtail_localize/admin/edit_translatable_alias.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/edit_translatable_alias.html
@@ -6,7 +6,7 @@
         {% url 'wagtailadmin_pages:edit' page.alias_of_id as edit_original_page_url %}
         <p>
             {% blocktrans with edit_original_page_url=edit_original_page_url original_locale=page.alias_of.locale.get_display_name trimmed %}
-                This page hasn't been translated yet. It is mirroring the <a href="{{ edit_original_page_url }}" target="_blank">{{ original_locale }} page.</a>.
+                This page hasn't been translated yet. It is mirroring the <a href="{{ edit_original_page_url }}" target="_blank">{{ original_locale }} page</a>.
             {% endblocktrans %}
         </p>
 

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -1811,3 +1811,48 @@ class TestMachineTranslateView(EditTranslationTestData, TestCase):
         })
 
         assert_permission_denied(self, response)
+
+
+class TestEditAlias(WagtailTestUtils, TestCase):
+    """
+    Tests that Wagtail Localize's custom edit alias template is rendered for aliases
+    that have a different locale to their original.
+    """
+    def setUp(self):
+        self.login()
+        self.user = get_user_model().objects.get()
+
+        # Create a test page
+        self.home_page = Page.objects.get(depth=2)
+        self.page = self.home_page.add_child(instance=TestPage(
+            title="The title",
+            slug="test",
+        ))
+
+        # Set up French locale
+        self.fr_locale = Locale.objects.create(language_code="fr")
+        self.fr_home_page = self.home_page.copy_for_translation(self.fr_locale)
+
+    def test_edit_translatable_alias(self):
+        # Create an alias of the page in French
+        alias_page = self.page.create_alias(parent=self.fr_home_page, update_locale=self.fr_locale)
+
+        # Try to edit the page
+        response = self.client.get(reverse('wagtailadmin_pages:edit', args=[alias_page.id]))
+
+        # Check the translatable alias template was rendered
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtail_localize/admin/edit_translatable_alias.html')
+
+    def test_edit_non_translatable_alias(self):
+        # Create an alias of the page in English
+        alias_page = self.page.create_alias(update_slug='test-alias')
+
+        # Try to edit the page
+        response = self.client.get(reverse('wagtailadmin_pages:edit', args=[alias_page.id]))
+
+        # Check the translatable alias template was not rendered
+        # Wagtail's builtin edit_alias.html should be rendered instead
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateNotUsed(response, 'wagtail_localize/admin/edit_translatable_alias.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/edit_alias.html')

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -130,7 +130,7 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
 @hooks.register("before_edit_page")
 def before_edit_page(request, page):
     # If the page is an alias of a page in another locale, override the edit page so that we can show a "Translate this page" option
-    if page.alias_of and page.alias_of.locale is not page.locale:
+    if page.alias_of and page.alias_of.locale_id != page.locale_id:
         return edit_translation.edit_translatable_alias_page(request, page)
 
     # Check if the user has clicked the "Restart Translation" menu item


### PR DESCRIPTION
A faulty if statement made Wagtail Localize's custom "edit alias" template render for aliases that are in the same language as the original page. We only want this template to be used if the alias is in a different locale.

Fixes #322