### PR TITLE
[Wagtail mainline] keep up with mainline

### DIFF
--- a/wagtail_localize/test/models.py
+++ b/wagtail_localize/test/models.py
@@ -3,6 +3,7 @@ import uuid
 from django.db import models
 from django.utils.translation import gettext_lazy
 from modelcluster.fields import ParentalKey
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.edit_handlers import (
     FieldPanel,
     InlinePanel,
@@ -178,6 +179,9 @@ class TestCustomField(models.TextField):
         return [StringSegmentValue("foo", "{} and some extra".format(value))]
 
 
+SF_KWARGS = {"use_json_field": True} if WAGTAIL_VERSION >= (4, 0) else {}
+
+
 class TestPage(Page):
     test_charfield = models.CharField(
         gettext_lazy("char field"), max_length=255, blank=True, null=True, default=""
@@ -188,7 +192,7 @@ class TestPage(Page):
     test_urlfield = models.URLField(blank=True)
 
     test_richtextfield = RichTextField(blank=True)
-    test_streamfield = StreamField(TestStreamBlock, blank=True)
+    test_streamfield = StreamField(TestStreamBlock, blank=True, **SF_KWARGS)
 
     test_snippet = models.ForeignKey(
         TestSnippet, null=True, blank=True, on_delete=models.SET_NULL
@@ -204,7 +208,9 @@ class TestPage(Page):
     test_synchronized_urlfield = models.URLField(blank=True)
 
     test_synchronized_richtextfield = RichTextField(blank=True)
-    test_synchronized_streamfield = StreamField(TestStreamBlock, blank=True)
+    test_synchronized_streamfield = StreamField(
+        TestStreamBlock, blank=True, **SF_KWARGS
+    )
 
     test_synchronized_image = models.ForeignKey(
         "wagtailimages.Image",
@@ -280,7 +286,9 @@ class TestPage(Page):
         FieldPanel("test_slugfield"),
         FieldPanel("test_urlfield"),
         FieldPanel("test_richtextfield"),
-        StreamFieldPanel("test_streamfield"),
+        FieldPanel("test_streamfield")
+        if WAGTAIL_VERSION >= (3, 0)
+        else StreamFieldPanel("test_streamfield"),
         FieldPanel("test_snippet"),
         InlinePanel("test_childobjects"),
         FieldPanel("test_customfield"),
@@ -290,7 +298,9 @@ class TestPage(Page):
         FieldPanel("test_synchronized_slugfield"),
         FieldPanel("test_synchronized_urlfield"),
         FieldPanel("test_synchronized_richtextfield"),
-        StreamFieldPanel("test_synchronized_streamfield"),
+        FieldPanel("test_synchronized_streamfield")
+        if WAGTAIL_VERSION >= (3, 0)
+        else StreamFieldPanel("test_synchronized_streamfield"),
         FieldPanel("test_synchronized_image"),
         FieldPanel("test_synchronized_document"),
         FieldPanel("test_synchronized_snippet"),
@@ -384,7 +394,7 @@ class TestGenerateTranslatableFieldsPage(Page):
     test_urlfield = models.URLField(blank=True)
 
     test_richtextfield = RichTextField(blank=True)
-    test_streamfield = StreamField(TestStreamBlock, blank=True)
+    test_streamfield = StreamField(TestStreamBlock, blank=True, **SF_KWARGS)
 
     test_snippet = models.ForeignKey(
         TestSnippet, null=True, blank=True, on_delete=models.SET_NULL

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -43,7 +43,6 @@ from wagtail.images.models import AbstractImage
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.models import get_snippet_models
 from wagtail.snippets.permissions import get_permission_name, user_can_edit_snippet_type
-from wagtail.snippets.views.snippets import get_snippet_edit_handler
 
 from wagtail_localize.compat import DATE_FORMAT
 from wagtail_localize.machine_translators import get_machine_translator
@@ -57,6 +56,13 @@ from wagtail_localize.models import (
 )
 from wagtail_localize.segments import StringSegmentValue
 
+
+if WAGTAIL_VERSION >= (4, 0):
+    from wagtail.snippets.views.snippets import (
+        get_snippet_panel as get_snippet_edit_handler,
+    )
+else:
+    from wagtail.snippets.views.snippets import get_snippet_edit_handler
 
 if WAGTAIL_VERSION >= (3, 0):
     # TODO: tidy this up once we drop support for Wagtail < 3.0


### PR DESCRIPTION
* `use_json_field` is required for StreamField definitions
* import `get_snippet_panel` instead of get_snippet_edit_handler -- the snippets test would fail on main without it
* ~add Wagtail 3.0 to test matrix~ will do in separate PR