### PR TITLE
add option for configurable timeout and docs

### DIFF
--- a/docs/how-to/integrations/machine-translation.md
+++ b/docs/how-to/integrations/machine-translation.md
@@ -146,6 +146,7 @@ WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
         "LIBRETRANSLATE_URL": "https://libretranslate.org",  # or your self-hosted instance URL
         # For self-hosted instances without API key setup, use a random string as the API key.
         "API_KEY": "<Your LibreTranslate api key here>",
+        "TIMEOUT": 40 # optional timeout in seconds, defaults to 10
     },
 }
 ```

--- a/wagtail_localize/machine_translators/libretranslate.py
+++ b/wagtail_localize/machine_translators/libretranslate.py
@@ -19,6 +19,9 @@ class LibreTranslator(BaseMachineTranslator):
     def get_api_endpoint(self):
         return self.options["LIBRETRANSLATE_URL"]
 
+    def get_timeout(self):
+        return self.options.get("TIMEOUT", 10)
+
     def language_code(self, code):
         return code.split("-")[0]
 
@@ -35,7 +38,7 @@ class LibreTranslator(BaseMachineTranslator):
                 }
             ),
             headers={"Content-Type": "application/json"},
-            timeout=10,
+            timeout=self.get_timeout(),
         )
         response.raise_for_status()
 


### PR DESCRIPTION
This PR adds an option for the libretranslate machine translator to configure an optional timeout. The hardcoded 10 seconds might not be enough for large pages. The default is now set to 10 seconds.

Also updated the docs to reflect the new setting