### PR TITLE
Show non-field errors in translation workflows and paginate the locales index

### DIFF
--- a/wagtail_localize/locales/templates/wagtaillocales/edit.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/edit.html
@@ -26,6 +26,8 @@
                 {% endfor %}
             {% endblock %}
 
+            {% include "wagtailadmin/shared/non_field_errors.html" %}
+
             <ul class="fields">
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}

--- a/wagtail_localize/locales/templates/wagtaillocales/index.html
+++ b/wagtail_localize/locales/templates/wagtaillocales/index.html
@@ -3,45 +3,54 @@
 
 {% block listing %}
     <div class="nice-padding">
-        <div id="locales-list">
-            <table class="listing">
-                <thead>
-                    <tr>
-                        <th class="hostname">
-                            {% if ordering == "name" %}
-                                <a href="{% url 'wagtaillocales:index' %}" class="icon icon-arrow-down-after teal">
-                                    {% trans "Language" %}
-                                </a>
-                            {% else %}
-                                <a href="{% url 'wagtaillocales:index' %}?ordering=name" class="icon icon-arrow-down-after">
-                                    {% trans "Language" %}
-                                </a>
-                            {% endif %}
-                        </th>
-                        <th>{% trans "Usage" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for locale in locales %}
+        {% if locales %}
+            <div id="locales-list">
+                <table class="listing">
+                    <thead>
                         <tr>
