### PR TITLE
[chore] Tooling tweaks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+concurrency = multiprocessing, thread
 include = wagtail_localize/*
 omit = **/migrations/*,**/tests/*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '**/pyproject.toml'
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v4
 
       # keep in sync with .pre-commit-config.yaml
-      - run: python -Im pip install --user ruff==0.4.8
+      - run: python -Im pip install --user ruff==0.6.1
 
       - name: Run ruff
         working-directory: .
-        run: ruff --output-format=github wagtail_localize
+        run: ruff check --output-format=github wagtail_localize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
       - 'stable/**'
-
   pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
 
 env:
   FORCE_COLOR: '1' # Make tools pretty.
@@ -18,9 +20,6 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: '1'
   PIP_NO_PYTHON_VERSION_WARNING: '1'
   PYTHON_LATEST: '3.11'
-
-permissions:
-  contents: read # to fetch code (actions/checkout)
 
 jobs:
   test-sqlite:
@@ -33,17 +32,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          python -m pip install --upgrade uv
+          python -m uv pip install setuptools wheel tox tox-gh-actions
       - name: Test with tox
-        run: tox -- -v1
+        run: tox -q -- -v1
         env:
           DATABASE: sqlite
+      - name: ⬆️ Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python }}-sqlite
+          path: .coverage.*
+          if-no-files-found: ignore
+          retention-days: 1
 
   test-postgres:
     runs-on: ubuntu-latest
@@ -72,19 +78,27 @@ jobs:
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         id: install-dependencies
         run: |
-          python -m pip install --upgrade pip tox tox-gh-actions
+          python -Im pip install --upgrade uv
+          python -Im uv pip install setuptools wheel tox tox-gh-actions
       - name: Test with tox
-        run: tox -- -v1
+        run: tox -q -- -v1
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
           DATABASE: postgres
+      - name: ⬆️ Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python }}-postgres
+          path: .coverage.*
+          if-no-files-found: ignore
+          retention-days: 1
 
   coverage:
     runs-on: ubuntu-latest
@@ -93,23 +107,34 @@ jobs:
       - test-postgres
     strategy:
       matrix:
-        python: ['3.11']
+        python: ['3.12']
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          # Use latest Python, so it understands all syntax.
+          python-version: ${{env.PYTHON_LATEST}}
+
       - name: Install dependencies
         run: |
-          python -Im pip install -U flit
-          python -Im pip install "coverage>=7.0,<8.0"
-          flit install --deps production --extras testing
-      - name: Test
+          python -Im pip install --upgrade uv
+          python -Im uv pip install "coverage>=7.0,<8.0"
+
+      - name: ⬇️ Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-data-*
+          merge-multiple: true
+
+      - name: ＋ Combine coverage
         run: |
-          coverage run testmanage.py test
+          python -Im coverage combine
+          python -Im coverage html --skip-covered --skip-empty
+          python -Im coverage report
+
       - name: 'Upload coverage to Codecov'
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # keep in sync with .github/workflows/ruff.yml
-    rev: 'v0.4.8'
+    rev: 'v0.6.1'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ package = skip
 deps =
     coverage>=7.0,<8.0
 commands =
+    python -Im coverage combine
     python -Im coverage report -m
 
 [testenv:wagtailmain]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-min_version = 4.0
+min_version = 4.11
 
 envlist =
     python{3.9,3.10,3.11,3.12}-django4.2-wagtail{5.2,6.1,6.2}-postgres15
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.1,6.2}-postgres15
     python{3.12}-django5.1-wagtail{6.2}-postgres15
     # note: we're running a subset of the test with sqlite
-    python3.11-django4.2-wagtail{5.2,6.1,6.2}-sqlite
-    python3.12-django5.0-wagtail{5.2,6.1,6.2}-sqlite
+    python3.10-django4.2-wagtail{5.2}-sqlite
+    python3.11-django5.0-wagtail{6.1}-sqlite
     python3.12-django5.1-wagtail{6.2}-sqlite
 
 [gh-actions]
@@ -34,6 +34,8 @@ constrain_package_deps = true
 setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_localize}
     PYTHONDEVMODE = 1
+    # use the Python 3.12+ sys.monitoring
+    python3.12: COVERAGE_CORE=sysmon
 
 extras = testing
 
@@ -73,7 +75,7 @@ commands =
 
 [testenv:interactive]
 description = An interactive environment for local testing purposes
-basepython = python3.11
+basepython = python3.12
 deps =
     wagtail>=5.2,<6.3
     Django>=4.2,<5.2

--- a/wagtail_localize/strings.py
+++ b/wagtail_localize/strings.py
@@ -335,12 +335,9 @@ def extract_strings(html):
 
             # Ignore if there are no text nodes
             # This will exclude both <br> tags and empty inline tags
-            if not any(
+            return not any(
                 isinstance(desc, NavigableString) for desc in element.descendants
-            ):
-                return True
-
-            return False
+            )
 
         if ignore_if_at_end(elements[0]):
             wrap(elements[1:])


### PR DESCRIPTION
- tidy up tox.config (includes `COVERAGE_CORE=sysmon` for Python 3.12, which should keep tests speedy)
- use combined coverages from all tests
- add missing token for Codecov
- use uv to install deps
- run tox in quiet mode - less noise, minor speed bump in CI
- bump ruff to latest version