### PR TITLE
Fix duplicate locale defintion in TranslatableCreateView template

### DIFF
--- a/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_create.html
+++ b/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_create.html
@@ -1,7 +1,5 @@
 {% extends "modeladmin/create.html" %}
 
 {% block header %}
-  {% include "wagtailadmin/shared/header_with_locale_selector.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon tabbed=1 merged=1 %}
+    {% include "wagtailadmin/shared/header_with_locale_selector.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon tabbed=1 merged=1 %}
 {% endblock %}
-
-{% block form_action %}{{ view.create_url }}?locale={{ locale.language_code }}{% endblock %}

--- a/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_create.html
+++ b/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_create.html
@@ -3,3 +3,4 @@
 {% block header %}
     {% include "wagtailadmin/shared/header_with_locale_selector.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon tabbed=1 merged=1 %}
 {% endblock %}
+{% block form_action %}{{ view.create_url }}{% if wagtail_version < "3.0" %}?locale={{ locale.language_code }}{% endif %}{% endblock %}

--- a/wagtail_localize/modeladmin/tests.py
+++ b/wagtail_localize/modeladmin/tests.py
@@ -78,6 +78,13 @@ class TestModelAdminViews(TestCase, WagtailTestUtils):
         create_url = reverse("wagtail_localize_test_testmodel_modeladmin_create")
         response = self.client.get(create_url)
 
+        # Check for correct Form Action
+        self.assertContains(
+            response,
+            '<form action="/admin/wagtail_localize_test/testmodel/create/?locale=en"',
+        )
+
+        # Check, if other Language is available in Dropdown
         self.assertContains(
             response,
             '<a href="/admin/wagtail_localize_test/testmodel/create/?locale=de"',


### PR DESCRIPTION
This PR fixes #579, as it removes the duplicate definition of the "locale" parameter. 

The "?locale=" parameter is already attached to the URL in the base template ("modeladmin/create.html"):
`{% block form_action %}{{ view.create_url }}{% endblock %}{% if locale %}?locale={{ locale.language_code }}{% endif %}`

As a result, it is currently not necessary to override the "form_action" block.

Removing the code ensures that the CreateView works again, and does not fail because of a malformed URL, ending in a 404 error.