### PR TITLE
Fix `edit_string_translation` and `edit_override` views when DRF is configured with explicit permission/authentication classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=flat)](https://github.com/pre-commit/pre-commit)
 
-Wagtail Localize is a translation plugin for the [Wagtail CMS](https://wagtail.io). It allows pages or snippets to be translated within Wagtail's admin interface. It also provides integrations with external translations services such as [Pontoon](https://pontoon.mozilla.org/) or [DeepL](https://www.deepl.com/), and importing/exporting translations with PO files.
+Wagtail Localize is a translation plugin for the [Wagtail CMS](https://wagtail.org). It allows pages or snippets to be translated within Wagtail's admin interface. It also provides integrations with external translations services such as [Pontoon](https://pontoon.mozilla.org/) or [DeepL](https://www.deepl.com/), and importing/exporting translations with PO files.
 
 [Documentation](https://www.wagtail-localize.org)
 [Changelog](https://github.com/wagtail/wagtail-localize/blob/main/CHANGELOG.md)
@@ -20,7 +20,7 @@ Wagtail Localize requires the following:
 
 - Python (3.7, 3.8, 3.9)
 - Django (2.2, 3.0, 3.1, 3.2)
-- Wagtail (2.11, 2.12, 2.13, 2.14, 2.15) with [internationalisation enabled](https://docs.wagtail.io/en/stable/advanced_topics/i18n.html#configuration)
+- Wagtail (2.11, 2.12, 2.13, 2.14, 2.15) with [internationalisation enabled](https://docs.wagtail.org/en/stable/advanced_topics/i18n.html#configuration)
 
 ## Installation
 
@@ -91,7 +91,7 @@ To run the test app interactively, use `tox -e interactive`, visit `http://127.0
 
 ## Support
 
-For support, please use [GitHub Discussions](https://github.com/wagtail/wagtail-localize/discussions) or ask a question on the `#multi-language` channel on [Wagtail's Slack instance](https://wagtail.io/slack/).
+For support, please use [GitHub Discussions](https://github.com/wagtail/wagtail-localize/discussions) or ask a question on the `#multi-language` channel on [Wagtail's Slack instance](`https://wagtail.org/slack/`).
 
 ## Thanks
 

--- a/docs/how-to/installation.md
+++ b/docs/how-to/installation.md
@@ -1,6 +1,6 @@
 # Installation guide
 
-Before you start, follow Wagtail's [configuration guide](https://docs.wagtail.io/en/stable/advanced_topics/i18n.html#configuration)
+Before you start, follow Wagtail's [configuration guide](https://docs.wagtail.or/en/stable/advanced_topics/i18n.html#configuration)
 to enable internationalisation in Wagtail and Django.
 
 ## Install the Python package

--- a/docs/tutorial/4-templates.md
+++ b/docs/tutorial/4-templates.md
@@ -65,7 +65,7 @@ Let's add a simple language switcher. Add the following snippet of code into the
 ```
 <!-- prettier-ignore-end -->
 
-This example was taken from the Wagtail docs, have a look [there](https://docs.wagtail.io/en/stable/advanced_topics/i18n.html#basic-example) for a full explanation of this example.
+This example was taken from the Wagtail docs, have a look [there](https://docs.wagtail.org/en/stable/advanced_topics/i18n.html#basic-example) for a full explanation of this example.
 
 Here's how it should look, the link should take you to the French version, then back again:
 

--- a/wagtail_localize/test/settings.py
+++ b/wagtail_localize/test/settings.py
@@ -188,11 +188,3 @@ if WAGTAIL_VERSION >= (2, 15):
             "BACKEND": "wagtail.search.backends.database",
         }
     }
-
-# wagtail localize should not use DEFAULT_PERMISSION_CLASSES
-# see: https://github.com/wagtail/wagtail-localize/issues/499
-REST_FRAMEWORK = {
-    "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
-    ],
-}

--- a/wagtail_localize/test/settings.py
+++ b/wagtail_localize/test/settings.py
@@ -188,3 +188,11 @@ if WAGTAIL_VERSION >= (2, 15):
             "BACKEND": "wagtail.search.backends.database",
         }
     }
+
+# wagtail localize should not use DEFAULT_PERMISSION_CLASSES
+# see: https://github.com/wagtail/wagtail-localize/issues/499
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
+    ],
+}

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -16,6 +16,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
 from freezegun import freeze_time
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.permissions import (
     DjangoModelPermissionsOrAnonReadOnly,
     IsAuthenticated,
@@ -2111,6 +2112,23 @@ class TestEditStringTranslationAPIView(EditTranslationTestData, APITestCase):
             edit_string_translation.view_class.permission_classes, [IsAuthenticated]
         )
 
+    @override_settings(
+        REST_FRAMEWORK={
+            "DEFAULT_AUTHENTICATION_CLASSES": [
+                "rest_framework.authentication.TokenAuthentication"
+            ]
+        }
+    )
+    def test_update_override_with_drf_default_authentication_classes(self):
+        self.assertEqual(
+            api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+            [TokenAuthentication],
+        )
+        self.assertEqual(
+            edit_string_translation.view_class.authentication_classes,
+            [SessionAuthentication],
+        )
+
 
 @freeze_time("2020-08-21")
 class TestEditOverrideAPIView(EditTranslationTestData, APITestCase):
@@ -2264,6 +2282,22 @@ class TestEditOverrideAPIView(EditTranslationTestData, APITestCase):
             [DjangoModelPermissionsOrAnonReadOnly],
         )
         self.assertEqual(edit_override.view_class.permission_classes, [IsAuthenticated])
+
+    @override_settings(
+        REST_FRAMEWORK={
+            "DEFAULT_AUTHENTICATION_CLASSES": [
+                "rest_framework.authentication.TokenAuthentication"
+            ]
+        }
+    )
+    def test_update_override_with_drf_default_authentication_classes(self):
+        self.assertEqual(
+            api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+            [TokenAuthentication],
+        )
+        self.assertEqual(
+            edit_override.view_class.authentication_classes, [SessionAuthentication]
+        )
 
 
 class TestDownloadPOFileView(EditTranslationTestData, TestCase):

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -11,11 +11,16 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
 from freezegun import freeze_time
+from rest_framework.permissions import (
+    DjangoModelPermissionsOrAnonReadOnly,
+    IsAuthenticated,
+)
+from rest_framework.settings import api_settings
 from rest_framework.test import APITestCase
 from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.core.blocks import StreamValue
@@ -42,6 +47,10 @@ from wagtail_localize.test.models import (
     TestHomePage,
     TestPage,
     TestSnippet,
+)
+from wagtail_localize.views.edit_translation import (
+    edit_override,
+    edit_string_translation,
 )
 from wagtail_localize.wagtail_hooks import SNIPPET_RESTART_TRANSLATION_ENABLED
 
@@ -2086,6 +2095,22 @@ class TestEditStringTranslationAPIView(EditTranslationTestData, APITestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    @override_settings(
+        REST_FRAMEWORK={
+            "DEFAULT_PERMISSION_CLASSES": [
+                "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
+            ]
+        }
+    )
+    def test_edit_translation_with_drf_default_permissions_classes(self):
+        self.assertEqual(
+            api_settings.DEFAULT_PERMISSION_CLASSES,
+            [DjangoModelPermissionsOrAnonReadOnly],
+        )
+        self.assertEqual(
+            edit_string_translation.view_class.permission_classes, [IsAuthenticated]
+        )
+
 
 @freeze_time("2020-08-21")
 class TestEditOverrideAPIView(EditTranslationTestData, APITestCase):
@@ -2225,6 +2250,20 @@ class TestEditOverrideAPIView(EditTranslationTestData, APITestCase):
         )
 
         self.assertEqual(response.status_code, 403)
+
+    @override_settings(
+        REST_FRAMEWORK={
+            "DEFAULT_PERMISSION_CLASSES": [
+                "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
+            ]
+        }
+    )
+    def test_update_override_with_drf_default_permissions_classes(self):
+        self.assertEqual(
+            api_settings.DEFAULT_PERMISSION_CLASSES,
+            [DjangoModelPermissionsOrAnonReadOnly],
+        )
+        self.assertEqual(edit_override.view_class.permission_classes, [IsAuthenticated])
 
 
 class TestDownloadPOFileView(EditTranslationTestData, TestCase):

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -727,7 +727,7 @@ class TestGetEditTranslationView(EditTranslationTestData, TestCase):
             {
                 "id": str(url_block_id),
                 "type": "test_urlblock",
-                "value": "https://wagtail.io/",
+                "value": "https://wagtail.org/",
             },
             {
                 "id": str(page_block_id),
@@ -785,7 +785,7 @@ class TestGetEditTranslationView(EditTranslationTestData, TestCase):
                 (
                     f"test_streamfield.{url_block_id}",
                     {"type": "text"},
-                    "https://wagtail.io/",
+                    "https://wagtail.org/",
                 ),
                 (
                     f"test_streamfield.{page_block_id}",

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -19,7 +19,12 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from modelcluster.fields import ParentalKey
 from rest_framework import serializers, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from wagtail.admin import messages
@@ -986,6 +991,7 @@ def restart_translation(request, translation, instance):
 
 @api_view(["PUT", "DELETE"])
 @permission_classes([IsAuthenticated])
+@authentication_classes([SessionAuthentication])
 def edit_string_translation(request, translation_id, string_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)
     string_segment = get_object_or_404(StringSegment, id=string_segment_id)
@@ -1044,6 +1050,7 @@ def edit_string_translation(request, translation_id, string_segment_id):
 
 @api_view(["PUT", "DELETE"])
 @permission_classes([IsAuthenticated])
+@authentication_classes([SessionAuthentication])
 def edit_override(request, translation_id, overridable_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)
     overridable_segment = get_object_or_404(

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -19,7 +19,8 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from modelcluster.fields import ParentalKey
 from rest_framework import serializers, status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from wagtail.admin import messages
 from wagtail.admin.edit_handlers import (
@@ -984,6 +985,7 @@ def restart_translation(request, translation, instance):
 
 
 @api_view(["PUT", "DELETE"])
+@permission_classes([IsAuthenticated])
 def edit_string_translation(request, translation_id, string_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)
     string_segment = get_object_or_404(StringSegment, id=string_segment_id)
@@ -1041,6 +1043,7 @@ def edit_string_translation(request, translation_id, string_segment_id):
 
 
 @api_view(["PUT", "DELETE"])
+@permission_classes([IsAuthenticated])
 def edit_override(request, translation_id, overridable_segment_id):
     translation = get_object_or_404(Translation, id=translation_id)
     overridable_segment = get_object_or_404(


### PR DESCRIPTION
Continuation of #500 with test fixes.
Fixes #499, fixes #497
