### PR TITLE
Change dependencies to allow Django 4.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Wagtail Localize is a translation plugin for the [Wagtail CMS](https://wagtail.o
 Wagtail Localize requires the following:
 
 - Python (3.7, 3.8, 3.9, 3.10, 3.11)
-- Django (3.2, 4.0, 4.1)
-- Wagtail (4.1, 4.2) with [internationalisation enabled](https://docs.wagtail.org/en/stable/advanced_topics/i18n.html#configuration)
+- Django (3.2, 4.0, 4.1, 4.2)
+- Wagtail (4.1, 4.2, 5.0) with [internationalisation enabled](https://docs.wagtail.org/en/stable/advanced_topics/i18n.html#configuration)
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
-    "Django>=3.2,<4.2",
+    "Django>=3.2,<5.0",
     "Wagtail>=4.1",
     "polib>=1.1,<2.0",
     "typing_extensions>=4.0"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,9 @@ envlist =
     python{3.7}-django{3.2}-wagtail{4.1,4.2}-{sqlite,postgres12}
     python{3.8,3.9,3.10}-django{3.2}-wagtail{4.1,4.2}-{sqlite,postgres12}
     python{3.8,3.9,3.10}-django{4.0,4.1}-wagtail{4.1,4.2}-{sqlite,postgres15}
+    python{3.8,3.9,3.10}-django{4.2}-wagtail{5.0}-{sqlite,postgres15}
     python{3.11}-django{4.1}-wagtail{4.1,4.2}-{sqlite,postgres15}
+    python{3.11}-django{4.2}-wagtail{5.0}-{sqlite,postgres15}
 
 [gh-actions]
 python =
@@ -37,10 +39,12 @@ deps =
     django3.2: Django>=3.2,<3.3
     django4.0: Django>=4.0,<4.1
     django4.1: Django>=4.1,<4.2
+    django4.2: Django>=4.2,<5.0
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail4.2: wagtail>=4.2,<5.0
+    wagtail5.0: wagtail>=5.0,<5.1
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     # Pinned to work around UTC connection error

--- a/wagtail_localize/__init__.py
+++ b/wagtail_localize/__init__.py
@@ -2,6 +2,6 @@ from .version import get_version
 
 
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 5, 0, "final", 1)
+VERSION = (1, 5, 1, "beta", 1)
 
 __version__ = get_version(VERSION)


### PR DESCRIPTION
Add tox envs for combos of Python with Django 4.2 and Wagtail 5.0. Refs #691 
