### PR TITLE
feat: render non-field error messages in locale forms and component 

### DIFF
--- a/wagtail_localize/locales/templates/wagtaillocales/edit.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/edit.html
@@ -27,6 +27,12 @@
             {% endblock %}
 
             <ul class="fields">
+                {% for error in form.non_field_errors %}
+                    <li class="error-message">
+                        <span>{{ error }}</span>
+                    </li>
+                {% endfor %}
+
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}
                         <li>{% include "wagtailadmin/shared/field.html" %}</li>

--- a/wagtail_localize/locales/tests.py
+++ b/wagtail_localize/locales/tests.py
@@ -1,4 +1,7 @@
+from unittest import mock
+
 from django.contrib.messages import get_messages
+from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -273,6 +276,35 @@ class TestLocaleCreateView(BaseLocaleTestCase):
         # Check that the locale was not created
         self.assertFalse(Locale.objects.filter(language_code="fr").exists())
 
+    def test_create_renders_non_field_errors_for_main_form(self):
+        with mock.patch(
+            "wagtail_localize.locales.forms.LocaleForm.clean",
+            side_effect=ValidationError("Main form non-field error"),
+        ):
+            response = self.post({"language_code": "fr"})
+
+        self.assert_successful_response(response)
+        self.assertContains(response, "Main form non-field error")
+        self.assertIn("__all__", response.context["form"].errors)
+
+    def test_create_renders_non_field_errors_for_component_form(self):
+        with mock.patch(
+            "wagtail_localize.models.LocaleSynchronizationModelForm.validate_with_locale",
+            side_effect=ValidationError("Component form non-field error"),
+        ):
+            response = self.post(
+                {
+                    "language_code": "fr",
+                    "component-wagtail_localize_localesynchronization-enabled": "on",
+                    "component-wagtail_localize_localesynchronization-sync_from": self.english.id,
+                }
+            )
+
+        self.assert_successful_response(response)
+        self.assertContains(response, "Component form non-field error")
+        component_form = list(response.context["components"])[0][2]
+        self.assertIn("__all__", component_form.errors)
+
 
 class TestLocaleEditView(BaseLocaleTestCase):
     def post(self, post_data=None, locale=None):
@@ -476,6 +508,37 @@ class TestLocaleEditView(BaseLocaleTestCase):
             component_form.errors["sync_from"],
             ["This locale cannot be synced into itself."],
         )
+
+    def test_edit_renders_non_field_errors_for_main_form(self):
+        with mock.patch(
+            "wagtail_localize.locales.forms.LocaleForm.clean",
+            side_effect=ValidationError("Main form non-field error"),
+        ):
+            response = self.post({"language_code": "en"})
+
+        self.assert_successful_response(response)
+        self.assertContains(response, "Main form non-field error")
+        self.assertIn("__all__", response.context["form"].errors)
+
+    def test_edit_renders_non_field_errors_for_component_form(self):
+        french = Locale.objects.create(language_code="fr")
+        with mock.patch(
+            "wagtail_localize.models.LocaleSynchronizationModelForm.validate_with_locale",
+            side_effect=ValidationError("Component form non-field error"),
+        ):
+            response = self.post(
+                {
+                    "language_code": "fr",
+                    "component-wagtail_localize_localesynchronization-enabled": "on",
+                    "component-wagtail_localize_localesynchronization-sync_from": self.english.id,
+                },
+                locale=french,
+            )
+
+        self.assert_successful_response(response)
+        self.assertContains(response, "Component form non-field error")
+        component_form = list(response.context["components"])[0][2]
+        self.assertIn("__all__", component_form.errors)
 
 
 class TestLocaleDeleteView(BaseLocaleTestCase):

--- a/wagtail_localize/templates/wagtail_localize/admin/_components.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/_components.html
@@ -5,6 +5,12 @@
         {% if component.help_text %}<p>{{ component.help_text }}</p>{% endif %}
 
         <ul class="fields component-form__fields">
+            {% for error in component_form.non_field_errors %}
+                <li class="error-message">
+                    <span>{{ error }}</span>
+                </li>
+            {% endfor %}
+
             {% for field in component_form.visible_fields %}
                 <li class="component-form__fieldname-{{ field.name }}">{% include "wagtailadmin/shared/field.html" %}</li>
             {% endfor %}


### PR DESCRIPTION
This pull request improves the user experience when editing and creating locales by ensuring that non-field errors are properly displayed in both the main and component forms. It also adds comprehensive tests to verify this behavior.

**User interface improvements:**

* Updated `edit.html` and `_components.html` templates to render non-field errors for the main form and component forms, ensuring users see relevant validation messages.

**Testing enhancements:**
* Added tests to `tests.py` that verify non-field errors are shown for both main and component forms during locale creation and editing.