### PR TITLE
Let machine translators skip fields

### DIFF
--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -1417,10 +1417,13 @@ def machine_translate(request, translation_id):
 
         with transaction.atomic():
             for string, contexts in segments.items():
+                if (
+                    translations.get(string) is None
+                    or translations[string].data is None
+                ):
+                    # Don't create a translation if the machine can't provide
+                    continue
                 for string_id, context_id in contexts:
-                    if string not in translations:
-                        # Don't create a translation if the machine can't provide
-                        continue
                     StringTranslation.objects.get_or_create(
                         translation_of_id=string_id,
                         locale=translation.target_locale,

--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -1418,6 +1418,9 @@ def machine_translate(request, translation_id):
         with transaction.atomic():
             for string, contexts in segments.items():
                 for string_id, context_id in contexts:
+                    if string not in translations:
+                        # Don't create a translation if the machine can't provide
+                        continue
                     StringTranslation.objects.get_or_create(
                         translation_of_id=string_id,
                         locale=translation.target_locale,


### PR DESCRIPTION
Currently there is no way to keep a field not translated in case of issues with the machine translator.
Setting the value to an empty StringValue will show the field as translated in the admin.

This patch will let machine translators omit the key value pair to keep the field not translated.

(Sorry for the double PR, had issues with my linter)