### PR TITLE
Fix TestSubmitPageTranslationWithComponents for Wagtail 4

### DIFF
--- a/wagtail_localize/tests/test_translation_components.py
+++ b/wagtail_localize/tests/test_translation_components.py
@@ -74,9 +74,12 @@ class TestSubmitPageTranslationWithComponents(TestCase, WagtailTestUtils):
             },
         )
 
-        self.assertContains(
-            response, "component-form__fieldname-custom_text_field error"
+        components = list(response.context["components"])
+        _, _, component_form = components[1]
+        self.assertEqual(
+            component_form.errors["custom_text_field"], ["This field is required."]
         )
+        # Check that error message is actually rendered
         self.assertContains(response, "This field is required")
 
         self.assertEqual(CustomTranslationData.objects.count(), 0)


### PR DESCRIPTION
The markup for form fields with errors has changed substantially in Wagtail 4, and now there's no straightforward way to assert "an error exists on field X" using a substring match on the HTML. Instead, check the form object directly.