### PR TITLE
Handle configurable comments relation (Wagtail 2.15 fix)

### DIFF
--- a/wagtail_localize/fields.py
+++ b/wagtail_localize/fields.py
@@ -6,6 +6,11 @@ from treebeard.mp_tree import MP_Node
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Page, TranslatableMixin
 
+try:
+    from wagtail.core.models import COMMENTS_RELATION_NAME
+except ImportError:
+    COMMENTS_RELATION_NAME = 'comments'
+
 
 class BaseTranslatableField:
     def __init__(self, field_name):
@@ -170,7 +175,7 @@ def get_translatable_fields(model):
     if issubclass(model, ClusterableModel):
         for child_relation in get_all_child_relations(model):
             # Ignore comments
-            if issubclass(model, Page) and child_relation.name == 'comments':
+            if issubclass(model, Page) and child_relation.name == COMMENTS_RELATION_NAME:
                 continue
 
             if issubclass(child_relation.related_model, TranslatableMixin):


### PR DESCRIPTION
The 'comments' relation on Page will be renamed to 'wagtail_admin_comments' in Wagtail 2.15, as per https://github.com/wagtail/wagtail/pull/7591, and 2.13.5 / 2.14.2 will allow developers to 'opt in' to the new name to prevent conflicts with third-party packages that also use the name 'comments' (https://github.com/wagtail/wagtail/pull/7600/ / https://github.com/wagtail/wagtail/pull/7601/). We therefore need to recognise the relation name in use, rather than hard-coding 'comments'.