### PR TITLE
Rename imageChosen, documentChosen to chosen

### DIFF
--- a/wagtail_localize/static_src/editor/components/TranslationEditor/segments.tsx
+++ b/wagtail_localize/static_src/editor/components/TranslationEditor/segments.tsx
@@ -664,7 +664,7 @@ const EditorSynchronisedValueSegment: FunctionComponent<
                 url: (window as any).chooserUrls.imageChooser,
                 onload: (window as any).IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
                 responses: {
-                    imageChosen: function(imageData: any) {
+                    chosen: function(imageData: any) {
                         saveOverride(
                             segment,
                             imageData.id,
@@ -695,7 +695,7 @@ const EditorSynchronisedValueSegment: FunctionComponent<
                 url: (window as any).chooserUrls.documentChooser,
                 onload: (window as any).DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS,
                 responses: {
-                    documentChosen: function(documentData: any) {
+                    chosen: function(documentData: any) {
                         saveOverride(
                             segment,
                             documentData.id,


### PR DESCRIPTION
Fixes #649 

After these commits choosers in the wagtail_localize didn't work correctly:
https://github.com/wagtail/wagtail/commit/157f7674bcced9e134b1a80ab8c299d13d5dd833
https://github.com/wagtail/wagtail/commit/6dba0cf4476e3b86cc20233c4694e58e93f8da83