### PR TITLE
Fix error preventing translating with empty EmbededBlock

### DIFF
--- a/wagtail_localize/segments/extract.py
+++ b/wagtail_localize/segments/extract.py
@@ -48,7 +48,7 @@ class StreamFieldSegmentExtractor:
             from wagtail.embeds.blocks import EmbedBlock
 
             if isinstance(block_type, EmbedBlock):
-                if self.include_overridables:
+                if self.include_overridables and block_value:
                     return [OverridableSegmentValue("", block_value.url)]
                 else:
                     return []


### PR DESCRIPTION
This PR fixes #875

When an embed block is added as a non-required child of another block, the translation can't be created.