### PR TITLE
Fix inconsistent position of translation buttons across admin contexts

### DIFF
--- a/wagtail_localize/tests/test_submit_translations.py
+++ b/wagtail_localize/tests/test_submit_translations.py
@@ -19,6 +19,10 @@ from wagtail_localize.test.models import (
     TestWithTranslationModeDisabledPage,
     TestWithTranslationModeEnabledPage,
 )
+from wagtail_localize.wagtail_hooks import (
+    page_header_buttons,
+    page_listing_more_buttons,
+)
 
 from .utils import assert_permission_denied, make_test_page
 
@@ -992,3 +996,28 @@ class TestSubmitSnippetTranslation(WagtailTestUtils, TestCase):
         )
 
         assert_permission_denied(self, response)
+
+
+class TestTranslationButtonPriority(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.en_locale = Locale.objects.get()
+        cls.fr_locale = Locale.objects.create(language_code="fr")
+        cls.de_locale = Locale.objects.create(language_code="de")
+
+        cls.en_homepage = Page.objects.get(depth=2)
+
+        cls.en_blog_index = make_test_page(cls.en_homepage, title="Blog", slug="blog")
+
+    def setUp(self):
+        self.user = self.login()
+
+    def test_listing_buttons_priority(self):
+        buttons = list(page_listing_more_buttons(self.en_blog_index, self.user))
+        translate_button = next(b for b in buttons if b.label == "Translate this page")
+        self.assertEqual(translate_button.priority, 35)
+
+    def test_page_header_buttons_priority(self):
+        buttons = list(page_header_buttons(self.en_blog_index, self.user))
+        translate_button = next(b for b in buttons if b.label == "Translate this page")
+        self.assertEqual(translate_button.priority, 55)

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -181,10 +181,13 @@ def translation_buttons(page: Page, user, next_url=None, priority=60):
 
 
 def page_listing_more_buttons(page: Page, user, next_url=None):
+    # priority=35: after Delete (30), before Sort menu order (60)
     yield from translation_buttons(page, user, next_url, priority=35)
 
 
 def page_header_buttons(page: Page, user, view_name=None, next_url=None):
+    # view_name ("index" or "edit") is not used, both contexts share the same priority
+    # priority=55: after Delete (50), before Unpublish (60)
     yield from translation_buttons(page, user, next_url, priority=55)
 
 

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -147,9 +147,8 @@ def register_submit_translation_permission():
     )
 
 
-def page_listing_more_buttons(page: Page, user, view_name=None, next_url=None):
+def translation_buttons(page: Page, user, next_url=None, priority=60):
     if not page.is_root() and user.has_perm("wagtail_localize.submit_translation"):
-        # If there's at least one locale that we haven't translated into yet, show "Translate this page" button
         has_locale_to_translate_to = Locale.objects.exclude(
             id__in=page.get_translations(inclusive=True)
             .exclude(alias_of__isnull=False)
@@ -166,7 +165,7 @@ def page_listing_more_buttons(page: Page, user, view_name=None, next_url=None):
             yield ListingButton(
                 _("Translate this page"),
                 url,
-                priority=60,
+                priority=priority,
                 icon_name="wagtail-localize-language",
             )
 
@@ -176,13 +175,20 @@ def page_listing_more_buttons(page: Page, user, view_name=None, next_url=None):
             url = reverse("wagtail_localize:update_translations", args=[source.id])
             if next_url is not None:
                 url += "?" + urlencode({"next": next_url})
-
             yield ListingButton(
-                _("Sync translated pages"), url, priority=60, icon_name="resubmit"
+                _("Sync translated pages"), url, priority=priority, icon_name="resubmit"
             )
 
 
-hooks.register("register_page_header_buttons", page_listing_more_buttons)
+def page_listing_more_buttons(page: Page, user, next_url=None):
+    yield from translation_buttons(page, user, next_url, priority=35)
+
+
+def page_header_buttons(page: Page, user, view_name=None, next_url=None):
+    yield from translation_buttons(page, user, next_url, priority=55)
+
+
+hooks.register("register_page_header_buttons", page_header_buttons)
 hooks.register("register_page_listing_more_buttons", page_listing_more_buttons)
 
 


### PR DESCRIPTION
Fixes #911

### Description

The "Translate this page" button appears in different contexts within the Wagtail admin: Page Listing, Page Index, and Page Editor. The "Sync translated pages" button is also affected, as it shares the same priority value within each context.

Its position was inconsistent across these contexts because the hooks defining this behavior used the same priority value, even though each hook operates within a different priority range.

Beyond aesthetics and consistency, the main issue was that in the Page Listing view the button was not visible without scrolling.

As an immediate fix, an internal function has been introduced. This function receives the priority value as a parameter and assigns it through context-specific hook handlers.


### AI usage

Used AI assistance to understand the hook priority system and identify appropriate priority values for each context.
