### PR TITLE
Add method to delete translation data on translatable model deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ __pycache__/
 /test-static
 /test-media
 .idea
+.fleet
 
 .DS_Store

--- a/docs/how-to/installation.md
+++ b/docs/how-to/installation.md
@@ -46,7 +46,24 @@ on your model. The default value is `synced`.
 e.g.
 
 ```python
+from wagtail.models import Page
+
+
 class MyPage(Page):
     localize_default_translation_mode = "simple"
     # ...
 ```
+
+## Control translation cleanup mode
+
+<!-- prettier-ignore -->
+!!! info "Changed in 1.3"
+    Prior to version 1.3, `Translation` objects were marked as disabled and all related data was kept. This led to
+    confusion and poor user experience. To restore the previous behaviour,
+    set `WAGTAILLOCALIZE_DISABLE_ON_DELETE = True` in your settings file.
+
+Wagtail Localize will remove translation data when the translation source (e.g. original page)
+or the translation destination (e.g. translated page) is deleted.
+
+To disable the `Translation` object and keep the related data, such as translated strings or overrides,
+set `WAGTAILLOCALIZE_DISABLE_ON_DELETE = True` in your settings file.

--- a/wagtail_localize/tests/test_translationsource_model.py
+++ b/wagtail_localize/tests/test_translationsource_model.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from wagtail.core.blocks import StreamValue
 from wagtail.core.models import Locale, Page, PageLogEntry
@@ -535,6 +535,7 @@ class TestCreateOrUpdateTranslationForPage(TestCase):
         self.assertEqual(e.exception.segment.string, self.string)
         self.assertEqual(e.exception.locale, self.dest_locale)
 
+    @override_settings(WAGTAILLOCALIZE_DISABLE_ON_DELETE=True)
     def test_create_related_object_not_ready(self):
         self.translated_snippet.delete()
 


### PR DESCRIPTION
Changes the default behaviour so that it removes related localize data on translatable model deletion, rather than marking the `Translation` as disabled.

Adds a setting (`WAGTAILLOCALIZE_DISABLE_ON_DELETE` to allow for the old behaviour should it be needed.

Fixes #402

To-Do:

- [x] Add tests
- [x] Update documentation