### PR TITLE
Use the url field for the project homepage in PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "wagtail-localize"
 authors = [{name = "Karl Hobley", email = "karl@torchbox.com"}]
+url = "https://www.wagtail-localize.org"
 description = "Translation plugin for Wagtail CMS"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -56,7 +57,6 @@ google = [
 ]
 
 [project.urls]
-Home = "https://www.wagtail-localize.org"
 Source = "https://github.com/wagtail/wagtail-localize"
 Documentation = "https://www.wagtail-localize.org"
 


### PR DESCRIPTION
Spotted while doing data analysis of Wagtail packages. [`url`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#url) is specifically meant for the project "Homepage", so is more appropriate than adding a `project_urls` set to "Home".