### PR TITLE
896 - When A Related Object Has No Translation, Use Origin Locale Fallback

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -693,8 +693,16 @@ class TranslationSource(models.Model):
                 segments.append(segment_value)
 
             elif fallback:
-                # Skip this segment, this will reuse what is already in the database
-                continue
+                # Use source locale object as fallback when target doesn't exist
+                source_instance = related_object_segment.object.get_instance(
+                    self.locale
+                )
+                segment_value = OverridableSegmentValue(
+                    related_object_segment.context.path,
+                    source_instance.pk,
+                    order=related_object_segment.order,
+                )
+                segments.append(segment_value)
             else:
                 raise MissingRelatedObjectError(related_object_segment, locale)
 


### PR DESCRIPTION
This pull request adresses the issue from #896, and handles the scenario by defaulting to the related object in the origin locale. This is an unusual scenario, but a unit test demonstrates how it can be recreated in a StreamField with only 1 block that is a snippet.

Closes #896