### PR TITLE
Fix edit handler logic with latest Wagtail 3.x

### DIFF
--- a/docs/tutorial/3-content.md
+++ b/docs/tutorial/3-content.md
@@ -34,7 +34,7 @@ Now, open `blog/models.py` and copy and paste the following code into it:
 
 ```python
 from django.db import models
-from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
 from wagtail.core.models import Page, TranslatableMixin
@@ -42,6 +42,11 @@ from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import register_snippet
+
+if WAGTAIL_VERSION >= (3, 0):
+    from wagtail.admin.panels import FieldPanel
+else:
+    from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
 
 
 class ImageBlock(blocks.StructBlock):
@@ -79,7 +84,7 @@ class BlogPostPage(Page):
     content_panels = Page.content_panels + [
         FieldPanel("publication_date"),
         ImageChooserPanel("image"),
-        StreamFieldPanel("body"),
+        FieldPanel("body") if WAGTAIL_VERSION >= (3, 0) else StreamFieldPanel("body"),
         SnippetChooserPanel("category"),
     ]
 

--- a/wagtail_localize/components.py
+++ b/wagtail_localize/components.py
@@ -3,12 +3,20 @@ import inspect
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
-from wagtail.admin.edit_handlers import (
-    ObjectList,
-    extract_panel_definitions_from_model_class,
-)
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.forms import WagtailAdminModelForm
 
+
+try:
+    from wagtail.admin.panels import (
+        ObjectList,
+        extract_panel_definitions_from_model_class,
+    )
+except ImportError:
+    from wagtail.admin.edit_handlers import (
+        ObjectList,
+        extract_panel_definitions_from_model_class,
+    )
 
 TRANSLATION_COMPONENTS = []
 
@@ -74,9 +82,14 @@ class BaseComponentManager:
             component_instance = cls.get_component_instance(
                 component_model, source_object_instance=source_object_instance
             )
-            edit_handler = cls.get_component_edit_handler(component_model).bind_to(
-                model=component_model, instance=component_instance, request=request
-            )
+            edit_handler = cls.get_component_edit_handler(component_model)
+
+            if WAGTAIL_VERSION >= (3, 0):
+                edit_handler = edit_handler.bind_to_model(component_model)
+            else:
+                edit_handler = edit_handler.bind_to(
+                    model=component_model, instance=component_instance, request=request
+                )
             form_class = edit_handler.get_form_class()
 
             # Add an 'enabled' field to the form if it isn't required


### PR DESCRIPTION
[Upgrade consideration notes](https://docs.wagtail.org/en/latest/releases/3.0.html#api-changes-to-panels-edithandlers)

To test locally, I edited `setup.py`:

```diff
    install_requires=["Django>=2.2,<4.1", "Wagtail>=2.11,<2.17", "polib>=1.1,<2.0"],
    install_requires=["Django>=2.2,<4.1", "Wagtail>=2.11,<3.1", "polib>=1.1,<2.0"],
```

then `tox -e python3.9-django4.0-wagtailmain-sqlite`