### PR TITLE
Sync source page privacy settings with translated page

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -234,6 +234,14 @@ class CannotSaveDraftError(Exception):
     pass
 
 
+class NoViewRestrictionsError(Exception):
+    """
+    Raised when trying to sync view restrictions for non-Page objects
+    """
+
+    pass
+
+
 class MissingTranslationError(Exception):
     def __init__(self, segment, locale):
         self.segment = segment
@@ -888,7 +896,7 @@ class TranslationSource(models.Model):
             translation_page (Page|Snippet): The translated instance.
         """
         if not isinstance(original, Page) or not isinstance(translation_page, Page):
-            return
+            raise NoViewRestrictionsError
 
         if original.view_restrictions.exists():
             original_restriction = original.view_restrictions.first()
@@ -943,7 +951,7 @@ class TranslationSource(models.Model):
 
         try:
             translation_page = self.get_translated_instance(locale)
-        except models.ObjectDoesNotExist:
+        except Page.DoesNotExist:
             return
 
         self.sync_view_restrictions(original, translation_page)

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -481,3 +481,70 @@ class TestUpdateTranslations(TestCase, WagtailTestUtils):
         self.assertTrue(
             self.fr_blog_post.view_restrictions.first().pk, view_restriction.pk
         )
+
+    def test_post_update_page_translation_after_source_privacy_removed(self):
+        PageViewRestriction.objects.create(
+            restriction_type="login", page=self.fr_blog_post
+        )
+
+        self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+        )
+        self.fr_blog_post.refresh_from_db()
+        self.assertFalse(self.fr_blog_post.view_restrictions.exists())
+
+    def test_post_update_page_translation_after_source_privacy_changed(self):
+        PageViewRestriction.objects.create(
+            restriction_type="login", page=self.en_blog_post
+        )
+
+        self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+        )
+
+        self.fr_blog_post.refresh_from_db()
+        self.assertTrue(self.fr_blog_post.view_restrictions.exists())
+        self.assertTrue(
+            self.fr_blog_post.view_restrictions.first().restriction_type, "login"
+        )
+
+        # change the restriction for the source
+        self.en_blog_post.view_restrictions.all().update(
+            restriction_type="password", password="test"
+        )
+        self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+        )
+        self.fr_blog_post.refresh_from_db()
+        translated_restriction = self.fr_blog_post.view_restrictions.first()
+        self.assertTrue(translated_restriction.restriction_type, "password")
+        self.assertTrue(translated_restriction.password, "test")
+
+        self.en_blog_post.view_restrictions.all().delete()
+
+        test_group = Group.objects.create(name="Test Group")
+        restriction = PageViewRestriction.objects.create(
+            restriction_type="groups", page=self.en_blog_post
+        )
+        restriction.groups.set([test_group])
+
+        self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+        )
+        self.fr_blog_post.refresh_from_db()
+        translated_restriction = self.fr_blog_post.view_restrictions.first()
+        self.assertTrue(translated_restriction.restriction_type, "groups")
+        self.assertEqual(translated_restriction.groups.count(), 1)
+        self.assertEqual(translated_restriction.groups.first(), test_group)

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from wagtail import VERSION as WAGTAIL_VERSION
-from wagtail.core.models import Locale, Page
+from wagtail.core.models import Locale, Page, PageViewRestriction
 from wagtail.tests.utils import WagtailTestUtils
 
 from wagtail_localize.models import StringSegment, Translation, TranslationSource
@@ -446,3 +446,38 @@ class TestUpdateTranslations(TestCase, WagtailTestUtils):
         # The FR version shouldn't be updated
         self.fr_blog_post.refresh_from_db()
         self.assertEqual(self.fr_blog_post.test_charfield, "Test content")
+
+    def test_post_update_page_translation_after_source_privacy_added(self):
+        view_restriction = PageViewRestriction.objects.create(
+            restriction_type="login", page=self.en_blog_post
+        )
+
+        self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+        )
+        self.fr_blog_post.refresh_from_db()
+        self.assertTrue(self.fr_blog_post.view_restrictions.exists())
+        self.assertTrue(
+            self.fr_blog_post.view_restrictions.first().pk, view_restriction.pk
+        )
+
+    def test_post_update_page_translation_with_publish_after_source_privacy_added(self):
+        view_restriction = PageViewRestriction.objects.create(
+            restriction_type="login", page=self.en_blog_post
+        )
+
+        self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+            {"publish_translations": "on"},
+        )
+        self.fr_blog_post.refresh_from_db()
+        self.assertTrue(self.fr_blog_post.view_restrictions.exists())
+        self.assertTrue(
+            self.fr_blog_post.view_restrictions.first().pk, view_restriction.pk
+        )


### PR DESCRIPTION
This PR fixes #317

it synchronizes the source page `PageViewRestriction` with the translated pages on translation creation and sync.

Scenarios covered:

Source | Translation | Action
-------|-------------|-----------
Has privacy settings | Doesn't have privacy settings | Translated page privacy settings get created
Has changes to the privacy settings | Has privacy settings | Translated page privacy settings get updated
Has privacy settings removed | Has privacy settings | Translated page privacy settings removed
Has privacy settings removed | Doesn't have privacy settings | Noop

Note: if the source page privacy settings change, the translated page(s) privacy settings will only get updated after "sync translations"