### PR TITLE
Add CI workflow task to detect new strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,39 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
+
+  new-strings:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.8']
+        node: ['14']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Set up Node ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install gettext
+        run: sudo apt-get install gettext
+      - name: Install podiff
+        run: |
+          wget ftp://download.gnu.org.ua/pub/release/podiff/podiff-1.3.tar.gz
+          tar -xf podiff-1.3.tar.gz
+          cd podiff-1.3
+          make
+      - name: Install dependencies
+        run: |
+          pip install -e.[testing]
+          npm install
+      - name: Check for new messages
+        run: |
+          msgcat wagtail_localize/locale/en/LC_MESSAGES/*.po | sed "/^\"POT-Creation-Date\:/d" > current.po
+          make messages
+          msgcat wagtail_localize/locale/en/LC_MESSAGES/*.po | sed "/^\"POT-Creation-Date\:/d" > next.po
+          ./podiff-1.3/podiff current.po next.po


### PR DESCRIPTION
This PR adds a new Github workflow task that checks if there are any changes to translatable strings that haven't yet been extracted into a PO file.

I've set up a one-way link from this repo to Transifex so that translations are updated there as soon as we've generated the PO files here.