### PR TITLE
updates filter to get translation source

### DIFF
--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -253,6 +253,10 @@ class TestGetEditTranslationView(EditTranslationTestData, TestCase):
             props["links"]["deleteUrl"],
             reverse("wagtailadmin_pages:delete", args=[self.fr_page.id]),
         )
+        self.assertEqual(
+            props["links"]["convertToAliasUrl"],
+            reverse("wagtail_localize:convert_to_alias", args=[self.fr_page.id]),
+        )
 
         self.assertEqual(
             props["previewModes"],
@@ -1449,6 +1453,34 @@ class TestGetEditTranslationView(EditTranslationTestData, TestCase):
             reverse("wagtailadmin_pages:edit", args=[self.fr_page.id])
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_edit_page_translation_from_translated_page_show_convert_to_alias_button(
+        self,
+    ):
+        de_locale = Locale.objects.create(language_code="de")
+        self.client.post(
+            reverse(
+                "wagtail_localize:submit_page_translation",
+                args=[self.fr_page.id],
+            ),
+            {"locales": [de_locale.id]},
+        )
+        de_page = self.fr_page.get_translation(de_locale)
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[de_page.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "wagtail_localize/admin/edit_translation.html"
+        )
+
+        # Check props
+        props = json.loads(response.context["props"])
+
+        self.assertEqual(
+            props["links"]["convertToAliasUrl"],
+            reverse("wagtail_localize:convert_to_alias", args=[de_page.id]),
+        )
 
 
 @freeze_time("2020-08-21")

--- a/wagtail_localize/views/convert.py
+++ b/wagtail_localize/views/convert.py
@@ -29,6 +29,7 @@ def convert_to_alias(request, page_id):
         translation_source = TranslationSource.objects.get(
             object_id=page.translation_key,
             specific_content_type=page.content_type_id,
+            translations__target_locale=page.locale,
         )
 
         source_page = translation_source.get_source_instance()

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -905,6 +905,7 @@ def edit_translation(request, translation, instance):
                     locale_id=TranslationSource.objects.get(
                         object_id=instance.translation_key,
                         specific_content_type=instance.content_type_id,
+                        translations__target_locale=instance.locale,
                     ).locale_id,
                 )
                 .exclude(pk=instance.pk)

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -315,6 +315,7 @@ class ConvertToAliasPageActionMenuItem(PageActionMenuItem):
                     locale_id=TranslationSource.objects.get(
                         object_id=page.translation_key,
                         specific_content_type=page.content_type_id,
+                        translations__target_locale=page.locale,
                     ).locale_id,
                 ).exists()
             )


### PR DESCRIPTION
Fixes #547 

## steps to reproduce the issue
- create locales L1, L2, L3
- create a page P1 in locale L1
- translate page P1 to locale L2 (let's say the newly translated page is P1')
- translate page P1' to locale L3 (let's say the newly translated page is P1'')
- you will be redirected to edit page with error `MultipleObjectsReturned - get() returned more than one TranslationSource -- it returned 2!`

## observations
- above-mentioned scenario creates 2 translation sources with same `object_id`, and `spectific_content_type_id` but from different locales
- "convert to alias" buttons' logic (finding the source of translation) is dependent on these 2 fields but these 2 fields alone can't uniquely identify the translation source (hence the error - multiple objects returned)

## solution
the combination of `object_id`, `spectific_content_type_id`, and `translations__target_locale_id` can uniquely identify the translation source

Let me know if I missed something.