### PR TITLE
Sets the DeepL API key in the HTTP authorisation header

### DIFF
--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -33,7 +33,6 @@ class DeepLTranslator(BaseMachineTranslator):
         target_lang = language_code(target_locale.language_code, is_target=True)
 
         parameters = {
-            "auth_key": self.options["AUTH_KEY"],
             "text": [string.data for string in strings],
             "tag_handling": "xml",
             "source_lang": source_lang,

--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -60,11 +60,18 @@ class DeepLTranslator(BaseMachineTranslator):
 
         return parameters
 
+    def get_headers(self):
+        return {
+            "Content-Type": "application/json",
+            "Authorization": f"DeepL-Auth-Key {self.options['AUTH_KEY']}",
+        }
+
     def translate(self, source_locale, target_locale, strings):
         response = requests.post(
             self.get_api_endpoint(),
             self.get_parameters(source_locale, target_locale, strings),
             timeout=int(self.options.get("TIMEOUT", 30)),
+            headers=self.get_headers(),
         )
 
         return {

--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -61,7 +61,6 @@ class DeepLTranslator(BaseMachineTranslator):
 
     def get_headers(self):
         return {
-            "Content-Type": "application/json",
             "Authorization": f"DeepL-Auth-Key {self.options['AUTH_KEY']}",
         }
 


### PR DESCRIPTION
With this PR the DeepL API key is set within the HTTP authorisation headers, which could've been set in the request body in the earlier DeepL API versions. Since March 2025, due to security enforcements, this approach is forbidden.

This PR fixes the #869 .