### PR TITLE
Translate custom field block

### DIFF
--- a/wagtail_localize/segments/extract.py
+++ b/wagtail_localize/segments/extract.py
@@ -5,6 +5,7 @@ from django.db import models
 from modelcluster.fields import ParentalKey
 from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
+from wagtail.core.blocks import field_block
 from wagtail.core.models import TranslatableMixin, Page
 
 from wagtail_localize.segments import (
@@ -96,6 +97,10 @@ class StreamFieldSegmentExtractor:
 
         elif isinstance(block_type, blocks.StreamBlock):
             return self.handle_stream_block(block_value)
+
+        # Custom Field Block having a field of type text has to be translated.
+        elif isinstance(block_type, (field_block.FieldBlock)) and isinstance(block_value, str):
+            return [StringSegmentValue("", block_value)]
 
         # Ignore everything else
         return []


### PR DESCRIPTION
Hello everyone,  here is a small patch I need to made,
please consider to fix that upstream.


We used to have a block `class AnchorOrURLBlock(CharBlock)`.

This block override the "URLField" of Django to authorize urls (`https://`) or direct link in the page `#anchor`.


While we update from wagtail "~2.13.1" to "~2.14.1" we encountered issues with the validation field in the Admin.

that become a `class AnchorOrURLBlock(FieldBlock)` to fix the validation of the field.

But now, url are not extracted anymore for translations.

`isinstance(block_value, str)` is here because the block value may be None or any inner field that may be another field such as BooleanField.
