### PR TITLE
Fix tests against Wagtail 5.1

### DIFF
--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.models import Locale, Page, PageViewRestriction
 from wagtail.test.utils import WagtailTestUtils
 
@@ -75,14 +76,28 @@ class TestTranslatePageListingButton(TestCase, WagtailTestUtils):
             reverse("wagtailadmin_explore", args=[self.en_homepage.id])
         )
 
-        self.assertContains(
-            response,
-            (
-                f'<a href="/admin/localize/submit/page/{self.en_blog_index.id}/" '
-                'aria-label="" class="u-link is-live ">Translate this page</a>'
-            ),
-            html=True,
-        )
+        if WAGTAIL_VERSION >= (5, 1):
+            self.assertContains(
+                response,
+                (
+                    f'<a href="/admin/localize/submit/page/{self.en_blog_index.id}/" '
+                    'aria-label="" class="">'
+                    '<svg class="icon icon-wagtail-localize-language icon" aria-hidden="true">'
+                    '<use href="#icon-wagtail-localize-language"></use></svg>'
+                    "Translate this page"
+                    "</a>"
+                ),
+                html=True,
+            )
+        else:
+            self.assertContains(
+                response,
+                (
+                    f'<a href="/admin/localize/submit/page/{self.en_blog_index.id}/" '
+                    'aria-label="" class="u-link is-live ">Translate this page</a>'
+                ),
+                html=True,
+            )
 
     def test_hides_if_page_already_translated(self):
         self.en_blog_index.copy_for_translation(self.fr_locale)

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.models import Locale, Page, PageViewRestriction
 from wagtail.test.utils import WagtailTestUtils
 
@@ -79,14 +80,26 @@ class TestPageUpdateTranslationsListingButton(TestCase, WagtailTestUtils):
             reverse("wagtailadmin_explore", args=[self.en_homepage.id])
         )
 
-        self.assertContains(
-            response,
-            (
-                f'<a href="/admin/localize/update/{self.source.id}/?next=%2Fadmin%2Fpages%2F{self.en_homepage.id}%2F" '
-                'aria-label="" class="u-link is-live ">Sync translated pages</a>'
-            ),
-            html=True,
-        )
+        if WAGTAIL_VERSION >= (5, 1):
+            self.assertContains(
+                response,
+                (
+                    f'<a href="/admin/localize/update/{self.source.id}/?next=%2Fadmin%2Fpages%2F{self.en_homepage.id}%2F" '
+                    'aria-label="" class="">'
+                    '<svg class="icon icon-resubmit icon" aria-hidden="true"><use href="#icon-resubmit"></use></svg>'
+                    "Sync translated pages</a>"
+                ),
+                html=True,
+            )
+        else:
+            self.assertContains(
+                response,
+                (
+                    f'<a href="/admin/localize/update/{self.source.id}/?next=%2Fadmin%2Fpages%2F{self.en_homepage.id}%2F" '
+                    'aria-label="" class="u-link is-live ">Sync translated pages</a>'
+                ),
+                html=True,
+            )
 
     def test_hides_if_page_hasnt_got_translations(self):
         self.source.delete()


### PR DESCRIPTION
Fix test failures against Wagtail nightly / 5.1rc1 - these are caused by the markup for "More..." menu items changing. Along with updating the test assertions, I've confirmed that these menu items render sensibly on a 5.1 installation:

![Screenshot 2023-07-27 at 15 05 56](https://github.com/wagtail/wagtail-localize/assets/85097/cb85d334-30fe-4160-be17-a4e31317f43f)
![Screenshot 2023-07-27 at 15 06 16](https://github.com/wagtail/wagtail-localize/assets/85097/7a5726a3-8e1b-4e83-b7c1-17a47bad8505)