-                            <td class="hostname title">
-                                <div class="title-wrapper">
-                                    <a href="{% url 'wagtaillocales:edit' locale.id %}">{{ locale }}</a>
-                                    {% if not locale.language_code_is_valid %}
-                                        {% trans "This locale's language code is not supported" as error %}
-                                          {% include "wagtaillocales/_icon.html" with error=error only %}
-                                    {% endif %}
-                                </div>
-                            </td>
-                            <td>
-                                {# TODO Make this translatable #}
-                                {{ locale.num_pages }} pages{% if locale.num_others %} + {{ locale.num_others }} others{% endif %}
-                            </td>
+                            <th class="hostname">
+                                {% if ordering == "name" %}
+                                    <a href="{% url 'wagtaillocales:index' %}" class="icon icon-arrow-down-after teal">
+                                        {% trans "Language" %}
+                                    </a>
+                                {% else %}
+                                    <a href="{% url 'wagtaillocales:index' %}?ordering=name" class="icon icon-arrow-down-after">
+                                        {% trans "Language" %}
+                                    </a>
+                                {% endif %}
+                            </th>
+                            <th>{% trans "Usage" %}</th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-
-        </div>
+                    </thead>
+                    <tbody>
+                        {% for locale in locales %}
+                            <tr>
+                                <td class="hostname title">
+                                    <div class="title-wrapper">
+                                        <a href="{% url 'wagtaillocales:edit' locale.id %}">{{ locale }}</a>
+                                        {% if not locale.language_code_is_valid %}
+                                            {% trans "This locale's language code is not supported" as error %}
+                                            {% include "wagtaillocales/_icon.html" with error=error only %}
+                                        {% endif %}
+                                    </div>
+                                </td>
+                                <td>
+                                    {# TODO Make this translatable #}
+                                    {{ locale.num_pages }} pages{% if locale.num_others %} + {{ locale.num_others }} others{% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="w-mt-8">{% trans "No locales have been created yet." %}</p>
+        {% endif %}
     </div>
+
+    {% if locales and is_paginated %}
+        <div class="nice-padding">
+            {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl=index_url %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/wagtail_localize/locales/tests.py
+++ b/wagtail_localize/locales/tests.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 from django.contrib.messages import get_messages
+from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -83,6 +86,19 @@ class TestLocaleIndexView(BaseLocaleTestCase):
         self.assert_successful_response(response)
         expected_wagtail_version = get_main_version()
         self.assertEqual(response.context["wagtail_version"], expected_wagtail_version)
+
+    def test_pagination_displayed(self):
+        for index in range(21):
+            Locale.objects.create(language_code=f"zz{index:02d}")
+
+        response = self.execute_request("GET", "wagtaillocales:index")
+        self.assert_successful_response(response)
+        self.assertContains(response, "Page 1 of 2")
+        self.assertContains(response, "?p=2")
+
+        page_two = self.execute_request("GET", "wagtaillocales:index", params={"p": 2})
+        self.assert_successful_response(page_two)
+        self.assertContains(page_two, "Page 2 of 2")
 
     def test_get_locale_usage(self):
         # Test the get_locale_usage function with different scenarios
@@ -228,6 +244,28 @@ class TestLocaleCreateView(BaseLocaleTestCase):
 
         # Check that the locale was not created
         self.assertFalse(Locale.objects.filter(language_code="fr").exists())
+
+    def test_component_non_field_error_is_rendered(self):
+        with patch(
+            "wagtail_localize.models.LocaleSynchronizationModelForm.validate_with_locale",
+            side_effect=ValidationError("Component non-field issue"),
+        ):
+            response = self.post(
+                {
+                    "language_code": "fr",
+                    "component-wagtail_localize_localesynchronization-enabled": "on",
+                    "component-wagtail_localize_localesynchronization-sync_from": self.english.id,
+                }
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+        component_errors = []
+        for _, _, component_form in response.context["components"]:
+            component_errors.extend(component_form.non_field_errors())
+
+        self.assertIn("Component non-field issue", component_errors)
+        self.assertContains(response, "Component non-field issue")
 
     def test_sync_from_not_required_when_disabled(self):
         # Test creating a locale with synchronization disabled

--- a/wagtail_localize/locales/views.py
+++ b/wagtail_localize/locales/views.py
@@ -78,6 +78,7 @@ class IndexView(generic.IndexView):
     add_item_label = gettext_lazy("Add a locale")
     context_object_name = "locales"
     queryset = Locale.all_objects.all()
+    paginate_by = 20
 
     def get_context_data(self):
         context = super().get_context_data()

--- a/wagtail_localize/templates/wagtail_localize/admin/_components.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/_components.html
@@ -4,6 +4,8 @@
         <h3>{{ component.heading }}</h3>
         {% if component.help_text %}<p>{{ component.help_text }}</p>{% endif %}
 
+        {% include "wagtailadmin/shared/non_field_errors.html" with form=component_form %}
+
         <ul class="fields component-form__fields">
             {% for field in component_form.visible_fields %}
                 <li class="component-form__fieldname-{{ field.name }}">{% include "wagtailadmin/shared/field.html" %}</li>

--- a/wagtail_localize/templates/wagtail_localize/admin/submit_translation.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/submit_translation.html
@@ -15,6 +15,8 @@
 
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
 
+            {% include "wagtailadmin/shared/non_field_errors.html" %}
+
             <ul class="fields">
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}

--- a/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/update_translations.html
@@ -34,6 +34,8 @@
 
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
 
+            {% include "wagtailadmin/shared/non_field_errors.html" %}
+
             <ul class="fields">
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}

--- a/wagtail_localize/test/models.py
+++ b/wagtail_localize/test/models.py
@@ -5,7 +5,8 @@ from django.utils.translation import gettext_lazy
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
 from wagtail import VERSION as WAGTAIL_VERSION
-from wagtail import blocks, telepath
+from wagtail import blocks
+from wagtail.admin import telepath
 from wagtail.admin.panels import (
     FieldPanel,
     InlinePanel,

--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -4,6 +4,7 @@ from django.contrib.admin.utils import quote
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -277,6 +278,22 @@ class TestSubmitPageTranslation(WagtailTestUtils, TestCase):
         self.assertRedirects(
             response, reverse("wagtailadmin_pages:edit", args=[translated_page.id])
         )
+
+    @patch("wagtail_localize.views.submit_translations.SubmitTranslationForm.clean")
+    def test_submit_translation_form_non_field_error_is_rendered(self, mock_clean):
+        mock_clean.side_effect = ValidationError("Form level problem")
+
+        response = self.client.post(
+            reverse(
+                "wagtail_localize:submit_page_translation",
+                args=[self.en_blog_index.id],
+            ),
+            {"locales": [self.fr_locale.id]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Form level problem", response.context["form"].non_field_errors())
+        self.assertContains(response, "Form level problem")
 
     @override_settings(WAGTAILLOCALIZE_SYNC_LIVE_STATUS_ON_TRANSLATE=False)
     def test_post_submit_page_translation_draft(self):


### PR DESCRIPTION

## Summary
  - display form-level validation errors on the submit/update translation pages so editors see why a submission fails (wagtail-
  localize #811)
  - surface component-level non-field errors in translation components and locale edit forms
  - paginate the locales index view (20 per page) and add an empty state, addressing UX feedback from wagtail-localize #851

  ## Testing
  - python testmanage.py test
  wagtail_localize.tests.test_submit_translations.TestSubmitPageTranslation.test_submit_translation_form_non_field_error_is_rendered
  wagtail_localize.locales.tests.TestLocaleIndexView.test_pagination_displayed
  - python testmanage.py test wagtail_localize.tests.test_submit_translations wagtail_localize.locales.tests
  
  ##PFA Images running test
  
<img width="1183" height="436" alt="Screenshot 2026-03-08 at 3 51 40 PM" src="https://github.com/user-attachments/assets/24dad5c3-f53b-4c7c-937c-211f8a0118a0" />


