### PR TITLE
Added support for SynchronizedField on ManyToManyFields

### DIFF
--- a/wagtail_localize/fields.py
+++ b/wagtail_localize/fields.py
@@ -292,6 +292,11 @@ def copy_synchronised_fields(source, target):
                     if values:
                         setattr(target, field.attname, values)
 
+            elif isinstance(field, models.ManyToManyField):
+                source_manager = getattr(source, field.name)
+                target_manager = getattr(target, field.name)
+                target_manager.set(source_manager.all())
+
             else:
                 # For all other fields, just set the attribute
                 setattr(target, field.attname, getattr(source, field.attname))

--- a/wagtail_localize/fields.py
+++ b/wagtail_localize/fields.py
@@ -293,6 +293,9 @@ def copy_synchronised_fields(source, target):
                         setattr(target, field.attname, values)
 
             elif isinstance(field, models.ManyToManyField):
+                if target.pk is None:
+                    continue
+
                 source_manager = getattr(source, field.name)
                 target_manager = getattr(target, field.name)
                 target_manager.set(source_manager.all())

--- a/wagtail_localize/test/migrations/0001_initial.py
+++ b/wagtail_localize/test/migrations/0001_initial.py
@@ -2273,4 +2273,44 @@ class Migration(migrations.Migration):
                 "unique_together": {("translation_key", "locale")},
             },
         ),
+        migrations.CreateModel(
+            name="TestM2MSnippet",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "translation_key",
+                    models.UUIDField(default=uuid.uuid4, editable=False),
+                ),
+                ("title", models.CharField(blank=True, max_length=255)),
+                (
+                    "locale",
+                    models.ForeignKey(
+                        editable=False,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="wagtailcore.locale",
+                    ),
+                ),
+                (
+                    "m2m_field",
+                    models.ManyToManyField(
+                        blank=True,
+                        related_name="m2m_snippets",
+                        to="wagtail_localize_test.nontranslatablesnippet",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+                "unique_together": {("translation_key", "locale")},
+            },
+        ),
     ]

--- a/wagtail_localize/test/models.py
+++ b/wagtail_localize/test/models.py
@@ -145,6 +145,33 @@ class NonTranslatableSnippet(models.Model):
         return self.field
 
 
+@register_snippet
+class TestM2MSnippet(TranslatableMixin, models.Model):
+    """
+    A snippet with a regular ManyToManyField to test synchronization.
+    """
+
+    title = models.CharField(max_length=255, blank=True)
+    m2m_field = models.ManyToManyField(
+        NonTranslatableSnippet,
+        blank=True,
+        related_name="m2m_snippets",
+    )
+
+    translatable_fields = [
+        TranslatableField("title"),
+        SynchronizedField("m2m_field"),
+    ]
+
+    panels = [
+        FieldPanel("title"),
+        FieldPanel("m2m_field"),
+    ]
+
+    def __str__(self):
+        return self.title or f"TestM2MSnippet ({self.pk})"
+
+
 class TestStructBlock(blocks.StructBlock):
     field_a = blocks.TextBlock()
     field_b = blocks.TextBlock()

--- a/wagtail_localize/tests/test_get_translatable_fields.py
+++ b/wagtail_localize/tests/test_get_translatable_fields.py
@@ -1,12 +1,16 @@
 from django.test import TestCase
+from wagtail.models import Locale
 
 from wagtail_localize.fields import (
     SynchronizedField,
     TranslatableField,
+    copy_synchronised_fields,
     get_translatable_fields,
 )
 from wagtail_localize.test.models import (
+    NonTranslatableSnippet,
     TestGenerateTranslatableFieldsPage,
+    TestM2MSnippet,
     TestOverrideTranslatableFieldsPage,
 )
 
@@ -71,3 +75,104 @@ class TestOverrideTranslatableFields(TestCase):
                 SynchronizedField("test_nontranslatable_childobjects"),
             ],
         )
