### PR TITLE
Fix further Wagtail `main` failures and tidy up GH Action/Makefile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,20 @@ on:
 
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.8'
       - uses: pre-commit/action@v2.0.3
@@ -43,14 +48,20 @@ jobs:
             django: '3.2'
             wagtail: '3.0'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox
         run: |
           python -m pip install tox
+      - name: Cache tox environments
+        id: cache-tox
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ hashFiles('setup.py') }}-py${{ matrix.python }}-dj${{ matrix.django }}-w${{ matrix.wagtail }}-sqlite
       - name: Test
         run: |
           tox
@@ -108,14 +119,20 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox
         run: |
           python -m pip install tox
+      - name: Cache tox environments
+        id: cache-tox
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ hashFiles('setup.py') }}-py${{ matrix.python }}-dj${{ matrix.django }}-w${{ matrix.wagtail }}-postgres
       - name: Test
         run: |
           tox
@@ -131,9 +148,9 @@ jobs:
         python: ['3.8']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,47 @@
-npm_deps:
+# ----------------------------------------------------------------------------
+# Self-Documented Makefile
+# ref: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+# ----------------------------------------------------------------------------
+.PHONY: help
+.DEFAULT_GOAL := help
+
+help:											## ⁉️  - Display help comments for each make command
+	@grep -E '^[0-9a-zA-Z_-]+:.*? .*$$'  \
+		$(MAKEFILE_LIST)  \
+		| awk 'BEGIN { FS=":.*?## " }; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'  \
+		| sort
+
+npm_deps:  ## 🧰 - Install npm dependencies
 	npm install
 
-build: npm_deps
+build: npm_deps  ## 🧰 - Build front-end assets
 	npm run build
 
-dev: npm_deps
+dev: npm_deps ## 🧰 - Build front-end assets and watch for changes in development mode
 	npm run start
 
-messages:
+messages:  ## 🔨 - Make messages
 	node ./scripts/extract-translatable-strings.js
 	cd wagtail_localize && python ../testmanage.py makemessages --locale=en
 
-fetch-translations:
+fetch-translations:  ## 🔨 - Fetch new translations
 	./scripts/fetch-translations.sh
 
-compile-messages:
+compile-messages:  ## 🔨 - Compile messages
 	cd wagtail_localize && python ../testmanage.py compilemessages
+
+translations: build messages fetch-translations compile-messages  ## 🌍 - Prepare translations
+
+clean:	## 🗑️  - Remove __pycache__ and test artifacts
+	@echo "🗑️ - Removing __pycache__ and test artifacts"
+	find . -name ".tox" -prune -o -type d -name  "__pycache__" -exec rm -r {} +
+
+package-setup:
+	@echo "📦 - Packaging for PyPI"
+	python3 setup.py clean --all sdist bdist_wheel
+
+package: clean package-setup  ## 📦 - Package for PyPI
+
+test:  ## 🧪 - Run test suite
+	@echo "🧪 - Running test suite"
+	tox

--- a/wagtail_localize/compat.py
+++ b/wagtail_localize/compat.py
@@ -60,3 +60,9 @@ def get_snippet_delete_url(snippet):
         "wagtailsnippets:delete",
         args=[snippet._meta.app_label, snippet._meta.model_name, quote(snippet.pk)],
     )
+
+
+def get_revision_model():
+    if WAGTAIL_VERSION >= (4, 0):
+        return "wagtailcore.Revision"
+    return "wagtailcore.PageRevision"

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -49,7 +49,7 @@ from wagtail.core.models import (
 from wagtail.core.utils import find_available_slug
 from wagtail.snippets.models import get_snippet_models
 
-from .compat import DATE_FORMAT, get_snippet_edit_url
+from .compat import DATE_FORMAT, get_revision_model, get_snippet_edit_url
 from .fields import copy_synchronised_fields
 from .locales.components import LocaleComponentModelForm, register_locale_component
 from .segments import (
@@ -1362,7 +1362,7 @@ class TranslationLog(models.Model):
     )
     created_at = models.DateTimeField(auto_now_add=True)
     page_revision = models.ForeignKey(
-        "wagtailcore.PageRevision",
+        get_revision_model(),
         on_delete=models.SET_NULL,
         null=True,
         blank=True,


### PR DESCRIPTION
This PR:

* adds a callable for the page revision model (with Wagtail 4.0, that will be `wagtailcore.Revision` ref: https://github.com/wagtail/wagtail/pull/8441) -- should fix the nightly test failures
* updates the test GitHub Action to:
  * cancel previous in-progress jobs for the same branch/PR
  * cache tox
  * use newer action versions from GitHub
* adds a few more commands to the Makefile 