### PR TITLE
Use gettext_lazy to avoid generating unnecessary migrations

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -1307,8 +1307,8 @@ class StringTranslation(models.Model):
     TRANSLATION_TYPE_MANUAL = 'manual'
     TRANSLATION_TYPE_MACHINE = 'machine'
     TRANSLATION_TYPE_CHOICES = [
-        (TRANSLATION_TYPE_MANUAL, _("Manual")),
-        (TRANSLATION_TYPE_MACHINE, _("Machine")),
+        (TRANSLATION_TYPE_MANUAL, gettext_lazy("Manual")),
+        (TRANSLATION_TYPE_MACHINE, gettext_lazy("Machine")),
     ]
 
     translation_of = models.ForeignKey(


### PR DESCRIPTION
When your LANGUAGE_CODE is not `en` and strings `Manual` or `Machine` have already been added to translations, usage of non lazy gettext generates new strings inside the `makemigrations` runtime, which leads to Django false positively detecting changes in models.