### PR TITLE
Locale filter selector based on installed languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ tox
 ```
 
 or, you can run them for a specific environment `tox -e python3.8-django3.2-wagtail4.1` or specific test
-`tox -e python3.9-django3.2-wagtail4.1-sqlite wagtail_localize.tests.test_edit_translation.TestGetEditTranslationView`
+`tox -e python3.9-django3.2-wagtail4.1-sqlite -- wagtail_localize.tests.test_edit_translation.TestGetEditTranslationView`
 
 To run the test app interactively, use `tox -e interactive`, visit `http://127.0.0.1:8020/admin/` and log in with `admin`/`changeme`.
 

--- a/wagtail_localize/tests/test_translations_report.py
+++ b/wagtail_localize/tests/test_translations_report.py
@@ -135,6 +135,17 @@ class TestTranslationReport(TestCase, WagtailTestUtils):
         self.assertNotIn(self.blog_index_translation, response.context["object_list"])
         self.assertNotIn(self.blog_post_translation, response.context["object_list"])
 
+    def test_filter_by_source_locale_all_options(self):
+        response = self.client.get(
+            reverse("wagtail_localize:translations_report") + "?source_locale=all"
+        )
+
+        self.assertIn(self.snippet_translation, response.context["object_list"])
+        self.assertIn(self.homepage_translation, response.context["object_list"])
+        self.assertIn(self.de_homepage_translation, response.context["object_list"])
+        self.assertIn(self.blog_index_translation, response.context["object_list"])
+        self.assertIn(self.blog_post_translation, response.context["object_list"])
+
     def test_filter_by_target_locale(self):
         response = self.client.get(
             reverse("wagtail_localize:translations_report") + "?target_locale=de"
@@ -145,3 +156,14 @@ class TestTranslationReport(TestCase, WagtailTestUtils):
         self.assertIn(self.de_homepage_translation, response.context["object_list"])
         self.assertNotIn(self.blog_index_translation, response.context["object_list"])
         self.assertNotIn(self.blog_post_translation, response.context["object_list"])
+
+    def test_filter_by_target_locale_all_options(self):
+        response = self.client.get(
+            reverse("wagtail_localize:translations_report") + "?target_locale=all"
+        )
+
+        self.assertIn(self.snippet_translation, response.context["object_list"])
+        self.assertIn(self.homepage_translation, response.context["object_list"])
+        self.assertIn(self.de_homepage_translation, response.context["object_list"])
+        self.assertIn(self.blog_index_translation, response.context["object_list"])
+        self.assertIn(self.blog_post_translation, response.context["object_list"])

--- a/wagtail_localize/tests/test_translations_report.py
+++ b/wagtail_localize/tests/test_translations_report.py
@@ -167,3 +167,28 @@ class TestTranslationReport(TestCase, WagtailTestUtils):
         self.assertIn(self.de_homepage_translation, response.context["object_list"])
         self.assertIn(self.blog_index_translation, response.context["object_list"])
         self.assertIn(self.blog_post_translation, response.context["object_list"])
+
+    def test_locale_filters_get_proper_choices(self):
+        response = self.client.get(reverse("wagtail_localize:translations_report"))
+
+        self.assertEqual(
+            list(response.context["filters"].form.fields["source_locale"].choices),
+            [
+                ("all", "All"),
+                ("en", "English"),
+                ("fr", "French"),
+                ("de", "German"),
+                ("es", "Spanish"),
+            ],
+        )
+
+        self.assertEqual(
+            list(response.context["filters"].form.fields["target_locale"].choices),
+            [
+                ("all", "All"),
+                ("en", "English"),
+                ("fr", "French"),
+                ("de", "German"),
+                ("es", "Spanish"),
+            ],
+        )

--- a/wagtail_localize/views/report.py
+++ b/wagtail_localize/views/report.py
@@ -100,11 +100,7 @@ class ContentTypeModelChoiceFilter(django_filters.ModelChoiceFilter):
 
 
 def _get_locale_choices():
-    choices = [
-        (language_code, display_name)
-        for language_code, display_name in get_content_languages().items()
-    ]
-    return choices
+    return list(get_content_languages().items())
 
 
 class LocaleFilter(django_filters.ChoiceFilter):
@@ -124,13 +120,13 @@ class TranslationsReportFilterSet(WagtailFilterSet):
         field_name="source__locale",
         choices=_get_locale_choices,
         empty_label=None,
-        null_label="All",
+        null_label=gettext_lazy("All"),
         null_value="all",
     )
     target_locale = LocaleFilter(
         choices=_get_locale_choices,
         empty_label=None,
-        null_label="All",
+        null_label=gettext_lazy("All"),
         null_value="all",
     )
 


### PR DESCRIPTION
## The problem

On the "Translations" report, the current way to filter by locales is to type the language code in the field exactly as it was defined by the developers. This causes some issues.

First, we could have some editors/admins that might just want a quick reference into translations and might not experts in the field. Hence, it is not fair to expect them to know the language codes for all installed languages. For instance, although ubiquitous, one might not know that "de" is the language code for the German language.

The second problem is more subtle and more difficult to debug when it happens. If a project defines their `WAGTAIL_CONTENT_LANGUAGES` as

```python
LANGUAGE_CODE = "en"
WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = (
    ("en", gettext_lazy("English")),
    ("de", gettext_lazy("German")),
    ("es", gettext_lazy("Spanish")),
    ("fr", gettext_lazy("French")),
    ("fy-NL", gettext_lazy("Frisian")),
    ("nl", gettext_lazy("Dutch")),
    ("pl", gettext_lazy("Polish")),
    ("pt-BR", gettext_lazy("Portuguese (Brazil)")),
    ("sw", gettext_lazy("Swahili")),
)
```
for example, the field as it current stands will only recognise "pt-BR" as the "Portuguese (Brazil)" language, but not "pt-br".

From the [ITEF wiki](https://en.wikipedia.org/wiki/IETF_language_tag):

> Subtags are not [case-sensitive](https://en.wikipedia.org/wiki/Case-sensitive), but the specification recommends using the same case as in the Language Subtag Registry, where region subtags are [UPPERCASE](https://en.wikipedia.org/wiki/UPPERCASE), script subtags are [Title Case](https://en.wikipedia.org/wiki/Title_case), and all other subtags are [lowercase](https://en.wikipedia.org/wiki/Lowercase). This capitalization follows the recommendations of the underlying ISO standards.

So that the "correct-er" form would be "pt-BR", although if subtags are supposed to not be case-senstive then both cases must filter properly (which is not the currently behaviour).

## The solution

This PR leverages the language codes defined in `WAGTAIL_CONTENT_LANGUAGES` to provide chooser fields for the locales instead of relying on having to type the proper language code. This abstracts the language code information from editors/admins with the bonus of displaying language names localized to their Wagtail admin choice.

An "All" option is defined to display translations in all locales.

#### Screenshots:

Using the provided test app with:

```python
LANGUAGES = WAGTAIL_CONTENT_LANGUAGES = [
    ("en", "English"),
    ("fr", "French"),
    ("fr-CA", "French (Canada)"),
    ("es", "Spanish"),
]
```

![image](https://github.com/wagtail/wagtail-localize/assets/61277874/ee372679-be42-447b-91b0-0548b89e7446)

![image](https://github.com/wagtail/wagtail-localize/assets/61277874/2b187199-c17b-4d2d-a090-30c7886e7aad)

![image](https://github.com/wagtail/wagtail-localize/assets/61277874/6cb7e357-f8f9-4ee4-a29f-716fcc491b34)
