### PR TITLE
Fixes #851 - Missing pagination on locale index view

### DIFF
--- a/wagtail_localize/locales/templates/wagtaillocales/index.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/index.html
@@ -44,4 +44,8 @@
 
         </div>
     </div>
+    {% if is_paginated %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with page_obj=page_obj %}
+    {% endif %}
+
 {% endblock %}

--- a/wagtail_localize/locales/tests.py
+++ b/wagtail_localize/locales/tests.py
@@ -98,29 +98,77 @@ class TestLocaleIndexView(BaseLocaleTestCase):
         self.assertIn(locale, response.context["locales"])
 
     @override_settings(
-    LANGUAGES=[
-        ("en", "English"), ("fr", "French"), ("de", "German"),
-        ("es", "Spanish"), ("it", "Italian"), ("nl", "Dutch"),
-        ("pl", "Polish"), ("sv", "Swedish"), ("da", "Danish"),
-        ("fi", "Finnish"), ("nb", "Norwegian"), ("cs", "Czech"),
-        ("sk", "Slovak"), ("hu", "Hungarian"), ("ro", "Romanian"),
-        ("bg", "Bulgarian"), ("hr", "Croatian"), ("sl", "Slovenian"),
-        ("lt", "Lithuanian"), ("lv", "Latvian"), ("et", "Estonian"),
-    ],
-    WAGTAIL_CONTENT_LANGUAGES=[
-        ("en", "English"), ("fr", "French"), ("de", "German"),
-        ("es", "Spanish"), ("it", "Italian"), ("nl", "Dutch"),
-        ("pl", "Polish"), ("sv", "Swedish"), ("da", "Danish"),
-        ("fi", "Finnish"), ("nb", "Norwegian"), ("cs", "Czech"),
-        ("sk", "Slovak"), ("hu", "Hungarian"), ("ro", "Romanian"),
-        ("bg", "Bulgarian"), ("hr", "Croatian"), ("sl", "Slovenian"),
-        ("lt", "Lithuanian"), ("lv", "Latvian"), ("et", "Estonian"),
-    ]
-)
+        LANGUAGES=[
+            ("en", "English"),
+            ("fr", "French"),
+            ("de", "German"),
+            ("es", "Spanish"),
+            ("it", "Italian"),
+            ("nl", "Dutch"),
+            ("pl", "Polish"),
+            ("sv", "Swedish"),
+            ("da", "Danish"),
+            ("fi", "Finnish"),
+            ("nb", "Norwegian"),
+            ("cs", "Czech"),
+            ("sk", "Slovak"),
+            ("hu", "Hungarian"),
+            ("ro", "Romanian"),
+            ("bg", "Bulgarian"),
+            ("hr", "Croatian"),
+            ("sl", "Slovenian"),
+            ("lt", "Lithuanian"),
+            ("lv", "Latvian"),
+            ("et", "Estonian"),
+        ],
+        WAGTAIL_CONTENT_LANGUAGES=[
+            ("en", "English"),
+            ("fr", "French"),
+            ("de", "German"),
+            ("es", "Spanish"),
+            ("it", "Italian"),
+            ("nl", "Dutch"),
+            ("pl", "Polish"),
+            ("sv", "Swedish"),
+            ("da", "Danish"),
+            ("fi", "Finnish"),
+            ("nb", "Norwegian"),
+            ("cs", "Czech"),
+            ("sk", "Slovak"),
+            ("hu", "Hungarian"),
+            ("ro", "Romanian"),
+            ("bg", "Bulgarian"),
+            ("hr", "Croatian"),
+            ("sl", "Slovenian"),
+            ("lt", "Lithuanian"),
+            ("lv", "Latvian"),
+            ("et", "Estonian"),
+        ],
+    )
     def test_pagination(self):
         # Test that pagination works when there are more than 20 locales
-        for lang in ["fr", "de", "es", "it", "nl", "pl", "sv", "da", "fi",
-                     "nb", "cs", "sk", "hu", "ro", "bg", "hr", "sl", "lt", "lv", "et"]:
+        for lang in [
+            "fr",
+            "de",
+            "es",
+            "it",
+            "nl",
+            "pl",
+            "sv",
+            "da",
+            "fi",
+            "nb",
+            "cs",
+            "sk",
+            "hu",
+            "ro",
+            "bg",
+            "hr",
+            "sl",
+            "lt",
+            "lv",
+            "et",
+        ]:
             Locale.objects.get_or_create(language_code=lang)
 
         response = self.execute_request("GET", "wagtaillocales:index")

