### PR TITLE
Normalize whitespace in StringTranslation data processing

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -1,4 +1,5 @@
 import json
+import re
 import uuid
 
 import polib
@@ -67,6 +68,9 @@ from .segments.extract import extract_segments
 from .segments.ingest import ingest_segments
 from .strings import StringValue, validate_translation_links
 from .tasks import background
+
+
+WHITESPACE_RE = WHITESPACE_RE = re.compile(r"[ \t\n\f\r]+")
 
 
 def pk(obj):
@@ -1707,6 +1711,13 @@ class StringTranslation(models.Model):
         Returns:
             String: The String instance that corresponds with the given stringvalue and locale.
         """
+
+        # normalise whitespace sequences to a single space unless whitespace is contained in <pre> tag,
+        # in which case, leave it alone
+        # This is in line with https://www.w3.org/TR/html4/struct/text.html#h-9.1
+
+        data = re.sub(WHITESPACE_RE, " ", data)
+
         segment, created = cls.objects.get_or_create(
             translation_of=translation_of,
             locale_id=pk(locale),


### PR DESCRIPTION
Fix: Normalize Strings Before Insertion and Querying

Issue Reference: [#838](https://github.com/wagtail/wagtail-localize/issues/838)

This PR addresses an issue where certain string segments reset after synchronization and publishing due to inconsistencies in how they are stored and queried from templates.