### PR TITLE
Fix some UI issues in the footer's action menu

### DIFF
--- a/wagtail_localize/static_src/editor/components/TranslationEditor/footer.tsx
+++ b/wagtail_localize/static_src/editor/components/TranslationEditor/footer.tsx
@@ -15,47 +15,32 @@ const EditorFooter: FunctionComponent<EditorProps> = ({
     locale,
 }) => {
     let actions = [
-        <form method="POST" action={links.stopTranslationUrl}>
-            <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
-            <input type="hidden" name="next" value={window.location.href} />
-
-            <button
-                type="submit"
-                className="button button-longrunning action-secondary"
-                data-controller="w-progress"
-                data-action="w-progress#activate"
-                data-w-progress-active-value={gettext(
-                    'Stopping Synced translation'
-                )}
-            >
-                <Icon name="cross" />
-                <em data-w-progress-target="label">
-                    {gettext('Stop Synced translation')}
-                </em>
-            </button>
-        </form>,
+        <button
+            type="submit"
+            className="button button-longrunning action-secondary"
+            data-controller="w-progress w-action"
+            data-action="w-progress#activate w-action#post"
+            data-w-progress-active-value={gettext(
+                'Stopping Synced translation'
+            )}
+            data-w-action-url-value={links.stopTranslationUrl}
+        >
+            <Icon name="cross" />
+            <em data-w-progress-target="label">
+                {gettext('Stop Synced translation')}
+            </em>
+        </button>,
     ];
 
     if (links.convertToAliasUrl) {
         actions.push(
-            <form method="GET" action={links.convertToAliasUrl}>
-                <input type="hidden" name="next" value={window.location.href} />
-
-                <button
-                    type="submit"
-                    className="button button-longrunning action-secondary"
-                    data-controller="w-progress"
-                    data-action="w-progress#activate"
-                    data-w-progress-active-value={gettext(
-                        'Converting to alias page'
-                    )}
-                >
-                    <Icon name="wagtail-localize-convert" />
-                    <em data-w-progress-target="label">
-                        {gettext('Convert to alias page')}
-                    </em>
-                </button>
-            </form>
+            <a
+                className="button action-secondary"
+                href={`${links.convertToAliasUrl}?next=${window.location.href}`}
+            >
+                <Icon name="wagtail-localize-convert" />
+                {gettext('Convert to alias page')}
+            </a>
         );
     }
 
@@ -70,53 +55,33 @@ const EditorFooter: FunctionComponent<EditorProps> = ({
 
     if (perms.canLock && !isLocked) {
         actions.push(
-            <form method="POST" action={links.lockUrl}>
-                <input
-                    type="hidden"
-                    name="csrfmiddlewaretoken"
-                    value={csrfToken}
-                />
-                <input type="hidden" name="next" value={window.location.href} />
-
-                <button
-                    type="submit"
-                    className="button button-longrunning action-secondary"
-                    data-controller="w-progress"
-                    data-action="w-progress#activate"
-                    data-w-progress-active-value={gettext(
-                        'Applying editor lock'
-                    )}
-                >
-                    <Icon name="lock" />
-                    <em data-w-progress-target="label">{gettext('Lock')}</em>
-                </button>
-            </form>
+            <button
+                type="submit"
+                className="button button-longrunning action-secondary"
+                data-controller="w-progress w-action"
+                data-action="w-progress#activate w-action#post"
+                data-w-progress-active-value={gettext('Applying editor lock')}
+                data-w-action-url-value={links.lockUrl}
+            >
+                <Icon name="lock" />
+                <em data-w-progress-target="label">{gettext('Lock')}</em>
+            </button>
         );
     }
 
     if (perms.canUnlock && isLocked) {
         actions.push(
-            <form method="POST" action={links.unlockUrl}>
-                <input
-                    type="hidden"
-                    name="csrfmiddlewaretoken"
-                    value={csrfToken}
-                />
-                <input type="hidden" name="next" value={window.location.href} />
-
-                <button
-                    type="submit"
-                    className="button button-longrunning action-secondary"
-                    data-controller="w-progress"
-                    data-action="w-progress#activate"
-                    data-w-progress-active-value={gettext(
-                        'Removing editor lock'
-                    )}
-                >
-                    <Icon name="lock-open" />
-                    <em data-w-progress-target="label">{gettext('Unlock')}</em>
-                </button>
-            </form>
+            <button
+                type="submit"
+                className="button button-longrunning action-secondary"
+                data-controller="w-progress w-action"
+                data-action="w-progress#activate w-action#post"
+                data-w-progress-active-value={gettext('Removing editor lock')}
+                data-w-action-url-value={links.unlockUrl}
+            >
+                <Icon name="lock-open" />
+                <em data-w-progress-target="label">{gettext('Unlock')}</em>
+            </button>
         );
     }
 


### PR DESCRIPTION
- This mostly replaces forms with w-action controllers.
- The convert-to-alias button used a form unnecessarily (it's just a link to a separate page).
- I've tested it with 6.3, 7.0 and 7.1 (bakerydemo)

**TODO:** Unfortunately the `w-action` controller does not support an "action" form field and therefore the publish-form is still required. So this minor UI issue remains as seen below (without the form the button container would be have the same width as the dropdown). It probably requires css fixes, where I'm not an expert in.
<img width="399" height="273" alt="Bildschirmfoto vom 2025-10-21 10-30-55" src="https://github.com/user-attachments/assets/996eb6c2-5159-49e1-9bb7-d16c5e0e99db" />


Relates to #885