### PR TITLE
CI and package cleanups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,16 +79,6 @@ jobs:
             wagtail: '2.16'
             postgres: '10.8'
             experimental: false
-          - python: '3.9'
-            django: '3.2'
-            wagtail: 'main'
-            postgres: '10.8'
-            experimental: true
-          - python: '3.10'
-            django: '4.0'
-            wagtail: 'main'
-            postgres: '10.8'
-            experimental: true
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
 include LICENSE *.rst *.txt *.md
 graft wagtail_localize
-global-exclude __pycache__
+prune **/__pycache__
+prune **/static_src
+prune **/test
+prune **/tests
 global-exclude *.py[co]
+global-exclude .gitignore


### PR DESCRIPTION
- drops main testing in regular CI (leaving it on the nightly tests)
- tidies up MANIFEST.in for lighter sdist