### PR TITLE
Ensure we remove translation of source that have been removed

### DIFF
--- a/wagtail_localize/segments/ingest.py
+++ b/wagtail_localize/segments/ingest.py
@@ -234,7 +234,13 @@ def ingest_segments(original_obj, translated_obj, src_locale, tgt_locale, segmen
         field = translated_obj.__class__._meta.get_field(field_name)
 
         if not field_segments:
-            data = field.value_from_object(original_obj)
+
+            if isinstance(field, (models.TextField, models.CharField)):
+                data = field.value_from_object(original_obj)
+            else:
+                # TODO implement for other types
+                continue
+
             setattr(translated_obj, field_name, data)
 
         elif hasattr(field, "restore_translated_segments"):


### PR DESCRIPTION
Hello @kaedroho 

We have currently a bug in the translation.

The flow is:

 we have a field named "strapline", and we have to clean it in some pages.

 * in the translation editor, the source disapear

 * after publishing, the translation is still there because it has not been cleaned in the translated page.

All tables (wagtail_localized_string, wagtail_localized_stringtranslation, ...) are cleaned but the data is still in the published page.


Here is my pull request for the fix.


Tell me if you need more explanation of the bug.



