### PR TITLE
Add support for syncing translations from unpublished revisions

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -448,7 +448,7 @@ class TranslationSource(models.Model):
         return source, created
 
     @transaction.atomic
-    def update_from_db(self):
+    def update_from_db(self, from_latest_revision=False):
         """
         Retrieves the source instance from the database and updates this TranslationSource
         with its current contents.
@@ -457,6 +457,8 @@ class TranslationSource(models.Model):
             Model.DoesNotExist: If the source instance has been deleted.
         """
         instance = self.get_source_instance()
+        if from_latest_revision and isinstance(instance, RevisionMixin):
+            instance = instance.get_latest_revision_as_object()
 
         if isinstance(instance, ClusterableModel):
             self.content_json = instance.to_json()

--- a/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
@@ -37,7 +37,7 @@
             <ul class="fields">
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}
-                        {% if field.name == 'publish_translations' %}
+                        {% if field.name == 'publish_translations' or field.name == 'from_revision' %}
                             <li class="publish-translations-field">
                                 <div class="field boolean_field checkbox_input">
                                     <div class="field-content">


### PR DESCRIPTION
This is intended to provide for syncing Translation source changes that haven't yet been published.

Currently, once a `TranslationSource` is created it is frozen until the source is published. This can be a problem when a translation is created early in the content creation process: updates to the source cannot be synced until the source is published, which may not be desirable.  
Supporting pre-publish and ongoing draft workflows is essential, imo.

This PR adds another field to the Update Translations form which allows for updating the `TranslationSource` from the latest revision.

The code here is a first draft - a prompt for discussion - because workflow-wise there are things to consider:
- If the source for `TranslationSource` has *never* been published, perhaps we just *always* sync from the latest revision?
- It's potentially surprising when you've previously updated from latest revision and you forget to enable it on the "Update Translations" form (the `TranslationSource` reverts to what is current in source object, which may not be the latest revision.)
- Does Sync from draft option even belong in the "Update Translations" form - would it be better as another option in the header buttons? (assuming draft is draft, and we don't want to put this next to a "Publish immediately" option)

Will add tests if/when an acceptable approach to this is agreed on. 