### PR TITLE
Move revision publishing in `TranslationSource` to `transaction.on_commit`

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -798,7 +798,7 @@ class TranslationSource(models.Model):
                     self.sync_view_restrictions(original, translation)
 
                     if publish:
-                        page_revision.publish()
+                        transaction.on_commit(page_revision.publish)
 
                 else:
                     # Note: we don't need to run full_clean for Pages as Wagtail does that in Page.save()

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -2,6 +2,8 @@ import json
 import tempfile
 import uuid
 
+from unittest.mock import patch
+
 import polib
 
 from django.contrib.admin.utils import quote
@@ -10,6 +12,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import transaction
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -149,7 +152,10 @@ class EditTranslationTestData(WagtailTestUtils):
             source=self.page_source,
             target_locale=self.fr_locale,
         )
-        self.page_translation.save_target()
+
+        with patch.object(transaction, "on_commit", side_effect=lambda func: func()):
+            self.page_translation.save_target()
+
         self.fr_page = self.page.get_translation(self.fr_locale)
         self.fr_home_page = self.home_page.get_translation(self.fr_locale)
 

--- a/wagtail_localize/tests/test_translation_model.py
+++ b/wagtail_localize/tests/test_translation_model.py
@@ -1,9 +1,10 @@
 from unittest import mock
+from unittest.mock import patch
 
 import polib
 
 from django.conf import settings
-from django.db import OperationalError
+from django.db import OperationalError, transaction
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -602,7 +603,8 @@ class TestSaveTarget(TestCase):
         self.test_content_string = String.objects.get(data="Test content")
         self.more_test_content_string = String.objects.get(data="More test content")
 
-    def test_save_target(self):
+    @patch.object(transaction, "on_commit", side_effect=lambda func: func())
+    def test_save_target(self, _mock_on_commit):
         self.translation.save_target()
 
         # Should create the page with English content


### PR DESCRIPTION
Replaces #711 to bring up to date with `main`