### PR TITLE
ParentalManyToManyField pointing to model with UUID primary key: Object of type UUID is not JSON serializable

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -1979,7 +1979,7 @@ class StringSegment(BaseSegment):
             context=context,
             order=value.order,
             string=string,
-            attrs=json.dumps(value.attrs),
+            attrs=json.dumps(value.attrs, cls=DjangoJSONEncoder),
         )
 
         return segment
@@ -2135,7 +2135,7 @@ class OverridableSegment(BaseSegment):
             source=source,
             context=context,
             order=value.order,
-            data_json=json.dumps(value.data),
+            data_json=json.dumps(value.data, cls=DjangoJSONEncoder),
         )
 
         return segment


### PR DESCRIPTION
Hello,
after adding a `ParentalManyToManyField` to my snippet which points to a model with a UUID primary key I got the following error message:

```
Traceback (most recent call last):
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail/admin/urls/__init__.py", line 125, in wrapper
    return view_func(request, *args, **kwargs)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail/admin/auth.py", line 174, in decorated_view
    response = view_func(request, *args, **kwargs)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail_localize/views/submit_translations.py", line 242, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail_localize/views/submit_translations.py", line 190, in post
    return self.form_valid(form)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail_localize/views/submit_translations.py", line 198, in form_valid
    translator.create_translations(self.object)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail_localize/views/submit_translations.py", line 99, in create_translations
    source, created = TranslationSource.get_or_create_from_instance(instance)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail_localize/models.py", line 378, in get_or_create_from_instance
    source.refresh_segments()
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail_localize/models.py", line 558, in refresh_segments
    segment_obj = OverridableSegment.from_value(self, segment)
  File "/Users/herbert/.local/share/virtualenvs/hbh_backend-bNZ8nmEp/lib/python3.9/site-packages/wagtail_localize/models.py", line 2138, in from_value
    data_json=json.dumps(value.data),
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type UUID is not JSON serializable
```

I think it makes sense to use `DjangoJSONEncoder` for all json.dumps - it fixed the error I was seeing. Any thoughts if this is a viable solution?