### PR TITLE
Fix slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To run the test app interactively, use `tox -e interactive`, visit `http://127.0
 
 ## Support
 
-For support, please use [GitHub Discussions](https://github.com/wagtail/wagtail-localize/discussions) or ask a question on the `#multi-language` channel on [Wagtail's Slack instance](`https://wagtail.org/slack/`).
+For support, please use [GitHub Discussions](https://github.com/wagtail/wagtail-localize/discussions) or ask a question on the `#multi-language` channel on [Wagtail's Slack instance](https://wagtail.org/slack/).
 
 ## Thanks
 


### PR DESCRIPTION
Link with backticks was going to "https://www.wagtail-localize.org/https:/wagtail.org/slack/" instead of the desired URL.

Tested by going to https://wagtail-localize.org and clicking the link on Firefox, Chrome and Edge.