### PR TITLE
Add a machine translation option when syncing pages

### DIFF
--- a/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
@@ -49,6 +49,20 @@
                                 </div>
                                 <p class="help">{{ field.help_text }}</p>
                             </li>
+                        {% elif field.name == 'use_machine_translation'%}
+                            {% if machine_translator %}
+                                <li class="use-machine-translation-field">
+                                    <div class="field boolean_field checkbox_input">
+                                        <div class="field-content">
+                                            <div class="input">
+                                                <input type="checkbox" name="{{ field.name }}" id="{{ field.auto_id }}">
+                                                <label class="use-machine-translation-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <p class="help">{{ field.help_text }}</p>
+                                </li>
+                            {% endif %}
                         {% else %}
                             <li>{% include "wagtailadmin/shared/field.html" %}</li>
                         {% endif %}

--- a/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
@@ -49,20 +49,6 @@
                                 </div>
                                 <p class="help">{{ field.help_text }}</p>
                             </li>
-                        {% elif field.name == 'use_machine_translation'%}
-                            {% if machine_translator %}
-                                <li class="use-machine-translation-field">
-                                    <div class="field boolean_field checkbox_input">
-                                        <div class="field-content">
-                                            <div class="input">
-                                                <input type="checkbox" name="{{ field.name }}" id="{{ field.auto_id }}">
-                                                <label class="use-machine-translation-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <p class="help">{{ field.help_text }}</p>
-                                </li>
-                            {% endif %}
                         {% else %}
                             <li>{% include "wagtailadmin/shared/field.html" %}</li>
                         {% endif %}

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -10,7 +10,12 @@ from django.urls import reverse
 from wagtail.models import Locale, Page, PageViewRestriction
 from wagtail.test.utils import WagtailTestUtils
 
-from wagtail_localize.models import StringSegment, Translation, TranslationSource
+from wagtail_localize.models import (
+    StringSegment,
+    StringTranslation,
+    Translation,
+    TranslationSource,
+)
 from wagtail_localize.test.models import NonTranslatableSnippet, TestSnippet
 
 from .utils import assert_permission_denied, make_test_page
@@ -612,3 +617,66 @@ class TestUpdateTranslations(TestCase, WagtailTestUtils):
         )
         # one call from the first post, and one from above
         self.assertEqual(update_target_view_restrictions.call_count, 2)
+
+    def test_post_update_page_translation_with_publish_translations_and_use_machine_translation(
+        self,
+    ):
+        self.en_blog_post.test_charfield = "Edited blog post"
+        self.en_blog_post.save_revision().publish()
+
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+            {
+                "publish_translations": "on",
+                "use_machine_translation": "on",
+            },
+        )
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_explore", args=[self.en_blog_index.id])
+        )
+
+        # The FR version should be translated (Dummy translator will reverse) and updated
+        self.fr_blog_post.refresh_from_db()
+        self.assertEqual(self.fr_blog_post.test_charfield, "post blog Edited")
+
+    def test_post_update_page_translation_with_use_machine_translation(self):
+        self.en_blog_post.test_charfield = "Edited blog post"
+        self.en_blog_post.save_revision().publish()
+
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.page_source.id],
+            ),
+            {
+                "use_machine_translation": "on",
+            },
+        )
+
+        self.assertRedirects(
+            response, reverse("wagtailadmin_explore", args=[self.en_blog_index.id])
+        )
+
+        self.fr_blog_post.refresh_from_db()
+        self.assertEqual(self.fr_blog_post.test_charfield, "Test content")
+
+        # Check that the translation is done, awaiting publication
+        fr = Locale.objects.get(language_code="fr")
+        translation_source = TranslationSource.objects.get_for_instance_or_none(
+            self.en_blog_post
+        )
+        translation = translation_source.translations.get(target_locale=fr)
+
+        string_segment = translation.source.stringsegment_set.get(
+            string__data="Edited blog post"
+        )
+        string_translation = StringTranslation.objects.get(
+            translation_of_id=string_segment.string_id,
+            locale=fr,
+            context_id=string_segment.context_id,
+        )
+        self.assertEqual(string_translation.data, "post blog Edited")

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.forms.widgets import CheckboxInput, HiddenInput
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from wagtail.models import Locale, Page, PageViewRestriction
@@ -617,6 +618,39 @@ class TestUpdateTranslations(TestCase, WagtailTestUtils):
         )
         # one call from the first post, and one from above
         self.assertEqual(update_target_view_restrictions.call_count, 2)
+
+    @mock.patch(
+        "wagtail_localize.views.update_translations.HAS_MACHINE_TRANSLATOR", False
+    )
+    def test_update_translations_form_without_machine_translator(self):
+        response = self.client.get(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.snippet_source.id],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIsInstance(
+            response.context["form"].fields["use_machine_translation"].widget,
+            HiddenInput,
+        )
+
+    def test_update_translations_form_with_machine_translator(self):
+        response = self.client.get(
+            reverse(
+                "wagtail_localize:update_translations",
+                args=[self.snippet_source.id],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIsInstance(
+            response.context["form"].fields["use_machine_translation"].widget,
+            CheckboxInput,
+        )
 
     def test_post_update_page_translation_with_publish_translations_and_use_machine_translation(
         self,

--- a/wagtail_localize/views/update_translations.py
+++ b/wagtail_localize/views/update_translations.py
@@ -25,13 +25,14 @@ from wagtail_localize.views.submit_translations import TranslationComponentManag
 
 if get_machine_translator():
     PUBLISH_TRANSLATIONS_HELP = (
-        "Select this to publish immediately. Changes will be published "
-        "in the original language unless you also select use machine translation."
+        "Apply the updates and publish immediately. The changes will use "
+        "the original language until translated unless you also select "
+        '"Use machine translation".'
     )
 else:
     PUBLISH_TRANSLATIONS_HELP = (
-        "Select this to publish immediately. Changes will be published "
-        "in the original language until you translate and publish them."
+        "Apply the updates and publish immediately. The changes will use "
+        "the original language until translated."
     )
 
 USE_MACHINE_TRANSLATION_HELP = "Apply machine translations to the incoming changes."


### PR DESCRIPTION
This PR adds an option for machine translation to be performed when synicing page translations as per issue:
[#786](https://github.com/wagtail/wagtail-localize/issues/786#issue-2169754390)

It adds the option alongside the existing 'publish immediately' option as I found that these can be made to work togther in all combinations:
 - sync only
 - sync and publish without machine translation
 - sync and publish with machine tranlation
 - sync with machine translation (unpublished but ready for review)

This is slightly as odds with what was discussed on the ticket. However, I'm hopeful that the extra flexibility will be welcome. 