### PR TITLE
Wagtail 6.0 fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,10 @@ jobs:
 
       - run: pip install flit
       - run: flit install --deps production --extras testing
-      - run: pip install wagtail_modeladmin ./wagtail
+      - run: |
+          pip install \
+          git+https://github.com/wagtail-nest/wagtail-modeladmin.git@main#egg=wagtail-modeladmin \
+          ./wagtail
 
       - run: python testmanage.py test
 

--- a/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_edit.html
+++ b/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_edit.html
@@ -5,27 +5,13 @@
     {% include "modeladmin/includes/header_with_history.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon tabbed=1 merged=1 latest_log_entry=latest_log_entry history_url=history_url %}
 {% endblock %}
 
-{% block form_actions %}
-  <div class="dropdown dropup dropdown-button match-width">
-    {# TODO: remove data-clicked-text once we drop support for Wagtail 4.x #}
-    <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}" data-controller="w-progress" data-action="w-progress#activate" data-w-progress-active-value="{% trans 'Saving…' %}">
-      {% icon name="spinner" %}<em>{% trans "Save" %}</em>
-    </button>
+{% block more_action_items %}
+    {{ block.super }}
 
-    {% if user_can_delete %}
-      <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
-      <ul>
-        {% if translation %}
-          <li>
-            <form method="POST">
-              <input type="hidden" name="localize-restart-translation">
-              <button class="button">{% trans "Start Synced translation" %}</button>
-            </form>
-          </li>
-        {% endif %}
-        <li><a href="{{ view.delete_url }}" class="shortcut">{% trans "Delete" %}</a></li>
-      </ul>
+    {% if user_can_delete and translation %}
+        <form method="POST">
+            <input type="hidden" name="localize-restart-translation">
+            <button class="button">{% trans "Start Synced translation" %}</button>
+        </form>
     {% endif %}
-
-  </div>
 {% endblock %}

--- a/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_index.html
+++ b/wagtail_localize/modeladmin/templates/wagtail_localize/modeladmin/translatable_index.html
@@ -12,13 +12,7 @@
       </div>
     {% endif %}
     {% if view.list_export %}
-      <div class="dropdown dropdown-button match-width col">
-        <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
-        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
-        <ul>
-          <li><a  class="button bicolor button--icon" href="?export=csv&{{ request.GET.urlencode }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
-        </ul>
-      </div>
+        {% include view.export_buttons_template_name %}
     {% endif %}
   </div>
 {% endblock %}

--- a/wagtail_localize/test/wagtail_hooks.py
+++ b/wagtail_localize/test/wagtail_hooks.py
@@ -23,6 +23,7 @@ class TestPageAdmin(TranslatableModelAdmin):
 class TestModelAdmin(TranslatableModelAdmin):
     model = TestModel
     inspect_view_enabled = True
+    list_export = ["title", "test_charfield", "test_textfield", "test_emailfield"]
 
 
 class NonTranslatableModelAdmin(ModelAdmin):


### PR DESCRIPTION
Incomplete, just a few fixes for the modeladmin stuff based on fixes in wagtail-modeladmin. I don't have the time to properly test yet (and I don't fully know the extent of the features).

Suggestion: for the next release, only support Wagtail 5.2+ and drop support for `wagtail.contrib.modeladmin`.