### PR TITLE
Add publish-and-sync translations actions to editor and bulk workflows (Fixes #789)

### DIFF
--- a/wagtail_localize/bulk_actions.py
+++ b/wagtail_localize/bulk_actions.py
@@ -1,0 +1,56 @@
+from django.utils.translation import gettext_lazy as _
+from wagtail.admin.views.pages.bulk_actions.page_bulk_action import PageBulkAction
+
+from wagtail_localize.models import TranslationSource
+from wagtail_localize.views.update_translations import sync_translation_source
+
+
+class PublishAndSyncTranslationsBulkAction(PageBulkAction):
+    display_name = _("Publish & sync translations")
+    action_type = "publish-and-sync-translations"
+    aria_label = _("Publish selected pages and sync translations")
+    template_name = (
+        "wagtail_localize/admin/pages/bulk_actions/confirm_publish_and_sync.html"
+    )
+    action_priority = 45
+
+    def check_perm(self, page):
+        return page.permissions_for_user(self.request.user).can_publish()
+
+    @classmethod
+    def execute_action(cls, objects, include_descendants=False, user=None, **kwargs):
+        num_parent_objects = 0
+        num_child_objects = 0
+
+        def publish_page(page):
+            specific_page = page.specific
+            revision = page.get_latest_revision()
+            if revision is None:
+                revision = specific_page.save_revision(user=user)
+            revision.publish(user=user)
+
+            source = TranslationSource.objects.get_for_instance_or_none(specific_page)
+            if source is not None:
+                sync_translation_source(source, user=user, publish=True)
+
+        for page in objects:
+            publish_page(page)
+            num_parent_objects += 1
+
+            if include_descendants:
+                descendants = (
+                    page.get_descendants()
+                    .not_live()
+                    .defer_streamfields()
+                    .specific()
+                    .iterator()
+                )
+                for descendant in descendants:
+                    if (
+                        user is None
+                        or descendant.permissions_for_user(user).can_publish()
+                    ):
+                        publish_page(descendant)
+                        num_child_objects += 1
+
+        return num_parent_objects, num_child_objects

--- a/wagtail_localize/templates/wagtail_localize/admin/action_menu/publish_and_sync.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/action_menu/publish_and_sync.html
@@ -1,0 +1,22 @@
+{% load i18n wagtailadmin_tags %}
+<button
+    type="submit"
+    name="action-publish"
+    value="{{ submit_value|default:'action-publish-and-sync' }}"
+    class="button button-longrunning"
+    data-controller="w-progress"
+    data-action="w-progress#activate"
+    data-w-progress-active-value="{% if is_scheduled %}{% trans 'Scheduling and syncing…' %}{% else %}{% trans 'Publishing and syncing…' %}{% endif %}"
+>
+    {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
+    {% icon name="spinner" %}
+    <em data-w-progress-target="label">
+        {% if is_scheduled %}
+            {% trans "Schedule to publish & sync" %}
+        {% elif is_revision %}
+            {% trans "Publish this version & sync" %}
+        {% else %}
+            {{ label }}
+        {% endif %}
+    </em>
+</button>

--- a/wagtail_localize/templates/wagtail_localize/admin/pages/bulk_actions/confirm_publish_and_sync.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/pages/bulk_actions/confirm_publish_and_sync.html
@@ -1,0 +1,63 @@
+{% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}
+            Publish & sync 1 page
+        {% plural %}
+            Publish & sync {{ counter }} pages
+        {% endblocktrans %}
+    {% endwith %}
+{% endblock %}
+
+{% block header %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Publish & sync translations") icon="doc-empty-inverse" %}
+{% endblock header %}
+
+{% block items_with_access %}
+    {% if items %}
+        <p>{% trans "Are you sure you want to publish these pages and sync their translations?" %}</p>
+        <ul>
+            {% for page in items %}
+                <li>
+                    <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
+                    {% with draft_descendant_count=page.draft_descendant_count %}
+                        {% if draft_descendant_count %}
+                            <p>
+                                {% blocktrans trimmed with counter=draft_descendant_count|intcomma count counter_val=draft_descendant_count %}
+                                    This page has one unpublished subpage
+                                {% plural %}
+                                    This page has {{ counter }} unpublished subpages
+                                {% endblocktrans %}
+                            </p>
+                        {% endif %}
+                    {% endwith %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock items_with_access %}
+
+{% block items_with_no_access %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}
+        You don't have permission to publish or sync this page
+    {% plural %}
+        You don't have permission to publish or sync these pages
+    {% endblocktrans %}
+    {% include './list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
+{% endblock items_with_no_access %}
+
+{% block form_section %}
+    {% if items %}
+        {% trans 'Yes, publish & sync' as action_button_text %}
+        {% trans "No, don't publish" as no_action_button_text %}
+        {% if has_draft_descendants %}
+            {% include 'wagtailadmin/bulk_actions/confirmation/form_with_fields.html' %}
+        {% else %}
+            {% include 'wagtailadmin/bulk_actions/confirmation/form.html' %}
+        {% endif %}
+    {% else %}
+        {% include 'wagtailadmin/bulk_actions/confirmation/go_back.html' %}
+    {% endif %}
+{% endblock form_section %}

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -4,16 +4,14 @@ from django.contrib.admin.utils import quote
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import ValidationError
 from django.forms.widgets import CheckboxInput
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.models import Locale, Page, PageViewRestriction
 from wagtail.test.utils import WagtailTestUtils
 
-from wagtail_localize.bulk_actions import PublishAndSyncTranslationsBulkAction
 from wagtail_localize.models import (
     StringSegment,
     StringTranslation,
@@ -21,7 +19,6 @@ from wagtail_localize.models import (
     TranslationSource,
 )
 from wagtail_localize.test.models import NonTranslatableSnippet, TestSnippet
-from wagtail_localize.wagtail_hooks import publish_page_sync_translations
 
 from .utils import assert_permission_denied, make_test_page
 
@@ -119,28 +116,6 @@ class TestPageUpdateTranslationsListingButton(TestCase, WagtailTestUtils):
         )
 
         self.assertNotContains(response, "Sync translated pages")
-
-    def test_publish_and_sync_button_shown_on_edit_view(self):
-        response = self.client.get(
-            reverse("wagtailadmin_pages:edit", args=[self.en_blog_index.id])
-        )
-        self.assertContains(response, "Publish &amp; sync translations")
-
-    def test_publish_and_sync_button_hidden_without_translations(self):
-        self.source.delete()
-
-        response = self.client.get(
-            reverse("wagtailadmin_pages:edit", args=[self.en_blog_index.id])
-        )
-        self.assertNotContains(response, "Publish &amp; sync translations")
-
-    def test_publish_and_sync_button_hidden_without_permission(self):
-        strip_user_perms()
-
-        response = self.client.get(
-            reverse("wagtailadmin_pages:edit", args=[self.en_blog_index.id])
-        )
-        self.assertNotContains(response, "Publish &amp; sync translations")
 
 
 @override_settings(
@@ -754,128 +729,3 @@ class TestUpdateTranslations(TestCase, WagtailTestUtils):
             context_id=string_segment.context_id,
         )
         self.assertEqual(string_translation.data, "post blog Edited")
-
-
-@override_settings(
-    LANGUAGES=[
-        ("en", "English"),
-        ("fr", "French"),
-        ("de", "German"),
-        ("es", "Spanish"),
-    ],
-    WAGTAIL_CONTENT_LANGUAGES=[
-        ("en", "English"),
-        ("fr", "French"),
-        ("de", "German"),
-        ("es", "Spanish"),
-    ],
-)
-class TestPublishAndSyncHooks(TestCase, WagtailTestUtils):
-    def setUp(self):
-        self.user = self.login()
-        self.factory = RequestFactory()
-
-        self.en_locale = Locale.objects.get()
-        self.fr_locale = Locale.objects.create(language_code="fr")
-
-        self.en_homepage = Page.objects.get(depth=2)
-        self.en_blog_index = make_test_page(
-            self.en_homepage, title="Blog", slug="blog-to-publish"
-        )
-        self.fr_blog_index = self.en_blog_index.copy_for_translation(self.fr_locale)
-        self.source = TranslationSource.objects.get_for_instance_or_none(
-            self.en_blog_index
-        )
-
-    def _build_request(self, post_data=None):
-        request = self.factory.post(
-            "/", data=post_data or {"action-publish": "action-publish-and-sync"}
-        )
-        request.user = self.user
-        request.session = self.client.session
-        storage = FallbackStorage(request)
-        request._messages = storage
-        return request, storage
-
-    @mock.patch("wagtail_localize.wagtail_hooks.sync_translation_source")
-    def test_after_publish_page_syncs_translations(self, mock_sync):
-        request, storage = self._build_request()
-
-        publish_page_sync_translations(request, self.en_blog_index)
-
-        mock_sync.assert_called_once_with(self.source, user=self.user, publish=True)
-        messages = list(storage)
-        self.assertTrue(messages)
-        self.assertIn("synced", messages[0].message)
-
-    @mock.patch("wagtail_localize.wagtail_hooks.sync_translation_source")
-    def test_after_publish_page_no_translations(self, mock_sync):
-        self.source.delete()
-        request, storage = self._build_request()
-
-        publish_page_sync_translations(request, self.en_blog_index)
-
-        mock_sync.assert_not_called()
-        messages = list(storage)
-        self.assertTrue(messages)
-        self.assertIn("no translations", messages[0].message.lower())
-
-    @mock.patch("wagtail_localize.wagtail_hooks.sync_translation_source")
-    def test_after_publish_requires_permission(self, mock_sync):
-        strip_user_perms()
-        request, storage = self._build_request()
-
-        publish_page_sync_translations(request, self.en_blog_index)
-
-        mock_sync.assert_not_called()
-        self.assertFalse(list(storage))
-
-
-@override_settings(
-    LANGUAGES=[
-        ("en", "English"),
-        ("fr", "French"),
-        ("de", "German"),
-        ("es", "Spanish"),
-    ],
-    WAGTAIL_CONTENT_LANGUAGES=[
-        ("en", "English"),
-        ("fr", "French"),
-        ("de", "German"),
-        ("es", "Spanish"),
-    ],
-)
-class TestPublishAndSyncBulkAction(TestCase, WagtailTestUtils):
-    def setUp(self):
-        self.user = self.login()
-        self.factory = RequestFactory()
-
-        self.en_locale = Locale.objects.get()
-        self.fr_locale = Locale.objects.create(language_code="fr")
-        self.en_homepage = Page.objects.get(depth=2)
-        self.en_blog_index = make_test_page(
-            self.en_homepage, title="Bulk blog", slug="bulk-blog"
-        )
-        self.en_blog_index.copy_for_translation(self.fr_locale)
-
-    @mock.patch("wagtail_localize.bulk_actions.sync_translation_source")
-    def test_execute_action_syncs_translations(self, mock_sync):
-        PublishAndSyncTranslationsBulkAction.execute_action(
-            [self.en_blog_index], include_descendants=False, user=self.user
-        )
-
-        self.assertTrue(mock_sync.called)
-
-    def test_check_perm_requires_publish_permission(self):
-        request = self.factory.post("/", data={"id": [self.en_blog_index.id]})
-        request.user = self.user
-        request.session = self.client.session
-        request.META["QUERY_STRING"] = ""
-
-        action = PublishAndSyncTranslationsBulkAction(request, Page)
-        self.assertTrue(action.check_perm(self.en_blog_index))
-
-        strip_user_perms()
-        request.user = get_user_model().objects.get()
-        action_no_perm = PublishAndSyncTranslationsBulkAction(request, Page)
-        self.assertFalse(action_no_perm.check_perm(self.en_blog_index))

--- a/wagtail_localize/tests/test_update_translations.py
+++ b/wagtail_localize/tests/test_update_translations.py
@@ -4,14 +4,16 @@ from django.contrib.admin.utils import quote
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import ValidationError
 from django.forms.widgets import CheckboxInput
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.models import Locale, Page, PageViewRestriction
 from wagtail.test.utils import WagtailTestUtils
 
+from wagtail_localize.bulk_actions import PublishAndSyncTranslationsBulkAction
 from wagtail_localize.models import (
     StringSegment,
     StringTranslation,
@@ -19,6 +21,7 @@ from wagtail_localize.models import (
     TranslationSource,
 )
 from wagtail_localize.test.models import NonTranslatableSnippet, TestSnippet
+from wagtail_localize.wagtail_hooks import publish_page_sync_translations
 
 from .utils import assert_permission_denied, make_test_page
 
@@ -116,6 +119,28 @@ class TestPageUpdateTranslationsListingButton(TestCase, WagtailTestUtils):
         )
 
         self.assertNotContains(response, "Sync translated pages")
+
+    def test_publish_and_sync_button_shown_on_edit_view(self):
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[self.en_blog_index.id])
+        )
+        self.assertContains(response, "Publish &amp; sync translations")
+
+    def test_publish_and_sync_button_hidden_without_translations(self):
+        self.source.delete()
+
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[self.en_blog_index.id])
+        )
+        self.assertNotContains(response, "Publish &amp; sync translations")
+
+    def test_publish_and_sync_button_hidden_without_permission(self):
+        strip_user_perms()
+
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[self.en_blog_index.id])
+        )
+        self.assertNotContains(response, "Publish &amp; sync translations")
 
 
 @override_settings(
@@ -729,3 +754,128 @@ class TestUpdateTranslations(TestCase, WagtailTestUtils):
             context_id=string_segment.context_id,
         )
         self.assertEqual(string_translation.data, "post blog Edited")
