### PR TITLE
Stop translations from being automatically published when source is in draft state

### DIFF
--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -579,6 +579,30 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             translated_page.view_restrictions.first().pk, view_restriction.pk
         )
 
+    def test_post_submit_page_translation_from_draft_source_still_draft(self):
+        custom_page = make_test_page(
+            self.en_homepage,
+            cls=TestWithTranslationModeDisabledPage,
+            title="Translation draft state test",
+            slug="translation-draft-state-test",
+            live=False,
+        )
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:submit_page_translation",
+                args=[custom_page.id],
+            ),
+            {"locales": [self.fr_locale.id]},
+        )
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+        )
+
+        translation = Translation.objects.get()
+        translated_page = translation.get_target_instance()
+        self.assertFalse(translated_page.live)
+
 
 @override_settings(
     LANGUAGES=[

--- a/wagtail_localize/views/submit_translations.py
+++ b/wagtail_localize/views/submit_translations.py
@@ -135,8 +135,11 @@ class TranslationCreator:
 
             self.mappings[source].append(translation)
 
+            # Determine whether or not to publish the translation.
+            publish = getattr(instance, "live", True)
+
             try:
-                translation.save_target(user=self.user)
+                translation.save_target(user=self.user, publish=publish)
             except ValidationError:
                 pass
 


### PR DESCRIPTION
Stop translations from being automatically published when source is in draft state

The `publish` parameter of `Translation.save_target()` defaults to True.

When `save_target()` is called by `TranslationCreator.create_translations()`, translations were saved in a live state even if a source page was in draft (live is False).

`create_translations()` now uses a page's `live` attribute to determine whether a translation of that page should be published when calling `save_target()`.

If for some reason that value can not be determined, a value of True is applied to preserve existing behaviour.

Fixes #553