### PR TITLE
Pass user to revision.publish() in save_target

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -801,7 +801,7 @@ class TranslationSource(models.Model):
                     self.sync_view_restrictions(original, translation)
 
                     if publish:
-                        transaction.on_commit(new_revision.publish)
+                        transaction.on_commit(lambda: new_revision.publish(user=user))
 
                 elif isinstance(translation, DraftStateMixin):
                     # We copied another instance which may be live, so we make sure this one matches the desired state
@@ -812,7 +812,7 @@ class TranslationSource(models.Model):
                     new_revision = translation.save_revision(user=user)
 
                     if publish:
-                        transaction.on_commit(new_revision.publish)
+                        transaction.on_commit(lambda: new_revision.publish(user=user))
 
                 elif isinstance(translation, RevisionMixin):
                     translation.save()


### PR DESCRIPTION
## Summary

When `save_target()` publishes a translated page or draftable snippet, it defers the publish via `transaction.on_commit(new_revision.publish)`. Because `publish()` is called without arguments, the resulting `PageLogEntry` has a null `user_id`, making it impossible to determine who published translated content from the audit log.

This passes the `user` parameter through to `publish()` on both the `Page` and `DraftStateMixin` code paths (models.py lines 804 and 815).

## Context

We discovered this while diagnosing a production issue where bulk PO file imports were triggering `DataError` on auto-redirect creation. All 36 publish events in `PageLogEntry` had null `user_id`, which made it difficult to trace the activity back to the users who uploaded the PO files. The `user` was already being passed to `save_revision()` on the lines immediately above, but was not forwarded to the subsequent `publish()` call.

## Test plan

- [x] Existing `test_save_target` passes (calls `save_target()` without user, so `user=None` is forwarded — same behavior as before)
- [x] Full tox suite (`python3.14-django5.2-wagtail7.2-sqlite`): 444 tests, 0 new failures (1 pre-existing failure in `test_edit_nested_snippet_translation` unrelated to this change)
- [ ] Verify `PageLogEntry` records the user after publishing a translated page via PO file import

🤖 Generated with [Claude Code](https://claude.com/claude-code)