### PR TITLE
Limit width of segments editor

### DIFF
--- a/wagtail_localize/static_src/editor/components/TranslationEditor/segments.tsx
+++ b/wagtail_localize/static_src/editor/components/TranslationEditor/segments.tsx
@@ -371,6 +371,7 @@ const SegmentList = styled.ul`
     list-style-type: none;
     padding-left: 50px;
     padding-right: 50px;
+    max-width: 1200px;
 `;
 
 interface EditorStringSegmentProps {


### PR DESCRIPTION
They can get rather wide on a large screen.

Before:
![image](https://user-images.githubusercontent.com/1093808/165983248-d2f6c080-511c-4915-9f5b-036fd0189ef9.png)


After:
![image](https://user-images.githubusercontent.com/1093808/165983155-762079b4-fe99-4bea-87f1-8c3e0d4e794d.png)
