### PR TITLE
use glob pattern in exclude declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install -e .[testing] -U
 #### Using flit
 
 ```sh
-pip install flit
+pip install "flit>=3.8.0"
 flit install
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,7 @@ name = "wagtail_localize"
 exclude = [
     "wagtail_localize/static_src",
     "wagtail_localize/test",
-    "wagtail_localize/tests",
-    "wagtail_localize/machine_translators/tests",
-    "wagtail_localize/segments/tests",
+    "wagtail_localize/**/tests",
     "wagtail_localize/static/.gitignore",
     "Makefile",
     "scripts",


### PR DESCRIPTION
A little bit of follow up from https://github.com/wagtail/wagtail-localize/pull/589#discussion_r913691819

Now that [flit 3.8](https://flit.pypa.io/en/stable/history.html#version-3-8) is out, we can use a glob pattern which slightly simplifies things and means we don't need to remember to add another line here to exclude the tests if we add another app in future.
This does mean that flit 3.8.0 or higher is now required to build the package.