### PR TITLE
Redirect to newly translate page's edit view when submitting a translation for a single locale

### DIFF
--- a/wagtail_localize/components.py
+++ b/wagtail_localize/components.py
@@ -153,8 +153,9 @@ class TranslationComponentManager(BaseComponentManager):
     """
     The translation component manager handles all registered components for translation.
 
-    Classes registered as translation components should implement a `get_or_create_from_source_and_translation_data`
-    method which takes `translation_source`, `translations` and kwargs as parameters.
+    Classes registered as translation components should implement a
+    `get_or_create_from_source_and_translation_data` method which takes
+    `translation_source`, `translations` and kwargs as parameters.
     """
 
     @classmethod

--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -78,7 +78,7 @@ class TestTranslatePageListingButton(TestCase, WagtailTestUtils):
         self.assertContains(
             response,
             (
-                f'<a href="/admin/localize/submit/page/{self.en_blog_index.id}/?next=%2Fadmin%2Fpages%2F{self.en_homepage.id}%2F" '
+                f'<a href="/admin/localize/submit/page/{self.en_blog_index.id}/" '
                 'aria-label="" class="u-link is-live ">'
                 "\n                    Translate this page\n                </a>"
             ),
@@ -624,7 +624,7 @@ class TestTranslateSnippetListingButton(TestCase, WagtailTestUtils):
         self.assertContains(
             response,
             (
-                f'href="/admin/localize/submit/snippet/wagtail_localize_test/testsnippet/{self.en_snippet.id}/?next=%2Fadmin%2Fsnippets%2Fwagtail_localize_test%2Ftestsnippet%2F"{extra}>Translate</a>'
+                f'href="/admin/localize/submit/snippet/wagtail_localize_test/testsnippet/{self.en_snippet.id}/"{extra}>Translate</a>'
             ),
         )
 

--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -229,10 +229,6 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
-        )
-
         translation = Translation.objects.get()
         self.assertEqual(translation.source.locale, self.en_locale)
         self.assertEqual(translation.target_locale, self.fr_locale)
@@ -241,6 +237,10 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
         # The translated page should've been created and published
         translated_page = self.en_blog_index.get_translation(self.fr_locale)
         self.assertTrue(translated_page.live)
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
+        )
 
     def test_post_submit_page_translation_submits_linked_snippets(self):
         self.en_blog_index.test_snippet = TestSnippet.objects.create(
@@ -256,10 +256,6 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
-        )
-
         page_translation = Translation.objects.get(
             source__specific_content_type=ContentType.objects.get_for_model(TestPage)
         )
@@ -270,6 +266,10 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
         # The translated page should've been created and published
         translated_page = self.en_blog_index.get_translation(self.fr_locale)
         self.assertTrue(translated_page.live)
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
+        )
 
         snippet_translation = Translation.objects.get(
             source__specific_content_type=ContentType.objects.get_for_model(TestSnippet)
@@ -313,8 +313,10 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id], "include_subtree": "on"},
         )
 
+        translated_page = self.en_blog_index.get_translation(self.fr_locale)
+
         self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
         )
 
         # Check multiple translations were created
@@ -329,10 +331,6 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_blog_index.id])
-        )
-
         # One translation should be created
         fr_translation = Translation.objects.get()
         self.assertEqual(fr_translation.source.locale, self.en_locale)
@@ -342,6 +340,10 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
         # The translated page should've been created and published
         translated_page = self.en_blog_post.get_translation(self.fr_locale)
         self.assertTrue(translated_page.live)
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
+        )
 
         # The parent should've been created as an alias page
         translated_parent_page = self.en_blog_index.get_translation(self.fr_locale)
@@ -364,10 +366,6 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [es_locale.id]},
         )
 
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_blog_index.id])
-        )
-
         # One translation should be created
         fr_translation = Translation.objects.get()
         self.assertEqual(fr_translation.source.locale, self.en_locale)
@@ -377,6 +375,10 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
         # The translated page should've been created and published
         translated_page = self.en_blog_post.get_translation(es_locale)
         self.assertTrue(translated_page.live)
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
+        )
 
         # The parent should've been created as an alias page
         translated_parent_page = self.en_blog_index.get_translation(es_locale)
@@ -443,10 +445,6 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
-        )
-
         # Check that the translation was reactivated
         # Note, .get() here tests that another translation record wasn't created
         translation = Translation.objects.get()
@@ -457,6 +455,10 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
         # The translated page should've been created and published
         translated_page = self.en_blog_index.get_translation(self.fr_locale)
         self.assertTrue(translated_page.live)
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
+        )
 
     def test_post_submit_page_translation_doesnt_reactivate_deactivated_translation(
         self,
@@ -504,8 +506,9 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
+        translated_page = self.en_blog_index.get_translation(self.fr_locale)
         self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
         )
 
         translation = Translation.objects.get()
@@ -526,8 +529,9 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
+        translated_page = custom_page.get_translation(self.fr_locale)
         self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
         )
 
         translation = Translation.objects.get()
