### PR TITLE
Support Deepl free api

### DIFF
--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -44,7 +44,7 @@ class DeepLTranslator(BaseMachineTranslator):
         )
 
         if response.status_code != HTTPStatus.OK:
-            raise ApiEndpointError(response.code, response.reason, response.text)
+            raise ApiEndpointError(response.status_code, response.reason, response.text)
 
         return {
             string: StringValue(translation["text"])

--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -1,13 +1,13 @@
-import requests
-
 from http import HTTPStatus
+
+import requests
 
 from wagtail_localize.strings import StringValue
 
 from .base import BaseMachineTranslator
 
-class ApiEndpointError(Exception):
 
+class ApiEndpointError(Exception):
     def __init__(self, code, reason, message="Unspecified Deepl API error ocurred"):
         self.code = code
         self.reason = reason
@@ -27,7 +27,9 @@ class DeepLTranslator(BaseMachineTranslator):
     display_name = "DeepL"
 
     def translate(self, source_locale, target_locale, strings):
-        api_endpoint = self.options.get("API_ENDPOINT", "https://api.deepl.com/v2/translate")
+        api_endpoint = self.options.get(
+            "API_ENDPOINT", "https://api.deepl.com/v2/translate"
+        )
         response = requests.post(
             api_endpoint,
             {

--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -27,9 +27,7 @@ class DeepLTranslator(BaseMachineTranslator):
     display_name = "DeepL"
 
     def translate(self, source_locale, target_locale, strings):
-        api_endpoint = "https://api.deepl.com/v2/translate"
-        if "API_ENDPOINT" in self.options:
-            api_endpoint = self.options["API_ENDPOINT"]
+        api_endpoint = self.options.get("API_ENDPOINT", "https://api.deepl.com/v2/translate")
         response = requests.post(
             api_endpoint,
             {

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -3212,6 +3212,37 @@ class TestMachineTranslateView(EditTranslationTestData, TestCase):
 
         assert_permission_denied(self, response)
 
+    @override_settings(
+        WAGTAILLOCALIZE_MACHINE_TRANSLATOR={
+            "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
+            "OPTIONS": {
+                "AUTH_KEY": "00000000-aaaa-bbbb-1111-cccccccccccc:fx",
+                "API_ENDPOINT": "https://api-free.deepl.com/v2/translate",
+            },
+        }
+    )
+    def test_deepl_machine_translate_page(self):
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:machine_translate", args=[self.page_translation.id]
+            ),
+            {
+                "next": reverse("wagtailadmin_pages:edit", args=[self.fr_page.id]),
+            },
+        )
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_pages:edit", args=[self.fr_page.id])
+        )
+
+        # Check error message
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(messages[0].level_tag, "error")
+        self.assertEqual(
+            messages[0].message,
+            "Translation failed: 403: [Forbidden] .\n\n\n\n\n",
+        )
+
 
 class TestEditAlias(WagtailTestUtils, TestCase):
     """


### PR DESCRIPTION
Essentially it enables the Deepl API to be changed since they have two different (free and pro).
Also some improvements were made on error handling:

![image](https://user-images.githubusercontent.com/2648461/149854024-016dff93-c227-41b6-9956-7692089c3316.png)

There's a new option to define the Deepl API endpoint:

```
WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
    "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
    "OPTIONS": {
        "AUTH_KEY": os.environ.get('DEEPL_API_KEY', None),
        "API_ENDPOINT": os.environ.get('DEEPL_API_ENDPOINT', None),
    },
}
```