### PR TITLE
Fix regression in InlinePanel handling on Wagtail 6.5a0

### DIFF
--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -256,8 +256,7 @@ class TabHelper:
             elif (
                 isinstance(edit_handler, InlinePanel) and edit_handler.model is not None
             ):
-                # we can only reliably get panel definitions with the relevant instance data in Wagtail 3.0+
-                for panel in edit_handler.panel_definitions:
+                for panel in edit_handler.child_edit_handler.children:
                     walk(panel)
 
         walk(self.edit_handler)


### PR DESCRIPTION
Fix regression that appeared against Wagtail main following https://github.com/wagtail/wagtail/commit/96f9ebe3f6846099641e4b2d49e3e8f9f34aea59 (https://github.com/wagtail/wagtail-localize/actions/runs/14027070555/job/39267538142).

`TabHelper.field_edit_handler_mapping` walks the tree of panels / edit handlers to build a lookup table based on field name. However, when it encountered an InlinePanel, it followed the `panel_definitions` attribute, whose members are taken directly from the model's `panels` definition and contain no reference to the corresponding model.

Prior to https://github.com/wagtail/wagtail/commit/96f9ebe3f6846099641e4b2d49e3e8f9f34aea59, wagtail-localize was able to call `get_form_options` on those unbound panel instances and get a result (and even a usable one, because it only cares about the `widget` item - although it could have got that directly from the panel's `widget` attribute instead of going through `get_form_options`). After this commit, `get_form_options` no longer works on unbound panel instances, because it looks at self.db_field, which is invalid without a model.

Fix this by updating `TabHelper.field_edit_handler_mapping` to follow `child_edit_handler.children` instead (which does correctly keep track of the model).