### PR TITLE
Add more options to the DeepL settings (Fixes #831)

### DIFF
--- a/docs/how-to/integrations/machine-translation.md
+++ b/docs/how-to/integrations/machine-translation.md
@@ -127,6 +127,13 @@ WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
         # Optional DeepL API setting. Accepts "default", "prefer_more" or "prefer_less".\
         # For more information see the API docs https://www.deepl.com/docs-api/translate-text/
         "FORMALITY": "<Your DeepL formality preference here>",
+        # Optional DeepL Glossary IDs by (source, target) language pairs
+        "GLOSSARY_IDS": {
+            ("EN", "ES"): "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            ("EN", "FR"): "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        },
+        # Optional timeout for the request to the DeepL API
+        "TIMEOUT": 30,
     },
 }
 ```

--- a/wagtail_localize/machine_translators/tests/test_deepl_translator.py
+++ b/wagtail_localize/machine_translators/tests/test_deepl_translator.py
@@ -33,6 +33,28 @@ DEEPL_SETTINGS_WITH_UNSUPPORTED_FORMALITY = {
     },
 }
 
+DEEPL_SETTINGS_WITH_GLOSSARY_IDS = {
+    "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
+    "OPTIONS": {
+        "AUTH_KEY": "asd-23-ssd-243-adsf-dummy-auth-key:bla",
+        "GLOSSARY_IDS": {
+            ("EN", "DE"): "test-id-de",
+            ("EN", "FR"): "test-id-fr",
+        },
+    },
+}
+
+DEEPL_SETTINGS_WITH_MISSING_GLOSSARY_IDS = {
+    "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
+    "OPTIONS": {
+        "AUTH_KEY": "asd-23-ssd-243-adsf-dummy-auth-key:bla",
+        "GLOSSARY_IDS": {
+            ("EN", "FR"): "test-id-fr",
+            ("EN", "DE"): "test-id-de",
+        },
+    },
+}
+
 
 class TestDeeplTranslator(TestCase):
     @override_settings(WAGTAILLOCALIZE_MACHINE_TRANSLATOR=DEEPL_SETTINGS_FREE_ENDPOINT)
@@ -120,3 +142,36 @@ class TestDeeplTranslator(TestCase):
         for code, expected_value in mapping.items():
             with self.subTest(f"Testing language_code with {code} as target"):
                 self.assertEqual(expected_value, language_code(code, is_target=True))
+
+    @override_settings(
+        WAGTAILLOCALIZE_MACHINE_TRANSLATOR=DEEPL_SETTINGS_WITH_GLOSSARY_IDS
+    )
+    @patch("requests.post")
+    def test_translate_with_glossary_ids(self, mock_post):
+        translator = get_machine_translator()
+        source_locale = Mock(language_code="en")
+        target_locale = Mock(language_code="de")
+        strings = [StringValue("Test string")]
+
+        translator.translate(source_locale, target_locale, strings)
+
+        mock_post.assert_called_once()
+        called_args, called_kwargs = mock_post.call_args
+        self.assertIn("glossary_id", called_args[1])
+        self.assertEqual(called_args[1]["glossary_id"], "test-id-de")
+
+    @override_settings(
+        WAGTAILLOCALIZE_MACHINE_TRANSLATOR=DEEPL_SETTINGS_WITH_MISSING_GLOSSARY_IDS
+    )
+    @patch("requests.post")
+    def test_translate_with_missing_glossary_ids(self, mock_post):
+        translator = get_machine_translator()
+        source_locale = Mock(language_code="en")
+        target_locale = Mock(language_code="es")
+        strings = [StringValue("Test string")]
+
+        translator.translate(source_locale, target_locale, strings)
+
+        mock_post.assert_called_once()
+        called_args, called_kwargs = mock_post.call_args
+        self.assertNotIn("glossary_id", called_args[1])


### PR DESCRIPTION
- Add the ability to configure glossaries by (source, target) language pairs.
- Add the ability to configure the timeout instead of having it hardcoded to 30.
- Add tests for the new glossary options.
- Update docs for the new options.

Fixes #831

---

I've also extracted constructing the parameters into a separate method. This way if anyone else needs even more advanced customizations of the parameters it's easier to extend:

```python
from wagtail_localize.machine_translators.deepl import DeepLTranslator


class CustomDeepLTranslator(DeepLTranslator):
    def get_parameters(self, source_locale, target_locale, strings):
        parameters = super().get_parameters(source_locale, target_locale, strings)
        parameters["another_option"] = "My custom value"
        return parameters
```