### PR TITLE
Delete the related Translation object when converting a page back to alias

### DIFF
--- a/wagtail_localize/tests/test_convert_to_alias.py
+++ b/wagtail_localize/tests/test_convert_to_alias.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from wagtail.core.models import Locale, Page, PageLogEntry
 from wagtail.tests.utils import WagtailTestUtils
 
-from wagtail_localize.models import LocaleSynchronization
+from wagtail_localize.models import LocaleSynchronization, Translation
 from wagtail_localize.test.models import TestPage
 from wagtail_localize.wagtail_hooks import ConvertToAliasPageActionMenuItem
 
@@ -194,4 +194,23 @@ class ConvertToAliasViewTest(ConvertToAliasTestData, TestCase):
         response = self.client.post(self.convert_url + "?next=https://example.com")
         self.assertRedirects(
             response, reverse("wagtailadmin_pages:edit", args=[self.fr_page.id])
+        )
+
+    def test_convert_removes_translation_objects(self):
+        self.assertTrue(
+            Translation.objects.filter(
+                source__object_id=self.fr_page.translation_key,
+                source__specific_content_type=self.fr_page.content_type_id,
+                target_locale=self.fr_page.locale_id,
+            ).exists()
+        )
+
+        self.client.post(self.convert_url)
+
+        self.assertFalse(
+            Translation.objects.filter(
+                source__object_id=self.fr_page.translation_key,
+                source__specific_content_type=self.fr_page.content_type_id,
+                target_locale=self.fr_page.locale_id,
+            ).exists()
         )

--- a/wagtail_localize/views/convert.py
+++ b/wagtail_localize/views/convert.py
@@ -70,7 +70,9 @@ def convert_to_alias(request, page_id):
                 },
             )
 
-            # Now clean up the old translation
+            # Now clean up the old translation.
+            # We are deleting rather than disabling old translations as we've just gone
+            # back to an alias page, which by definition doesn't hold its own content
             try:
                 translation = Translation.objects.get(
                     source=translation_source, target_locale=page_to_alias.locale_id

--- a/wagtail_localize/views/convert.py
+++ b/wagtail_localize/views/convert.py
@@ -14,7 +14,7 @@ from wagtail.core.models import (
 )
 from wagtail.core.signals import page_published
 
-from wagtail_localize.models import TranslationSource
+from wagtail_localize.models import Translation, TranslationSource
 
 
 def convert_to_alias(request, page_id):
@@ -69,6 +69,15 @@ def convert_to_alias(request, page_id):
                     },
                 },
             )
+
+            # Now clean up the old translation
+            try:
+                translation = Translation.objects.get(
+                    source=translation_source, target_locale=page_to_alias.locale_id
+                )
+                translation.delete()
+            except Translation.DoesNotExist:
+                pass
 
             messages.success(
                 request,


### PR DESCRIPTION
Follow up to #515

Doing a bit of tidy up and is in line with #402 (although this does not fix that particular issue)