### PR TITLE
Some small gotcha with snippets

### DIFF
--- a/docs/how-to/tips.md
+++ b/docs/how-to/tips.md
@@ -1,0 +1,19 @@
+# Snippets and Synchronization
+Imagine you have a page with related tags added via snippets, and you want to query all pages with a specific tag.
+
+When synchronous translation is enabled, the tag will refer to the default language. However, if the user turns off
+synchronous translation, the tag will refer to the page’s language. This could mean the user references a translated tag
+within the translated page, causing the query to miss some pages tagged with the original tag.
+
+To solve this, you can query both the default language and the current language, then filter based on the active
+language.
+
+```python
+def get_something(request, tag):
+  lang = request.LANGUAGE_CODE
+  default_tag = tag.get_translation(tag.get_default_locale())
+  pages = SomePage.objects.live().filter(
+    Q(locale__language_code=lang),
+    Q(category__tags=default_tag) | Q(category__tags=tag)
+  ).distinct()
+```

--- a/docs/how-to/tips.md
+++ b/docs/how-to/tips.md
@@ -14,6 +14,6 @@ def get_something(request, tag):
   default_tag = tag.get_translation(tag.get_default_locale())
   pages = SomePage.objects.live().filter(
     Q(locale__language_code=lang),
-    Q(category__tags=default_tag) | Q(category__tags=tag)
+    Q(tags=default_tag) | Q(tags=tag)
   ).distinct()
 ```


### PR DESCRIPTION
When using snippets and translations there is a gotcha you might encounter. This might save somebody couple of hours figuring it out.

Imagine you have a page with related tags added via snippets, and you want to query all pages with a specific tag.

When synchronous translation is enabled, the tag will refer to the default language. However, if the user turns off
synchronous translation, the tag will refer to the page’s language. This could mean the user references a translated tag
within the translated page, causing the query to miss some pages tagged with the original tag.

To solve this, you can query both the default language and the current language, then filter based on the active
language.