### PR TITLE
Fix installed app in "Detailled installation guide"

### DIFF
--- a/docs/how-to/from-scratch.md
+++ b/docs/how-to/from-scratch.md
@@ -18,7 +18,7 @@ Add `wagtail_localize` and any optional sub modules to `INSTALLED_APPS` in `sett
 INSTALLED_APPS = [
     ...
     "wagtail_localize",
-    "wagtail_localize.translation",
+    "wagtail_localize.locales",
 ]
 ```
 


### PR DESCRIPTION
Prompted by https://wagtailcms.slack.com/archives/C81FGJR2S/p1619612134409700

The README says:

```
    'wagtail_localize',
    'wagtail_localize.locales',
```