+
+
+@override_settings(
+    LANGUAGES=[
+        ("en", "English"),
+        ("fr", "French"),
+        ("de", "German"),
+        ("es", "Spanish"),
+    ],
+    WAGTAIL_CONTENT_LANGUAGES=[
+        ("en", "English"),
+        ("fr", "French"),
+        ("de", "German"),
+        ("es", "Spanish"),
+    ],
+)
+class TestPublishAndSyncHooks(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.user = self.login()
+        self.factory = RequestFactory()
+
+        self.en_locale = Locale.objects.get()
+        self.fr_locale = Locale.objects.create(language_code="fr")
+
+        self.en_homepage = Page.objects.get(depth=2)
+        self.en_blog_index = make_test_page(
+            self.en_homepage, title="Blog", slug="blog-to-publish"
+        )
+        self.fr_blog_index = self.en_blog_index.copy_for_translation(self.fr_locale)
+        self.source = TranslationSource.objects.get_for_instance_or_none(
+            self.en_blog_index
+        )
+
+    def _build_request(self, post_data=None):
+        request = self.factory.post(
+            "/", data=post_data or {"action-publish": "action-publish-and-sync"}
+        )
+        request.user = self.user
+        request.session = self.client.session
+        storage = FallbackStorage(request)
+        request._messages = storage
+        return request, storage
+
+    @mock.patch("wagtail_localize.wagtail_hooks.sync_translation_source")
+    def test_after_publish_page_syncs_translations(self, mock_sync):
+        request, storage = self._build_request()
+
+        publish_page_sync_translations(request, self.en_blog_index)
+
+        mock_sync.assert_called_once_with(self.source, user=self.user, publish=True)
+        messages = list(storage)
+        self.assertTrue(messages)
+        self.assertIn("synced", messages[0].message)
+
+    @mock.patch("wagtail_localize.wagtail_hooks.sync_translation_source")
+    def test_after_publish_page_no_translations(self, mock_sync):
+        self.source.delete()
+        request, storage = self._build_request()
+
+        publish_page_sync_translations(request, self.en_blog_index)
+
+        mock_sync.assert_not_called()
+        messages = list(storage)
+        self.assertTrue(messages)
+        self.assertIn("no translations", messages[0].message.lower())
+
+    @mock.patch("wagtail_localize.wagtail_hooks.sync_translation_source")
+    def test_after_publish_requires_permission(self, mock_sync):
+        strip_user_perms()
+        request, storage = self._build_request()
+
+        publish_page_sync_translations(request, self.en_blog_index)
+
+        mock_sync.assert_not_called()
+        self.assertFalse(list(storage))
+
+
+@override_settings(
+    LANGUAGES=[
+        ("en", "English"),
+        ("fr", "French"),
+        ("de", "German"),
+        ("es", "Spanish"),
+    ],
+    WAGTAIL_CONTENT_LANGUAGES=[
+        ("en", "English"),
+        ("fr", "French"),
+        ("de", "German"),
+        ("es", "Spanish"),
+    ],
+)
+class TestPublishAndSyncBulkAction(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.user = self.login()
+        self.factory = RequestFactory()
+
+        self.en_locale = Locale.objects.get()
+        self.fr_locale = Locale.objects.create(language_code="fr")
+        self.en_homepage = Page.objects.get(depth=2)
+        self.en_blog_index = make_test_page(
+            self.en_homepage, title="Bulk blog", slug="bulk-blog"
+        )
+        self.en_blog_index.copy_for_translation(self.fr_locale)
+
+    @mock.patch("wagtail_localize.bulk_actions.sync_translation_source")
+    def test_execute_action_syncs_translations(self, mock_sync):
+        PublishAndSyncTranslationsBulkAction.execute_action(
+            [self.en_blog_index], include_descendants=False, user=self.user
+        )
+
+        self.assertTrue(mock_sync.called)
+
+    def test_check_perm_requires_publish_permission(self):
+        request = self.factory.post("/", data={"id": [self.en_blog_index.id]})
+        request.user = self.user
+        request.session = self.client.session
+        request.META["QUERY_STRING"] = ""
+
+        action = PublishAndSyncTranslationsBulkAction(request, Page)
+        self.assertTrue(action.check_perm(self.en_blog_index))
+
+        strip_user_perms()
+        request.user = get_user_model().objects.get()
+        action_no_perm = PublishAndSyncTranslationsBulkAction(request, Page)
+        self.assertFalse(action_no_perm.check_perm(self.en_blog_index))

--- a/wagtail_localize/views/update_translations.py
+++ b/wagtail_localize/views/update_translations.py
@@ -1,5 +1,7 @@
 import contextlib
 
+from dataclasses import dataclass
+
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -21,6 +23,69 @@ from wagtail_localize.machine_translators import get_machine_translator
 from wagtail_localize.models import TranslationSource
 from wagtail_localize.views.edit_translation import apply_machine_translation
 from wagtail_localize.views.submit_translations import TranslationComponentManager
+
+
+@dataclass
+class SyncTranslationsResult:
+    translations: list
+    published: int = 0
+    machine_translated: int = 0
+
+
+def sync_translation_source(
+    translation_source,
+    *,
+    user,
+    publish: bool = False,
+    use_machine_translation: bool = False,
+    machine_translator=None,
+    components=None,
+):
+    """
+    Synchronise translations for the given source. Optionally publish the updated targets
+    and/or run machine translation beforehand.
+    """
+    translation_source.update_from_db()
+
+    enabled_translations_qs = translation_source.translations.filter(enabled=True)
+    translations = list(enabled_translations_qs.select_related("target_locale"))
+
+    if not translations:
+        return SyncTranslationsResult(translations=[])
+
+    machine_translated = 0
+    if use_machine_translation:
+        if machine_translator is None:
+            machine_translator = get_machine_translator()
+        if machine_translator is not None:
+            for translation in translations:
+                apply_machine_translation(translation.id, user, machine_translator)
+                machine_translated += 1
+
+    published = 0
+    if publish:
+        for translation in translations:
+            with contextlib.suppress(ValidationError):
+                translation.save_target(user=user, publish=True)
+                published += 1
+    else:
+        for translation in translations:
+            with contextlib.suppress(ValidationError):
+                translation.source.update_target_view_restrictions(
+                    translation.target_locale
+                )
+
+    if components is not None:
+        components.save(
+            translation_source,
+            sources_and_translations={translation_source: translations},
+        )
+
+    return SyncTranslationsResult(
+        translations=translations,
+        published=published,
+        machine_translated=machine_translated,
+    )
 
 
 class UpdateTranslationsForm(forms.Form):
@@ -153,32 +218,15 @@ class UpdateTranslationsView(SingleObjectMixin, TemplateView):
 
     @transaction.atomic
     def form_valid(self, form):
-        self.object.update_from_db()
-
-        enabled_translations = self.object.translations.filter(enabled=True)
-        if form.cleaned_data.get("use_machine_translation"):
-            machine_translator = get_machine_translator()
-            for translation in enabled_translations.select_related("target_locale"):
-                apply_machine_translation(
-                    translation.id, self.request.user, machine_translator
-                )
-
-        if form.cleaned_data["publish_translations"]:
-            for translation in enabled_translations.select_related("target_locale"):
-                with contextlib.suppress(ValidationError):
-                    translation.save_target(user=self.request.user, publish=True)
-        else:
-            for translation in enabled_translations.select_related(
-                "source", "target_locale"
-            ):
-                with contextlib.suppress(ValidationError):
-                    translation.source.update_target_view_restrictions(
-                        translation.target_locale
-                    )
-
-        self.components.save(
+        use_machine_translation = form.cleaned_data.get(
+            "use_machine_translation", False
+        )
+        sync_translation_source(
             self.object,
-            sources_and_translations={self.object: list(enabled_translations)},
+            user=self.request.user,
+            publish=form.cleaned_data["publish_translations"],
+            use_machine_translation=use_machine_translation,
+            components=self.components,
         )
 
         # TODO: Button that links to page in translations report when we have it

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from urllib.parse import urlencode
 
+from django.contrib import messages
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import Permission
 from django.db.models import Q
@@ -12,7 +13,12 @@ from django.utils.translation import gettext_lazy
 from django.views.i18n import JavaScriptCatalog
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail import hooks
-from wagtail.admin.action_menu import ActionMenuItem as PageActionMenuItem
+from wagtail.admin.action_menu import (
+    ActionMenuItem as PageActionMenuItem,
+)
+from wagtail.admin.action_menu import (
+    PublishMenuItem,
+)
 from wagtail.admin.menu import MenuItem
 from wagtail.log_actions import LogFormatter
 from wagtail.models import Locale, Page, TranslatableMixin
@@ -20,6 +26,7 @@ from wagtail.snippets.action_menu import ActionMenuItem as SnippetActionMenuItem
 
 # Import synctree so it can register its signal handler
 from . import synctree  # noqa: F401
+from .bulk_actions import PublishAndSyncTranslationsBulkAction
 from .models import Translation, TranslationSource
 from .views import (
     convert,
@@ -29,6 +36,7 @@ from .views import (
     submit_translations,
     update_translations,
 )
+from .views.update_translations import sync_translation_source
 
 
 if WAGTAIL_VERSION >= (7, 0):
@@ -295,6 +303,75 @@ def register_restart_translation_page_action_menu_item():
     return RestartTranslationPageActionMenuItem(order=0)
 
 
+class PublishAndSyncTranslationsMenuItem(PublishMenuItem):
+    label = gettext_lazy("Publish & sync translations")
+    name = "localize-action-publish-and-sync"
+    template_name = "wagtail_localize/admin/action_menu/publish_and_sync.html"
+
+    def is_shown(self, context):
+        if context["view"] != "edit":
+            return False
+
+        if not super().is_shown(context):
+            return False
+
+        if not context["request"].user.has_perm("wagtail_localize.submit_translation"):
+            return False
+
+        page = context.get("page")
+        if not page:
+            return False
+
+        source = TranslationSource.objects.get_for_instance_or_none(page)
+        return source is not None and source.translations.filter(enabled=True).exists()
+
+    def get_context_data(self, parent_context):
+        context = super().get_context_data(parent_context)
+        context["submit_value"] = "action-publish-and-sync"
+        return context
+
+
+@hooks.register("register_page_action_menu_item")
+def register_publish_and_sync_menu_item():
+    return PublishAndSyncTranslationsMenuItem(order=61)
+
+
+@hooks.register("after_publish_page")
+def publish_page_sync_translations(request, page):
+    if request.POST.get("action-publish") != "action-publish-and-sync":
+        return
+
+    if not request.user.has_perm("wagtail_localize.submit_translation"):
+        return
+
+    source = TranslationSource.objects.get_for_instance_or_none(page)
+    if source is None:
+        messages.info(
+            request,
+            _("Published '%(title)s' (no translations to sync).")
+            % {"title": page.get_admin_display_title()},
+        )
+        return
+
+    result = sync_translation_source(source, user=request.user, publish=True)
+
+    if result.translations:
+        messages.success(
+            request,
+            _("Published '%(title)s' and synced %(count)d translations.")
+            % {
+                "title": page.get_admin_display_title(),
+                "count": len(result.translations),
+            },
+        )
+    else:
+        messages.info(
+            request,
+            _("Published '%(title)s' (no enabled translations to sync).")
+            % {"title": page.get_admin_display_title()},
+        )
+
+
 class ConvertToAliasPageActionMenuItem(PageActionMenuItem):
     label = gettext_lazy("Convert to alias page")
     name = "localize-convert-to-alias"
@@ -398,6 +475,9 @@ def register_wagtail_localize2_report_menu_item():
         icon_name="site",
         order=9000,
     )
+
+
+hooks.register("register_bulk_action", PublishAndSyncTranslationsBulkAction)
 
 
 @hooks.register("register_log_actions")


### PR DESCRIPTION
Solved Issue - #789 
Summary
- introduce a shared sync_translation_source() helper and result dataclass so page/snippet updates, hooks, and actions reuse the same publish + machine-translation pipeline
- add a “Publish & sync translations” editor action that appears when translated copies exist, reusing Wagtail’s long-running button UX and posting the special submit value
- mplement a bulk “Publish & sync translations” action with confirmation template, permission checks, and descendant handling so editors can publish multiple pages and synchronize locales in one step
- expand regression coverage for the new button visibility, hook messaging/permissions, and bulk action behavior