### PR TITLE
UpdateTranslationsView: sync draft content if available

### DIFF
--- a/wagtail_localize/views/update_translations.py
+++ b/wagtail_localize/views/update_translations.py
@@ -153,7 +153,10 @@ class UpdateTranslationsView(SingleObjectMixin, TemplateView):
 
     @transaction.atomic
     def form_valid(self, form):
-        self.object.update_from_db()
+        # To avoid the unintentional publication of draft content from the source, we only use live content if publication is requested.
+        self.object.update_from_db(
+            use_draft_content=not form.cleaned_data["publish_translations"]
+        )
 
         enabled_translations = self.object.translations.filter(enabled=True)
         if form.cleaned_data.get("use_machine_translation"):


### PR DESCRIPTION
As noted in https://github.com/wagtail/wagtail-localize/issues/823#issuecomment-2479458882 the draft content is not synced, when the "Sync translated pages" action is used.
This allows to change/prepare the content of a source object, without publishing it (yet), and further sync those changes to the translations to prepare those changes to be published later all at once.

I've deviated slightly [from my suggestion to introduce a new setting](https://github.com/wagtail/wagtail-localize/issues/823#issuecomment-3421150938). Instead, the sync only uses the draft content if the "Publish immediately" checkbox is not checked.

What do you think about it? Better use a setting and disable that functionality by default?

Fixes #823