@@ -551,8 +555,9 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
+        translated_page = custom_page.get_translation(self.fr_locale)
         self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
         )
 
         translation = Translation.objects.get()
@@ -790,14 +795,6 @@ class TestSubmitSnippetTranslation(TestCase, WagtailTestUtils):
             {"locales": [self.fr_locale.id]},
         )
 
-        self.assertRedirects(
-            response,
-            reverse(
-                "wagtailsnippets:edit",
-                args=["wagtail_localize_test", "testsnippet", self.en_snippet.id],
-            ),
-        )
-
         translation = Translation.objects.get()
         self.assertEqual(translation.source.locale, self.en_locale)
         self.assertEqual(translation.target_locale, self.fr_locale)
@@ -806,6 +803,14 @@ class TestSubmitSnippetTranslation(TestCase, WagtailTestUtils):
         # The translated snippet should've been created
         translated_snippet = self.en_snippet.get_translation(self.fr_locale)
         self.assertEqual(translated_snippet.field, "Test snippet")
+
+        self.assertRedirects(
+            response,
+            reverse(
+                "wagtailsnippets:edit",
+                args=["wagtail_localize_test", "testsnippet", translated_snippet.id],
+            ),
+        )
 
     def test_post_submit_snippet_translation_into_multiple_locales(self):
         response = self.client.post(

--- a/wagtail_localize/tests/test_translation_components.py
+++ b/wagtail_localize/tests/test_translation_components.py
@@ -93,8 +93,9 @@ class TestSubmitPageTranslationWithComponents(TestCase, WagtailTestUtils):
             },
         )
 
+        translated_page = self.en_blog_index.get_translation(self.fr_locale)
         self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=[self.en_homepage.id])
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
         )
 
         self.assertEqual(CustomTranslationData.objects.count(), 1)

--- a/wagtail_localize/views/submit_translations.py
+++ b/wagtail_localize/views/submit_translations.py
@@ -251,6 +251,12 @@ class SubmitPageTranslationView(SubmitTranslationView):
         return page
 
     def get_default_success_url(self):
+        translations = self.object.get_translations()
+        if len(translations) == 1:
+            # If the editor chose a single locale to translate to, redirect to
+            # the newly translated page's edit view.
+            return reverse("wagtailadmin_pages:edit", args=[translations[0].id])
+
         return reverse("wagtailadmin_explore", args=[self.get_object().get_parent().id])
 
     def get_success_message(self, locales):
@@ -276,6 +282,19 @@ class SubmitSnippetTranslationView(SubmitTranslationView):
         return get_object_or_404(model, pk=unquote(self.kwargs["pk"]))
 
     def get_default_success_url(self):
+        translations = self.object.get_translations()
+        if len(translations) == 1:
+            # If the editor chose a single locale to translate to, redirect to
+            # the newly translated snippet's edit view.
+            return reverse(
+                "wagtailsnippets:edit",
+                args=[
+                    self.kwargs["app_label"],
+                    self.kwargs["model_name"],
+                    translations[0].pk,
+                ],
+            )
+
         return reverse(
             "wagtailsnippets:edit",
             args=[

--- a/wagtail_localize/views/submit_translations.py
+++ b/wagtail_localize/views/submit_translations.py
@@ -210,8 +210,12 @@ class SubmitTranslationView(SingleObjectMixin, TemplateView):
 
                 _walk(self.object)
 
+        single_translated_object = None
         if len(form.cleaned_data["locales"]) == 1:
             locales = form.cleaned_data["locales"][0].get_display_name()
+            single_translated_object = self.object.get_translation(
+                form.cleaned_data["locales"][0]
+            )
 
         else:
             # Note: always plural
@@ -221,12 +225,6 @@ class SubmitTranslationView(SingleObjectMixin, TemplateView):
 
         # TODO: Button that links to page in translations report when we have it
         messages.success(self.request, self.get_success_message(locales))
-
-        single_translated_object = None
-        if len(form.cleaned_data["locales"]) == 1:
-            single_translated_object = self.object.get_translation(
-                form.cleaned_data["locales"][0]
-            )
 
         return redirect(
             self.get_success_url()

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -150,8 +150,6 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
 
         if has_locale_to_translate_to:
             url = reverse("wagtail_localize:submit_page_translation", args=[page.id])
-            if next_url is not None:
-                url += "?" + urlencode({"next": next_url})
 
             yield wagtailadmin_widgets.Button(
                 _("Translate this page"), url, priority=60
@@ -188,8 +186,6 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
                 "wagtail_localize:submit_snippet_translation",
                 args=[model._meta.app_label, model._meta.model_name, quote(snippet.pk)],
             )
-            if next_url is not None:
-                url += "?" + urlencode({"next": next_url})
 
             yield SnippetListingButton(
                 _("Translate"),


### PR DESCRIPTION
When an editor decides to submit a page for translation and only chooses one locale, they are redirected to the new translated page's edit view.