### PR TITLE
Enable setting to create draft, not live, pages on translation.

### DIFF
--- a/docs/how-to/installation.md
+++ b/docs/how-to/installation.md
@@ -54,6 +54,14 @@ class MyPage(Page):
     # ...
 ```
 
+
+## Disabling default publication of tranlsated pages
+
+Live pages that are submitted for translation are made live immediately. If you wish pages to stay in draft form at that point, set `WAGTAIL_LOCALIZE_PUBLISH_TRANSLATIONS_OF_LIVE_PAGES = False` in your settings file.
+
+
+
+
 ## Control translation cleanup mode
 
 <!-- prettier-ignore -->

--- a/docs/how-to/installation.md
+++ b/docs/how-to/installation.md
@@ -57,7 +57,7 @@ class MyPage(Page):
 
 ## Disabling default publication of tranlsated pages
 
-Live pages that are submitted for translation are made live immediately. If you wish pages to stay in draft form at that point, set `WAGTAIL_LOCALIZE_PUBLISH_TRANSLATIONS_OF_LIVE_PAGES = False` in your settings file.
+Live pages that are submitted for translation are made live immediately. If you wish pages to stay in draft form at that point, set `WAGTAILLOCALIZE_SYNC_LIVE_STATUS_ON_TRANSLATE = False` in your settings file.
 
 
 

--- a/wagtail_localize/operations.py
+++ b/wagtail_localize/operations.py
@@ -73,7 +73,7 @@ class TranslationCreator:
             self.mappings[source].append(translation)
 
             # Determine whether or not to publish the translation.
-            publish_on_translate_setting = getattr(settings, "WAGTAIL_LOCALIZE_PUBLISH_TRANSLATIONS_OF_LIVE_PAGES", True)
+            publish_on_translate_setting = getattr(settings, "WAGTAILLOCALIZE_SYNC_LIVE_STATUS_ON_TRANSLATE", True)
             if publish_on_translate_setting == True:
                 publish = getattr(instance, "live", True)
             else:

--- a/wagtail_localize/operations.py
+++ b/wagtail_localize/operations.py
@@ -73,7 +73,11 @@ class TranslationCreator:
             self.mappings[source].append(translation)
 
             # Determine whether or not to publish the translation.
-            publish = getattr(instance, "live", True)
+            publish_on_translate_setting = getattr(settings, "WAGTAIL_LOCALIZE_PUBLISH_TRANSLATIONS_OF_LIVE_PAGES", True)
+            if publish_on_translate_setting == True:
+                publish = getattr(instance, "live", True)
+            else:
+                publish = False
 
             try:
                 translation.save_target(user=self.user, publish=publish)

--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -246,6 +246,25 @@ class TestSubmitPageTranslation(TestCase, WagtailTestUtils):
             response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
         )
 
+    @override_settings(WAGTAILLOCALIZE_SYNC_LIVE_STATUS_ON_TRANSLATE=False)
+    def test_post_submit_page_translation_draft(self):
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:submit_page_translation",
+                args=[self.en_blog_index.id],
+            ),
+            {"locales": [self.fr_locale.id]},
+        )
+
+        translation = Translation.objects.get()
+        self.assertEqual(translation.source.locale, self.en_locale)
+        self.assertEqual(translation.target_locale, self.fr_locale)
+        self.assertTrue(translation.created_at)
+
+        # The translated page should've been created and published
+        translated_page = self.en_blog_index.get_translation(self.fr_locale)
+        self.assertFalse(translated_page.live)
+
     def test_post_submit_page_translation_submits_linked_snippets(self):
         self.en_blog_index.test_snippet = TestSnippet.objects.create(
             field="My test snippet"


### PR DESCRIPTION
As per #655 

and discussed on Slack: https://wagtailcms.slack.com/archives/CD4S91XF0/p1668602376804759