### PR TITLE
Wagtail 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,6 @@ jobs:
         run: |
           coverage run testmanage.py test
       - name: 'Upload coverage to Codecov'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for Wagtail 6.1
+
+### Removed
+
+- Support for Django < 4.2
+
 ## [1.9] - 2024-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ We'll be at Wagtail Space US this year! The Call for Participation and Registrat
 Wagtail Localize requires the following:
 
 - Python (3.8, 3.9, 3.10, 3.11)
-- Django (3.2, 4.2, 5.0)
-- Wagtail (5.2, 6.0) with [internationalisation enabled](https://docs.wagtail.org/en/stable/advanced_topics/i18n.html#configuration)
+- Django (4.2, 5.0)
+- Wagtail (5.2, 6.0, 6.1) with [internationalisation enabled](https://docs.wagtail.org/en/stable/advanced_topics/i18n.html#configuration)
 - [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/) if `using wagtail_localize.modeladmin` and Wagtail >= 5.2
 
 ## Installation

--- a/docs/how-to/modeladmin.md
+++ b/docs/how-to/modeladmin.md
@@ -18,8 +18,8 @@ INSTALLED_APPS = [
 When registering your custom models you can use the supplied `TranslatableModelAdmin` in place of Wagtail's `ModelAdmin` class.
 
 ```python
-from wagtail.contrib.modeladmin.options import modeladmin_register
 from wagtail_localize.modeladmin.options import TranslatableModelAdmin
+from wagtail_modeladmin.options import modeladmin_register
 
 from .models import MyTranslatableModel
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wagtail-localize-admin",
-  "version": "1.5.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wagtail-localize-admin",
-      "version": "1.5.0",
+      "version": "1.9.0",
       "license": "ISC",
       "dependencies": {
         "react": "^16.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "Django>=4.2,<5.1",
-    "Wagtail>=5.2",
+    "Wagtail>=5.2,<6.2",
     "polib>=1.1,<2.0",
     "typing_extensions>=4.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,17 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 4",
-    "Framework :: Wagtail :: 5"
+    "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6"
 ]
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
-    "Django>=3.2,<5.1",
+    "Django>=4.2,<5.1",
     "Wagtail>=5.2",
     "polib>=1.1,<2.0",
     "typing_extensions>=4.0"

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 min_version = 4.0
 
 envlist =
-    python3.10-django3.2-wagtail5.2-postgres15
-    python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.0}-postgres15
-    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.0}-postgres15
+    python{3.8,3.9,3.10,3.11,3.12}-django4.2-wagtail{5.2,6.0,6.1}-postgres15
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1}-postgres15
     # note: we're running a subset of the test with sqlite
-    python3.10-django3.2-wagtail5.2-sqlite
-    python3.11-django4.2-wagtail{5.2,6.0}-sqlite
-    python3.12-django5.0-wagtail{5.2,6.0}-sqlite
+    python3.10-django4.2-wagtail5.2-sqlite
+    python3.11-django4.2-wagtail{5.2,6.0,6.1}-sqlite
+    python3.12-django5.0-wagtail{5.2,6.0,6.1}-sqlite
 
 [gh-actions]
 python =
@@ -39,12 +38,12 @@ setenv =
 extras = testing
 
 deps =
-    django3.2: Django>=3.2,<3.3
     django4.2: Django>=4.2,<5.0
     django5.0: Django>=5.0,<5.1
 
     wagtail5.2: wagtail>=5.2.2,<5.3
     wagtail6.0: wagtail>=6.0,<6.1
+    wagtail6.1: wagtail>=6.1,<6.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.9
@@ -94,7 +93,7 @@ basepython = python3.11
 
 # always generate with the min supported versions
 deps =
-    Django>=3.2,<3.3
+    Django>=4.2,<5.0
     wagtail>=5.2,<6.0
 
 commands =

--- a/wagtail_localize/locales/templates/wagtaillocales/confirm_delete.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/confirm_delete.html
@@ -1,22 +1,18 @@
 {% extends "wagtailadmin/generic/confirm_delete.html" %}
 {% load i18n %}
 
-{% block content %}
-    {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
+{% block main_content %}
+    {% if can_delete %}
+        <p>{{ view.confirmation_message }}</p>
 
-    <div class="nice-padding">
-        {% if can_delete %}
-            <p>{{ view.confirmation_message }}</p>
-
-            <form action="{{ view.get_delete_url }}" method="POST">
-                {% csrf_token %}
-                <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
-                <a href="{% url 'wagtaillocales:edit' locale.id %}" class="button button-secondary">{% trans "Back" %}</a>
-            </form>
-        {% else %}
-            <p>{{ view.cannot_delete_message }}</p>
-
+        <form action="{{ view.get_delete_url }}" method="POST">
+            {% csrf_token %}
+            <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
             <a href="{% url 'wagtaillocales:edit' locale.id %}" class="button button-secondary">{% trans "Back" %}</a>
-        {% endif %}
-    </div>
+        </form>
+    {% else %}
+        <p>{{ view.cannot_delete_message }}</p>
+
+        <a href="{% url 'wagtaillocales:edit' locale.id %}" class="button button-secondary">{% trans "Back" %}</a>
+    {% endif %}
 {% endblock %}

--- a/wagtail_localize/tests/test_edit_translation.py
+++ b/wagtail_localize/tests/test_edit_translation.py
@@ -25,7 +25,7 @@ from rest_framework.permissions import (
 )
 from rest_framework.settings import api_settings
 from rest_framework.test import APITestCase
-from wagtail.admin.panels import FieldPanel
+from wagtail.admin.panels import FieldPanel, TitleFieldPanel
 from wagtail.blocks import StreamValue
 from wagtail.documents.models import Document
 from wagtail.images.models import Image
@@ -1506,7 +1506,7 @@ class TestGetEditTranslationView(EditTranslationTestData, TestCase):
         # Hide fields that don't have a panel to edit them with
         previous_panels = TestPage.content_panels
         TestPage.content_panels = [
-            FieldPanel("title"),
+            TitleFieldPanel("title"),
             FieldPanel("test_textfield"),
         ]
         TestPage.get_edit_handler.cache_clear()


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1

# Wagtail 6.1 upgrade check list

<details>
<summary>Code reviewing a consideration.</summary>

Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)

</details>