### PR TITLE
Fix the Locale create/edit/delete success messages

### DIFF
--- a/wagtail_localize/locales/views.py
+++ b/wagtail_localize/locales/views.py
@@ -91,7 +91,6 @@ class IndexView(generic.IndexView):
 
 class CreateView(generic.CreateView):
     page_title = gettext_lazy("Add locale")
-    success_message = gettext_lazy("Locale '{0}' created.")
     template_name = "wagtaillocales/create.html"
 
     def get_components(self):
@@ -112,6 +111,10 @@ class CreateView(generic.CreateView):
         else:
             return self.form_invalid(form)
 
+    @property
+    def success_message(self):
+        return gettext_lazy("Locale '{0}' created.").format(str(self.object))
+
     @transaction.atomic
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -125,7 +128,6 @@ class CreateView(generic.CreateView):
 
 
 class EditView(generic.EditView):
-    success_message = gettext_lazy("Locale '{0}' updated.")
     error_message = gettext_lazy("The locale could not be saved due to errors.")
     delete_item_label = gettext_lazy("Delete locale")
     context_object_name = "locale"
@@ -152,6 +154,10 @@ class EditView(generic.EditView):
         else:
             return self.form_invalid(form)
 
+    @property
+    def success_message(self):
+        return gettext_lazy("Locale '{0}' updated.").format(str(self.object))
+
     @transaction.atomic
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -165,7 +171,6 @@ class EditView(generic.EditView):
 
 
 class DeleteView(generic.DeleteView):
-    success_message = gettext_lazy("Locale '{0}' deleted.")
     cannot_delete_message = gettext_lazy(
         "This locale cannot be deleted because there are pages and/or other objects using it."
     )
@@ -188,6 +193,10 @@ class DeleteView(generic.DeleteView):
         else:
             messages.error(self.request, self.cannot_delete_message)
             return super().get(self.request)
+
+    @property
+    def success_message(self):
+        return gettext_lazy("Locale '{0}' deleted.").format(str(self.object))
 
 
 class LocaleViewSet(ModelViewSet):

--- a/wagtail_localize/locales/views.py
+++ b/wagtail_localize/locales/views.py
@@ -93,6 +93,10 @@ class CreateView(generic.CreateView):
     page_title = gettext_lazy("Add locale")
     template_name = "wagtaillocales/create.html"
 
+    @property
+    def success_message(self):
+        return gettext_lazy("Locale '{0}' created.").format(str(self.object))
+
     def get_components(self):
         return ComponentManager.from_request(self.request)
 
@@ -110,10 +114,6 @@ class CreateView(generic.CreateView):
             return self.form_valid(form)
         else:
             return self.form_invalid(form)
-
-    @property
-    def success_message(self):
-        return gettext_lazy("Locale '{0}' created.").format(str(self.object))
 
     @transaction.atomic
     def form_valid(self, form):
@@ -134,6 +134,10 @@ class EditView(generic.EditView):
     template_name = "wagtaillocales/edit.html"
     queryset = Locale.all_objects.all()
 
+    @property
+    def success_message(self):
+        return gettext_lazy("Locale '{0}' updated.").format(str(self.object))
+
     def get_components(self):
         return ComponentManager.from_request(
             self.request, source_object_instance=self.object
@@ -153,10 +157,6 @@ class EditView(generic.EditView):
             return self.form_valid(form)
         else:
             return self.form_invalid(form)
-
-    @property
-    def success_message(self):
-        return gettext_lazy("Locale '{0}' updated.").format(str(self.object))
 
     @transaction.atomic
     def form_valid(self, form):
@@ -179,6 +179,10 @@ class DeleteView(generic.DeleteView):
     template_name = "wagtaillocales/confirm_delete.html"
     queryset = Locale.all_objects.all()
 
+    @property
+    def success_message(self):
+        return gettext_lazy("Locale '{0}' deleted.").format(str(self.object))
+
     def can_delete(self, locale):
         return get_locale_usage(locale) == (0, 0)
 
@@ -193,10 +197,6 @@ class DeleteView(generic.DeleteView):
         else:
             messages.error(self.request, self.cannot_delete_message)
             return super().get(self.request)
-
-    @property
-    def success_message(self):
-        return gettext_lazy("Locale '{0}' deleted.").format(str(self.object))
 
 
 class LocaleViewSet(ModelViewSet):


### PR DESCRIPTION
This pull request addresses an issue related to success messages in the CreateView, EditView, and DeleteView for Locales. The previous implementation of success messages was not handling formatting properly, and this PR introduces improvements. Fix #761 
![761](https://github.com/wagtail/wagtail-localize/assets/63553768/6c43df20-4168-44ec-8aeb-9ebcec8a8cba)