+
+
+class TestCopySynchronisedFieldsWithManyToMany(TestCase):
+    """Tests for copy_synchronised_fields with ManyToManyField."""
+
+    def setUp(self):
+        self.src_locale = Locale.get_default()
+        self.dest_locale = Locale.objects.create(language_code="fr")
+
+        # Create some NonTranslatableSnippet instances to use in M2M relations
+        self.snippet1 = NonTranslatableSnippet.objects.create(field="Snippet 1")
+        self.snippet2 = NonTranslatableSnippet.objects.create(field="Snippet 2")
+        self.snippet3 = NonTranslatableSnippet.objects.create(field="Snippet 3")
+
+    def test_m2m_field_is_synchronized_when_set_as_synchronized_field(self):
+        """
+        Test that ManyToManyField values are copied when the field is
+        explicitly set as a SynchronizedField.
+        """
+        # Create source snippet with M2M relations
+        source = TestM2MSnippet.objects.create(
+            title="Source Snippet",
+            locale=self.src_locale,
+        )
+        source.m2m_field.set([self.snippet1, self.snippet2])
+
+        # Create target snippet (translation)
+        target = TestM2MSnippet.objects.create(
+            title="Target Snippet",
+            locale=self.dest_locale,
+            translation_key=source.translation_key,
+        )
+
+        # Verify target has no M2M relations initially
+        self.assertEqual(target.m2m_field.count(), 0)
+
+        # Copy synchronized fields
+        copy_synchronised_fields(source, target)
+
+        # Verify M2M relations were copied
+        self.assertEqual(target.m2m_field.count(), 2)
+        self.assertIn(self.snippet1, target.m2m_field.all())
+        self.assertIn(self.snippet2, target.m2m_field.all())
+
+    def test_m2m_field_sync_replaces_existing_relations(self):
+        """
+        Test that synchronizing M2M fields replaces existing relations
+        on the target with those from the source.
+        """
+        source = TestM2MSnippet.objects.create(
+            title="Source Snippet",
+            locale=self.src_locale,
+        )
+        source.m2m_field.set([self.snippet1, self.snippet2])
+
+        target = TestM2MSnippet.objects.create(
+            title="Target Snippet",
+            locale=self.dest_locale,
+            translation_key=source.translation_key,
+        )
+        # Set different M2M relations on target
+        target.m2m_field.set([self.snippet3])
+
+        # Verify target has different relations
+        self.assertEqual(target.m2m_field.count(), 1)
+        self.assertIn(self.snippet3, target.m2m_field.all())
+
+        # Copy synchronized fields
+        copy_synchronised_fields(source, target)
+
+        # Verify M2M relations were replaced with source's relations
+        self.assertEqual(target.m2m_field.count(), 2)
+        self.assertIn(self.snippet1, target.m2m_field.all())
+        self.assertIn(self.snippet2, target.m2m_field.all())
+        self.assertNotIn(self.snippet3, target.m2m_field.all())
+
+    def test_m2m_field_sync_with_empty_source(self):
+        """
+        Test that synchronizing clears target M2M relations when source has none.
+        """
+        source = TestM2MSnippet.objects.create(
+            title="Source Snippet",
+            locale=self.src_locale,
+        )
+        # Source has no M2M relations
+
+        target = TestM2MSnippet.objects.create(
+            title="Target Snippet",
+            locale=self.dest_locale,
+            translation_key=source.translation_key,
+        )
+        target.m2m_field.set([self.snippet1, self.snippet2])
+
+        # Verify target has relations
+        self.assertEqual(target.m2m_field.count(), 2)
+
+        # Copy synchronized fields
+        copy_synchronised_fields(source, target)
+
+        # Verify M2M relations were cleared
+        self.assertEqual(target.m2m_field.count(), 0)

--- a/wagtail_localize/tests/test_get_translatable_fields.py
+++ b/wagtail_localize/tests/test_get_translatable_fields.py
@@ -151,6 +151,20 @@ class TestCopySynchronisedFieldsWithManyToMany(TestCase):
         self.assertIn(self.snippet2, target.m2m_field.all())
         self.assertNotIn(self.snippet3, target.m2m_field.all())
 
+    def test_str_with_title(self):
+        snippet = TestM2MSnippet.objects.create(
+            title="My Snippet",
+            locale=self.src_locale,
+        )
+        self.assertEqual(str(snippet), "My Snippet")
+
+    def test_str_without_title(self):
+        snippet = TestM2MSnippet.objects.create(
+            title="",
+            locale=self.src_locale,
+        )
+        self.assertEqual(str(snippet), f"TestM2MSnippet ({snippet.pk})")
+
     def test_m2m_field_sync_with_empty_source(self):
         """
         Test that synchronizing clears target M2M relations when source has none.

--- a/wagtail_localize/tests/test_get_translatable_fields.py
+++ b/wagtail_localize/tests/test_get_translatable_fields.py
@@ -190,3 +190,24 @@ class TestCopySynchronisedFieldsWithManyToMany(TestCase):
 
         # Verify M2M relations were cleared
         self.assertEqual(target.m2m_field.count(), 0)
+
+    def test_m2m_field_sync_skips_unsaved_target(self):
+        """
+        Test that synchronizing does not error when target has not been saved yet.
+        """
+        source = TestM2MSnippet.objects.create(
+            title="Source Snippet",
+            locale=self.src_locale,
+        )
+        source.m2m_field.set([self.snippet1, self.snippet2])
+
+        # Create an unsaved target instance.
+        target = TestM2MSnippet(
+            title="Unsaved target",
+            locale=self.dest_locale,
+            translation_key=source.translation_key,
+        )
+        self.assertIsNone(target.pk)
+
+        # Before the early exit, this raised ValueError from M2M manager usage.
+        copy_synchronised_fields(source, target)


### PR DESCRIPTION
This PR lets users set a ManyToManyField as a SynchronizedField without recieving the error:
> Direct assignment to the forward side of a many-to-many set is prohibited. Use model_name.set() instead.

This does not solve the issue of whether a ManyToMany field should be translatable or syncronized, but gives the option for the user to syncronize it without errors.

This PR adds:
 - the code changes to handle many to many fields
 - a snippet model to test ManyToMany fields (with its migration)
 - 3 unit tests to check if the SynchronizedField is respected correctly for ManyToMany