### PR TITLE
Fixed IndexError when a translation with overridden and unchanged Chooser inside a ListBlock is published

### DIFF
--- a/wagtail_localize/segments/ingest.py
+++ b/wagtail_localize/segments/ingest.py
@@ -212,9 +212,10 @@ class StreamFieldSegmentsWriter:
 
         for block_index, block in enumerate(list_block.bound_blocks):
             block_segments = segments_by_block[block.id]
-            list_block.bound_blocks[block_index].value = self.handle_block(
-                block.block, block.value, block_segments
-            )
+            if len(block_segments):
+                list_block.bound_blocks[block_index].value = self.handle_block(
+                    block.block, block.value, block_segments
+                )
 
         return list_block
 


### PR DESCRIPTION
This affected all `Chooser`s inside a `ListBlock` , when only one of them is translated and the other kept unchanged.
I added a simple empty check to `handle_list_block` so that `self.handle_block` is not called when there are no `block_segments` , which was causing the `IndexError` later. This fixes #855.

Added two Tests. One with images in a list where only one is changed and another one for a list with `PageChooserBlock`s. Might be redundant, but I wanted to test that this issue is with all choosers and not just the `PageChooserBlock` where we encountered it.