### PR TITLE
Fix default REST_FRAMEWORK permission classes could break api views (#499)

### DIFF
--- a/wagtail_localize/test/settings.py
+++ b/wagtail_localize/test/settings.py
@@ -179,3 +179,12 @@ WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
 
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+
+# wagtail localize should not use DEFAULT_PERMISSION_CLASSES
+# see: https://github.com/wagtail/wagtail-localize/issues/499
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
+    ],
+}

--- a/wagtail_localize/test/settings.py
+++ b/wagtail_localize/test/settings.py
@@ -183,8 +183,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # wagtail localize should not use DEFAULT_PERMISSION_CLASSES
 # see: https://github.com/wagtail/wagtail-localize/issues/499
-REST_FRAMEWORK = {
-    "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
-    ],
-}
+# REST_FRAMEWORK = {
+    # "DEFAULT_PERMISSION_CLASSES": [
+        # "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
+    # ],
+# }

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
@@ -2225,6 +2225,13 @@ class TestEditOverrideAPIView(EditTranslationTestData, APITestCase):
         )
 
         self.assertEqual(response.status_code, 403)
+
+    def test_update_override_with_default_permissions_classes(self):
+        with override_settings(REST_FRAMEWORK={'DEFAULT_PERMISSION_CLASSES': ["rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"]}):
+            from wagtail_localize.views.edit_translation import edit_override
+            from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
+            print(edit_override.view_class.permission_classes)
+            assert edit_override.view_class.permission_classes == [DjangoModelPermissionsOrAnonReadOnly]
 
 
 class TestDownloadPOFileView(EditTranslationTestData, TestCase):

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -1043,7 +1043,7 @@ def edit_string_translation(request, translation_id, string_segment_id):
 
 
 @api_view(["PUT", "DELETE"])
-@permission_classes([IsAuthenticated])
+# @permission_classes([IsAuthenticated])
 def edit_override(request, translation_id, overridable_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)
     overridable_segment = get_object_or_404(

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -19,7 +19,8 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from modelcluster.fields import ParentalKey
 from rest_framework import serializers, status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from wagtail.admin import messages
 from wagtail.admin.edit_handlers import (
@@ -984,6 +985,7 @@ def restart_translation(request, translation, instance):
 
 
 @api_view(["PUT", "DELETE"])
+@permission_classes([IsAuthenticated])
 def edit_string_translation(request, translation_id, string_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)
     string_segment = get_object_or_404(StringSegment, id=string_segment_id)
@@ -1041,6 +1043,7 @@ def edit_string_translation(request, translation_id, string_segment_id):
 
 
 @api_view(["PUT", "DELETE"])
+@permission_classes([IsAuthenticated])
 def edit_override(request, translation_id, overridable_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)
     overridable_segment = get_object_or_404(


### PR DESCRIPTION
Fixes #499

Unfortunately, it seems there is no easy way to test this. DRF `api_views` decorator apply default permission classes early, and `settings_override` has no effect. I have added `REST_FRAMEWORK` settings that are known to break `wagtail_localize` in test app settings.