--- a/wagtail_localize/locales/tests.py
+++ b/wagtail_localize/locales/tests.py
@@ -97,6 +97,36 @@ class TestLocaleIndexView(BaseLocaleTestCase):
         self.assert_successful_response(response)
         self.assertIn(locale, response.context["locales"])
 
+    @override_settings(
+    LANGUAGES=[
+        ("en", "English"), ("fr", "French"), ("de", "German"),
+        ("es", "Spanish"), ("it", "Italian"), ("nl", "Dutch"),
+        ("pl", "Polish"), ("sv", "Swedish"), ("da", "Danish"),
+        ("fi", "Finnish"), ("nb", "Norwegian"), ("cs", "Czech"),
+        ("sk", "Slovak"), ("hu", "Hungarian"), ("ro", "Romanian"),
+        ("bg", "Bulgarian"), ("hr", "Croatian"), ("sl", "Slovenian"),
+        ("lt", "Lithuanian"), ("lv", "Latvian"), ("et", "Estonian"),
+    ],
+    WAGTAIL_CONTENT_LANGUAGES=[
+        ("en", "English"), ("fr", "French"), ("de", "German"),
+        ("es", "Spanish"), ("it", "Italian"), ("nl", "Dutch"),
+        ("pl", "Polish"), ("sv", "Swedish"), ("da", "Danish"),
+        ("fi", "Finnish"), ("nb", "Norwegian"), ("cs", "Czech"),
+        ("sk", "Slovak"), ("hu", "Hungarian"), ("ro", "Romanian"),
+        ("bg", "Bulgarian"), ("hr", "Croatian"), ("sl", "Slovenian"),
+        ("lt", "Lithuanian"), ("lv", "Latvian"), ("et", "Estonian"),
+    ]
+)
+    def test_pagination(self):
+        # Test that pagination works when there are more than 20 locales
+        for lang in ["fr", "de", "es", "it", "nl", "pl", "sv", "da", "fi",
+                     "nb", "cs", "sk", "hu", "ro", "bg", "hr", "sl", "lt", "lv", "et"]:
+            Locale.objects.get_or_create(language_code=lang)
+
+        response = self.execute_request("GET", "wagtaillocales:index")
+        self.assert_successful_response(response)
+        self.assertTrue(response.context["page_obj"].paginator.num_pages > 1)
+
 
 class TestLocaleCreateView(BaseLocaleTestCase):
     def post(self, post_data=None):

--- a/wagtail_localize/locales/tests.py
+++ b/wagtail_localize/locales/tests.py
@@ -50,7 +50,7 @@ class TestLocaleIndexView(BaseLocaleTestCase):
         # Test if the index view renders successfully
         response = self.execute_request("GET", "wagtaillocales:index")
         self.assert_successful_response(response)
-        self.assertTemplateUsed(response, "wagtaillocales/index.html")
+        self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
 
     def test_context_variables(self):
         # Test if the context variables are present and have the expected types

--- a/wagtail_localize/locales/views.py
+++ b/wagtail_localize/locales/views.py
@@ -73,14 +73,13 @@ class ComponentManager(BaseComponentManager):
 
 
 class IndexView(generic.IndexView):
-    template_name = "wagtaillocales/index.html"
     page_title = gettext_lazy("Locales")
     add_item_label = gettext_lazy("Add a locale")
     context_object_name = "locales"
     queryset = Locale.all_objects.all()
 
-    def get_context_data(self):
-        context = super().get_context_data()
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
         context["wagtail_version"] = get_main_version()
 
         for locale in context["locales"]:


### PR DESCRIPTION
### What
Fixes #851 - The Settings, Locales page was capped at 20 locales with no way to access the rest.

### Why
`IndexView` used a custom template (`wagtaillocales/index.html`) that overrode Wagtail's generic `{% block listing %}` with its own table loop. This bypassed Wagtail's built-in pagination entirely, meaning sites with 21+ locales could not access or manage the hidden ones.

### Fix
- Removed `template_name` from `IndexView` so it uses Wagtail's generic index template, which includes pagination automatically
- Updated the custom template to extend the generic template while preserving the Usage column (page counts per locale)
- Updated `test_simple` to assert the generic template is used instead of the custom one

### Testing
All `TestLocaleIndexView` tests pass:

<img width="1037" height="588" alt="TestLocaleIndexView" src="https://github.com/user-attachments/assets/39f92f60-3d22-4664-948d-070a6fad4200" />
