### PR TITLE
Add "html" format for libretranslate

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: python -Im pip install --user ruff
+      # keep in sync with .pre-commit-config.yaml
+      - run: python -Im pip install --user ruff==0.4.8
 
       - name: Run ruff
         working-directory: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -13,7 +13,8 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.3.2'
+    # keep in sync with .github/workflows/ruff.yml
+    rev: 'v0.4.8'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/wagtail_localize/machine_translators/libretranslate.py
+++ b/wagtail_localize/machine_translators/libretranslate.py
@@ -32,6 +32,7 @@ class LibreTranslator(BaseMachineTranslator):
                     "source": self.language_code(source_locale.language_code),
                     "target": self.language_code(target_locale.language_code),
                     "api_key": self.options["API_KEY"],
+                    "format": "html",
                 }
             ),
             headers={"Content-Type": "application/json"},

--- a/wagtail_localize/machine_translators/tests/test_libretranslate_translator.py
+++ b/wagtail_localize/machine_translators/tests/test_libretranslate_translator.py
@@ -87,6 +87,7 @@ class TestLibreTranslator(TestCase):
                     "source": "en",
                     "target": "fr",
                     "api_key": LIBRETRANSLATE_SETTINGS_ENDPOINT["OPTIONS"]["API_KEY"],
+                    "format": "html",
                 }
             ),
             headers={"Content-Type": "application/json"},
@@ -139,6 +140,7 @@ class TestLibreTranslator(TestCase):
                     "source": "en",
                     "target": "fr",
                     "api_key": LIBRETRANSLATE_SETTINGS_ENDPOINT["OPTIONS"]["API_KEY"],
+                    "format": "html",
                 }
             ),
             headers={"Content-Type": "application/json"},

--- a/wagtail_localize/modeladmin/tests.py
+++ b/wagtail_localize/modeladmin/tests.py
@@ -214,11 +214,9 @@ class TestModelAdminAdmin(TestCase, WagtailTestUtils):
     def test_get_templates(self):
         def result(action):
             return [
-                "wagtail_localize/modeladmin/wagtail_localize_test/testmodel/translatable_%s.html"
-                % action,
-                "wagtail_localize/modeladmin/wagtail_localize_test/translatable_%s.html"
-                % action,
-                "wagtail_localize/modeladmin/translatable_%s.html" % action,
+                f"wagtail_localize/modeladmin/wagtail_localize_test/testmodel/translatable_{action}.html",
+                f"wagtail_localize/modeladmin/wagtail_localize_test/translatable_{action}.html",
+                f"wagtail_localize/modeladmin/translatable_{action}.html",
             ]
 
         self.assertEqual(self.model_admin.get_templates("index"), result("index"))


### PR DESCRIPTION
This PR fixes #799. 

I haven't found any issues with translating non-html text using this as fix.