### PR TITLE
Avoid A Server Error During Translation If Optional Fields Are None

### DIFF
--- a/wagtail_localize/segments/extract.py
+++ b/wagtail_localize/segments/extract.py
@@ -42,6 +42,9 @@ class StreamFieldSegmentExtractor:
         self.include_overridables = include_overridables
 
     def handle_block(self, block_type, block_value, raw_value=None):
+        if block_value is None:
+            return []
+
         # Need to check if the app is installed before importing EmbedBlock
         # See: https://github.com/wagtail/wagtail-localize/issues/309
         if apps.is_installed("wagtail.embeds"):

--- a/wagtail_localize/segments/tests/test_segment_extraction.py
+++ b/wagtail_localize/segments/tests/test_segment_extraction.py
@@ -4,8 +4,11 @@ import uuid
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail import blocks
 from wagtail.blocks import StreamValue
+from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images import get_image_model
+from wagtail.images.blocks import ImageBlock
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Page, Site
 
@@ -694,3 +697,156 @@ class TestSegmentExtractionWithStreamField(TestCase):
             "was registered as a translatable field but the model it points to "
             "`wagtailcore.Site` is not translatable",
         )
+
+    def test_charblock_with_none_value(self):
+        """
+        If a CharBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(blocks.CharBlock(required=False), None)
+        self.assertEqual(result, [])
+
+    def test_textblock_with_none_value(self):
+        """
+        If a TextBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(blocks.TextBlock(required=False), None)
+        self.assertEqual(result, [])
+
+    def test_blockquoteblock_with_none_value(self):
+        """
+        If a BlockQuoteBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(blocks.BlockQuoteBlock(required=False), None)
+        self.assertEqual(result, [])
+
+    def test_richtextblock_with_none_value(self):
+        """
+        If a a RichTextBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(blocks.RichTextBlock(required=False), None)
+        self.assertEqual(result, [])
+
+    def test_structblock_with_optional_charblock_none_value(self):
+        """
+        If a StructBlock that contains a CharBlock with required=False produces a None
+        value for that field (when left empty), extract_segments must
+        return only the non-empty fields rather than raising an error.
+        """
+        struct_block_type = blocks.StructBlock(
+            [
+                ("required_field", blocks.CharBlock()),
+                ("optional_field", blocks.CharBlock(required=False)),
+            ]
+        )
+        struct_value = struct_block_type.to_python(
+            {"required_field": "Hello", "optional_field": None}
+        )
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        segments = extractor.handle_struct_block(struct_value)
+        self.assertEqual(
+            segments,
+            [StringSegmentValue("required_field", "Hello")],
+        )
+
+    def test_embedblock_with_none_value(self):
+        """
+        If an EmbedBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=True
+        )
+        result = extractor.handle_block(EmbedBlock(), None)
+        self.assertEqual(result, [])
+
+    def test_structblock_with_none_block_value(self):
+        """
+        If a StructBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(
+            blocks.StructBlock([("field_a", blocks.CharBlock())]), None
+        )
+        self.assertEqual(result, [])
+
+    def test_urlblock_with_none_value(self):
+        """
+        If a URLBlock with required=False produces a None value when left empty),
+        when include_overridables=True, handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=True
+        )
+        result = extractor.handle_block(blocks.URLBlock(), None)
+        self.assertEqual(result, [])
+
+    def test_emailblock_with_none_value(self):
+        """
+        If an EmailBlock with required=False produces a None value (when left empty),
+        when include_overridables=True, handle_block should return [] rather than
+        producing a spurious OverridableSegmentValue("", None).
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=True
+        )
+        result = extractor.handle_block(blocks.EmailBlock(), None)
+        self.assertEqual(result, [])
+
+    def test_streamblock_with_none_value(self):
+        """
+        If a StreamBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(
+            blocks.StreamBlock([("text", blocks.CharBlock())]), None
+        )
+        self.assertEqual(result, [])
+
+    def test_listblock_with_none_value(self):
+        """
+        If a ListBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(
+            blocks.ListBlock(blocks.CharBlock()), None
+        )
+        self.assertEqual(result, [])
+
+    @unittest.skipUnless(WAGTAIL_VERSION >= (6, 3), "ImageBlock was added in Wagtail 6.3")
+    def test_imageblock_with_none_value(self):
+        """
+        If an ImageBlock with required=False produces a None value (when left empty),
+        handle_block should return [].
+        """
+        extractor = StreamFieldSegmentExtractor(
+            TestPage.test_streamfield.field, include_overridables=False
+        )
+        result = extractor.handle_block(ImageBlock(), None)
+        self.assertEqual(result, [])

--- a/wagtail_localize/segments/tests/test_segment_extraction.py
+++ b/wagtail_localize/segments/tests/test_segment_extraction.py
@@ -834,12 +834,12 @@ class TestSegmentExtractionWithStreamField(TestCase):
         extractor = StreamFieldSegmentExtractor(
             TestPage.test_streamfield.field, include_overridables=False
         )
-        result = extractor.handle_block(
-            blocks.ListBlock(blocks.CharBlock()), None
-        )
+        result = extractor.handle_block(blocks.ListBlock(blocks.CharBlock()), None)
         self.assertEqual(result, [])
 
-    @unittest.skipUnless(WAGTAIL_VERSION >= (6, 3), "ImageBlock was added in Wagtail 6.3")
+    @unittest.skipUnless(
+        WAGTAIL_VERSION >= (6, 3), "ImageBlock was added in Wagtail 6.3"
+    )
     def test_imageblock_with_none_value(self):
         """
         If an ImageBlock with required=False produces a None value (when left empty),


### PR DESCRIPTION
Fixes #875, though this is a wider fix than what was mentioned in #875.
Fixes #918.

### Description

#### Problem
Currently, trying to translate a page with a blank optional field can cause a server error. To reproduce, I created [a sample repo](https://github.com/dchukhin/nonetype-translation-bug/tree/main) with an optional CharBlock, and when translating a page with the optional CharBlock, the server error is triggered.

#### Fix
This pull request adds a check for when  `StreamFieldSegmentExtractor.handle_block` has a `block_value` of `None`, and simply returns `[]` in that case.
Tests have been added for different block types.

### Question
One thing I want to make explicit here is that after implementing this change, translating the page does work 👏🏻 , but the translated page (in Wagtail) does not show the optional field (as if the field didn't exist). In the page's block's `raw_data`, I see that the optional field has a value of `None`:
```
[{'type': 'demo_block', 'value': {'required_text': 'This field has content', 'optional_text': None}, 'id': '45172f98-27d1-4780-8643-4f7248124f21'}]
```
To me this seems like a problem, but is it? Or is this the intended Wagtail behavior?
I started to explore what it may look like to make the field editable on the translated page, and it looks much more complex than this change. I'm ok with making that change, but want to make sure it's the direction that maintainers support.

### AI usage
This pull request includes code written with the assistance of AI. This code was reviewed and verified by me.
