### PR TITLE
Fixes #669: Log warning when ValidationError occurs during translation.

### DIFF
--- a/wagtail_localize/operations.py
+++ b/wagtail_localize/operations.py
@@ -1,4 +1,4 @@
-import contextlib
+import logging
 
 from collections import defaultdict
 
@@ -8,6 +8,9 @@ from django.db import transaction
 from wagtail.models import DraftStateMixin, Page
 
 from wagtail_localize.models import Translation, TranslationSource
+
+
+logger = logging.getLogger(__name__)
 
 
 class TranslationCreator:
@@ -85,8 +88,15 @@ class TranslationCreator:
                 # If the model can't be saved as a draft, then we have to publish it
                 publish = not isinstance(instance, DraftStateMixin)
 
-            with contextlib.suppress(ValidationError):
+            try:
                 translation.save_target(user=self.user, publish=publish)
+            except ValidationError as e:
+                logger.warning(
+                    "Failed to save translation of %r into %s due to a ValidationError: %s",
+                    instance,
+                    target_locale,
+                    e.messages,
+                )
 
 
 @transaction.atomic

--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -660,6 +660,29 @@ class TestSubmitPageTranslation(WagtailTestUtils, TestCase):
             translated_page.view_restrictions.first().pk, view_restriction.pk
         )
 
+    def test_post_submit_page_translation_logs_warning_on_validation_error(self):
+        """Test that a warning is logged when a ValidationError occurs during translation."""
+        from django.core.exceptions import ValidationError
+
+        with patch(
+            "wagtail_localize.operations.Translation.save_target",
+            side_effect=ValidationError("Test validation error"),
+        ), self.assertLogs(
+            "wagtail_localize.operations", level="WARNING"
+        ) as log_output:
+            self.client.post(
+                reverse(
+                    "wagtail_localize:submit_page_translation",
+                    args=[self.en_blog_index.id],
+                ),
+                {"locales": [self.fr_locale.id]},
+            )
+
+        self.assertTrue(
+            any("ValidationError" in msg for msg in log_output.output)
+        )
+
+
     def test_post_submit_page_translation_from_draft_source_still_draft(self):
         custom_page = make_test_page(
             self.en_homepage,

--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -664,12 +664,15 @@ class TestSubmitPageTranslation(WagtailTestUtils, TestCase):
         """Test that a warning is logged when a ValidationError occurs during translation."""
         from django.core.exceptions import ValidationError
 
-        with patch(
-            "wagtail_localize.operations.Translation.save_target",
-            side_effect=ValidationError("Test validation error"),
-        ), self.assertLogs(
-            "wagtail_localize.operations", level="WARNING"
-        ) as log_output:
+        with (
+            patch(
+                "wagtail_localize.operations.Translation.save_target",
+                side_effect=ValidationError("Test validation error"),
+            ),
+            self.assertLogs(
+                "wagtail_localize.operations", level="WARNING"
+            ) as log_output,
+        ):
             self.client.post(
                 reverse(
                     "wagtail_localize:submit_page_translation",
@@ -678,10 +681,7 @@ class TestSubmitPageTranslation(WagtailTestUtils, TestCase):
                 {"locales": [self.fr_locale.id]},
             )
 
-        self.assertTrue(
-            any("ValidationError" in msg for msg in log_output.output)
-        )
-
+        self.assertTrue(any("ValidationError" in msg for msg in log_output.output))
 
     def test_post_submit_page_translation_from_draft_source_still_draft(self):
         custom_page = make_test_page(

--- a/wagtail_localize/views/submit_translations.py
+++ b/wagtail_localize/views/submit_translations.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from django import forms
 from django.contrib import messages
 from django.contrib.admin.utils import quote, unquote
@@ -147,9 +149,10 @@ class SubmitTranslationView(SingleObjectMixin, TemplateView):
         single_translated_object = None
         if len(form.cleaned_data["locales"]) == 1:
             locales = form.cleaned_data["locales"][0].get_display_name()
-            single_translated_object = self.object.get_translation(
-                form.cleaned_data["locales"][0]
-            )
+            with contextlib.suppress(self.object.__class__.DoesNotExist):
+                single_translated_object = self.object.get_translation(
+                    form.cleaned_data["locales"][0]
+                )
 
         else:
             # Note: always plural

--- a/wagtail_localize/views/submit_translations.py
+++ b/wagtail_localize/views/submit_translations.py
@@ -1,5 +1,3 @@
-import contextlib
-
 from django import forms
 from django.contrib import messages
 from django.contrib.admin.utils import quote, unquote
@@ -149,10 +147,12 @@ class SubmitTranslationView(SingleObjectMixin, TemplateView):
         single_translated_object = None
         if len(form.cleaned_data["locales"]) == 1:
             locales = form.cleaned_data["locales"][0].get_display_name()
-            with contextlib.suppress(self.object.__class__.DoesNotExist):
+            try:  # noqa: SIM105
                 single_translated_object = self.object.get_translation(
                     form.cleaned_data["locales"][0]
                 )
+            except self.object.__class__.DoesNotExist:
+                pass
 
         else:
             # Note: always plural


### PR DESCRIPTION

Previously, when `save_target()` raised a `ValidationError` during translation, the error was silently suppressed. This caused a confusing  `DoesNotExist` error to surface to the user instead of the real cause.

### Changes
- `operations.py`: replaced `contextlib.suppress(ValidationError)` with a  `logger.warning()` so the actual error is visible in logs.
- `views/submit_translations.py`: wrapped `get_translation()` with  `contextlib.suppress(DoesNotExist)` so the view degrades gracefully when `save_target()` fails
- Added a test to verify the warning is logged