### PR TITLE
extract.py: fix list block for empty lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /node_modules
 /test-static
 /test-media
+.idea

--- a/wagtail_localize/segments/extract.py
+++ b/wagtail_localize/segments/extract.py
@@ -149,7 +149,11 @@ class StreamFieldSegmentExtractor:
             # stored value is the new format before extracting segments, otherwise the block ids will continue
             # to change.
             has_block_format = False
-            if isinstance(raw_value, dict) and "value" in raw_value and len(raw_value["value"]) > 0:
+            if (
+                isinstance(raw_value, dict)
+                and "value" in raw_value
+                and len(raw_value["value"]) > 0
+            ):
                 has_block_format = list_block.list_block._item_is_in_block_format(
                     raw_value["value"][0]
                 )

--- a/wagtail_localize/segments/extract.py
+++ b/wagtail_localize/segments/extract.py
@@ -149,11 +149,11 @@ class StreamFieldSegmentExtractor:
             # stored value is the new format before extracting segments, otherwise the block ids will continue
             # to change.
             has_block_format = False
-            if isinstance(raw_value, dict) and "value" in raw_value:
+            if isinstance(raw_value, dict) and "value" in raw_value and len(raw_value["value"]) > 0:
                 has_block_format = list_block.list_block._item_is_in_block_format(
                     raw_value["value"][0]
                 )
-            elif isinstance(raw_value, list):
+            elif isinstance(raw_value, list) and len(raw_value) > 0:
                 has_block_format = list_block.list_block._item_is_in_block_format(
                     raw_value[0]
                 )

--- a/wagtail_localize/segments/tests/test_segment_extraction.py
+++ b/wagtail_localize/segments/tests/test_segment_extraction.py
@@ -462,6 +462,17 @@ class TestSegmentExtractionWithStreamField(TestCase):
             ],
         )
 
+    @unittest.skipUnless(
+        WAGTAIL_VERSION >= (2, 16),
+        "ListBlocks are supported starting with Wagtail 2.16",
+    )
+    def test_list_block_empty_should_not_raise_error(self):
+        page = make_test_page_with_streamfield_block(uuid.uuid4(), "test_listblock", [])
+        segments = StreamFieldSegmentExtractor(
+            page.test_streamfield
+        ).handle_stream_block(page.test_streamfield)
+        self.assertEqual(segments, [])
+
     def test_nestedstreamblock(self):
         block_id = uuid.uuid4()
         nested_block_id = uuid.uuid4()


### PR DESCRIPTION
In case there is a listblock with no elements, by accident or design, the current code would raise an error.
This fix solves the case of empty list.