### PR TITLE
Update documentation links and fix import statements 

### DIFF
--- a/docs/concept/segments.md
+++ b/docs/concept/segments.md
@@ -92,5 +92,5 @@ to be changed and they also don't have to be text fields either. By default, the
 but a user can optionally override them with something else. When they are overridden, any changes to the original
 page are ignored.
 
-All fields configured with the [`SynchronisedField`](../ref/translatable-fields.md#wagtail_localize.fields.SynchronizedField)
+All fields configured with the [`SynchronizedField`](../ref/translatable-fields.md#wagtail_localize.fields.SynchronizedField)
 field type will be extracted as an overridable segment.

--- a/docs/concept/segments.md
+++ b/docs/concept/segments.md
@@ -92,5 +92,5 @@ to be changed and they also don't have to be text fields either. By default, the
 but a user can optionally override them with something else. When they are overridden, any changes to the original
 page are ignored.
 
-All fields configured with the [`SynchronisedField`](/ref/translatable-fields/#wagtail_localize.fields.SynchronizedField)
+All fields configured with the [`SynchronisedField`](../ref/translatable-fields.md#wagtail_localize.fields.SynchronizedField)
 field type will be extracted as an overridable segment.

--- a/docs/concept/translatable-fields-autogen.md
+++ b/docs/concept/translatable-fields-autogen.md
@@ -5,7 +5,7 @@ This document describes how Wagtail Localize automatically generates translatabl
 ## 1. Check if `translatable_fields` attribute is defined
 
 If the `translatable_fields` attribute is defined on the model, this whole process is bypassed.
-See the [Configuring translatable fields](/how-to/field-configuration) guide for more information on how to set this attribute.
+See the [Configuring translatable fields](../how-to/field-configuration.md) guide for more information on how to set this attribute.
 
 ## 2. Discover fields on the model
 

--- a/docs/how-to/configure-background-tasks.md
+++ b/docs/how-to/configure-background-tasks.md
@@ -26,14 +26,11 @@ The `OPTIONS` => `QUEUE` key configures the Django RQ queue to push tasks to.
 To configure any other queueing system, create a subclass of `wagtail_localize.tasks.BaseJobBackend` somewhere in your project and override the `__init__` and `enqueue` methods:
 
 ```python
-from wagtail_localize.tasks import BaseJobBacked
-
-
+from wagtail_localize.tasks import BaseJobBackend
 class MyJobBackend(BaseJobBackend):
     def __init__(self, options):
         # Any set up code goes here. Note that the 'options' parameter contains the value of WAGTAILLOCALIZE_JOBS["OPTIONS"]
         pass
-
     def enqueue(self, func, args, kwargs):
         # func is a function object to call
         # args is a list of positional arguments to pass into the function when it's called

--- a/docs/how-to/configure-background-tasks.md
+++ b/docs/how-to/configure-background-tasks.md
@@ -27,10 +27,12 @@ To configure any other queueing system, create a subclass of `wagtail_localize.t
 
 ```python
 from wagtail_localize.tasks import BaseJobBackend
+
 class MyJobBackend(BaseJobBackend):
     def __init__(self, options):
         # Any set up code goes here. Note that the 'options' parameter contains the value of WAGTAILLOCALIZE_JOBS["OPTIONS"]
         pass
+
     def enqueue(self, func, args, kwargs):
         # func is a function object to call
         # args is a list of positional arguments to pass into the function when it's called

--- a/docs/how-to/field-configuration.md
+++ b/docs/how-to/field-configuration.md
@@ -5,7 +5,7 @@
     It is not currently possible to configure `StructBlock` translatable fields. See [Issue #307](https://github.com/wagtail/wagtail-localize/issues/307) for more details.
 
 By default, Wagtail Localize will decide for you which fields are translatable and which fields should just be synchronised.
-This is decided by some simple rules described in the [Auto-generation of Translatable Fields](/concept/translatable-fields-autogen)
+This is decided by some simple rules described in the [Auto-generation of Translatable Fields](../concept/translatable-fields-autogen.md)
 explanation.
 
 This guide describes how to override this behaviour partially or completely. Firstly, a quick explanation of what this configuration

--- a/docs/ref/models/overridable-segments.md
+++ b/docs/ref/models/overridable-segments.md
@@ -19,5 +19,9 @@ style E stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models.SegmentOverride
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.OverridableSegment
+    options:
+      show_root_heading: true

--- a/docs/ref/models/overridable-segments.md
+++ b/docs/ref/models/overridable-segments.md
@@ -18,10 +18,6 @@ style D stroke-dasharray: 5 5
 style E stroke-dasharray: 5 5
 ```
 
-::: wagtail_localize.models
-    selection:
-        members:
-            - SegmentOverride
-            - OverridableSegment
-        filters:
-            - "!^save$"
+::: wagtail_localize.models.SegmentOverride
+
+::: wagtail_localize.models.OverridableSegment

--- a/docs/ref/models/settings.md
+++ b/docs/ref/models/settings.md
@@ -11,9 +11,4 @@ A[LocaleSynchronization] --> B[wagtail.Locale]
 style B stroke-dasharray: 5 5
 ```
 
-::: wagtail_localize.models
-    selection:
-        members:
-            - LocaleSynchronization
-        filters:
-            - "!^save$"
+::: wagtail_localize.models.LocaleSynchronization

--- a/docs/ref/models/settings.md
+++ b/docs/ref/models/settings.md
@@ -12,3 +12,5 @@ style B stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models.LocaleSynchronization
+    options:
+      show_root_heading: true

--- a/docs/ref/models/translatable-segments.md
+++ b/docs/ref/models/translatable-segments.md
@@ -22,11 +22,21 @@ style I stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models.SegmentOverride
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.StringSegment
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.TemplateSegment
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.RelatedObjectSegment
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.OverridableSegment
+    options:
+      show_root_heading: true

--- a/docs/ref/models/translatable-segments.md
+++ b/docs/ref/models/translatable-segments.md
@@ -21,13 +21,12 @@ style H stroke-dasharray: 5 5
 style I stroke-dasharray: 5 5
 ```
 
-::: wagtail_localize.models
-    selection:
-        members:
-            - SegmentOverride
-            - StringSegment
-            - TemplateSegment
-            - RelatedObjectSegment
-            - OverridableSegment
-        filters:
-            - "!^save$"
+::: wagtail_localize.models.SegmentOverride
+
+::: wagtail_localize.models.StringSegment
+
+::: wagtail_localize.models.TemplateSegment
+
+::: wagtail_localize.models.RelatedObjectSegment
+
+::: wagtail_localize.models.OverridableSegment

--- a/docs/ref/models/translation-management.md
+++ b/docs/ref/models/translation-management.md
@@ -18,9 +18,17 @@ style F stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models.TranslatableObject
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.TranslationSource
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.Translation
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.TranslationLog
+    options:
+      show_root_heading: true

--- a/docs/ref/models/translation-management.md
+++ b/docs/ref/models/translation-management.md
@@ -17,12 +17,10 @@ style E stroke-dasharray: 5 5
 style F stroke-dasharray: 5 5
 ```
 
-::: wagtail_localize.models
-    selection:
-        members:
-            - TranslatableObject
-            - TranslationSource
-            - Translation
-            - TranslationLog
-        filters:
-            - "!^save$"
+::: wagtail_localize.models.TranslatableObject
+
+::: wagtail_localize.models.TranslationSource
+
+::: wagtail_localize.models.Translation
+
+::: wagtail_localize.models.TranslationLog

--- a/docs/ref/models/translation-memory.md
+++ b/docs/ref/models/translation-memory.md
@@ -18,15 +18,23 @@ style E stroke-dasharray: 5 5
 ::: wagtail_localize.models.String
     options:
       show_root_heading: true
+      filters:
+        - "!^save$"
 
 ::: wagtail_localize.models.TranslationContext
     options:
       show_root_heading: true
+      filters:
+        - "!^save$"
 
 ::: wagtail_localize.models.Template
     options:
       show_root_heading: true
+      filters:
+        - "!^save$"
 
 ::: wagtail_localize.models.StringTranslation
     options:
       show_root_heading: true
+      filters:
+        - "!^save$"

--- a/docs/ref/models/translation-memory.md
+++ b/docs/ref/models/translation-memory.md
@@ -15,12 +15,10 @@ style B stroke-dasharray: 5 5
 style E stroke-dasharray: 5 5
 ```
 
-::: wagtail_localize.models
-    selection:
-        members:
-            - String
-            - TranslationContext
-            - Template
-            - StringTranslation
-        filters:
-            - "!^save$"
+::: wagtail_localize.models.String
+
+::: wagtail_localize.models.TranslationContext
+
+::: wagtail_localize.models.Template
+
+::: wagtail_localize.models.StringTranslation

--- a/docs/ref/models/translation-memory.md
+++ b/docs/ref/models/translation-memory.md
@@ -16,9 +16,17 @@ style E stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models.String
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.TranslationContext
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.Template
+    options:
+      show_root_heading: true
 
 ::: wagtail_localize.models.StringTranslation
+    options:
+      show_root_heading: true

--- a/docs/tutorial/3-content.md
+++ b/docs/tutorial/3-content.md
@@ -154,8 +154,8 @@ String segments are translatable pieces of text which are extracted from text fi
 broken down into smaller segments to make it easier for translators to translate them.
 
 String segments can be individually translated through this UI, by downloading/uploading PO files (using the buttons at
-the top of the editor), using a [machine translation service](/how-to/integrations/machine-translation) or an
-[external translation tool](/how-to/integrations/pontoon).
+the top of the editor), using a [machine translation service](../how-to/integrations/machine-translation.md) or an
+[external translation tool](../how-to/integrations/pontoon.md).
 
 ![A translated string segment](../assets/tutorial/wagtail-translated-segment.png)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,11 +36,6 @@ plugins:
           options:
             show_root_toc_entry: false
             show_signature_annotations: true
-          setup_commands:
-            - import os
-            - import django
-            - os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wagtail_localize.test.settings")
-            - django.setup()
   - include-markdown
 nav:
   - Home: index.md
@@ -54,6 +49,7 @@ nav:
       - Configuring translatable fields: how-to/field-configuration.md
       - Translatable ModelAdmin: how-to/modeladmin.md
       - Configuring background tasks: how-to/configure-background-tasks.md
+      - Tips: how-to/tips.md
       - Integrations:
           - Pontoon: how-to/integrations/pontoon.md
           - Machine Translation: how-to/integrations/machine-translation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,12 @@ plugins:
       handlers:
         python:
           options:
+            show_root_heading: false
             show_root_toc_entry: false
             show_signature_annotations: true
+            show_root_full_path: false
+            docstring_section_style: table
+            show_symbol_type_heading: true
   - include-markdown
 nav:
   - Home: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,15 @@ google = [
     "google-cloud-translate>=3.0.0"
 ]
 documentation = [
-    "mkdocs==1.4.3",
-    "mkdocs-material>=9.1,<10",
-    "mkdocstrings[python]==0.22.0",
-    "mkdocs-autorefs>=0.4.0,<0.5",
-    "mkdocs-include-markdown-plugin>=4.0.4,<5",
-    "pygments>=2.15,<2.16",
+    "mkdocs>=1.6,<2",
+    "mkdocs-material>=9.7,<12",
+    "mkdocstrings[python]>=1.0.0,<2",
+    "mkdocs-autorefs>=1.4.4,<2",
+    "mkdocs-include-markdown-plugin>=7.0.0,<8",
+    "pymdown-extensions>=10.21,<11",
+    "pygments>=2.16,<3",
+    "dj-database-url>=2.1.0,<3",
+    
 ]
 testing = [
     "dj-database-url>=2.1.0,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ documentation = [
     "pymdown-extensions>=10.21,<11",
     "pygments>=2.16,<3",
     "dj-database-url>=2.1.0,<3",
-    
 ]
 testing = [
     "dj-database-url>=2.1.0,<3",

--- a/wagtail_localize/fields.py
+++ b/wagtail_localize/fields.py
@@ -98,7 +98,7 @@ class SynchronizedField(BaseTranslatableField):
         return f"<SynchronizedField {self.field_name}>"
 
 
-def get_translatable_fields(model):
+def get_translatable_fields(model) -> list:
     """
     Derives a list of translatable fields from the given model class.
 

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -191,7 +191,7 @@ class TranslatableObject(models.Model):
     def __str__(self):
         return f"TranslatableObject: {self.translation_key}, {self.content_type_id}"
 
-    def has_translation(self, locale):
+    def has_translation(self, locale) -> bool:
         """
         Returns True if there is an instance of this object in the given Locale.
 
@@ -205,7 +205,7 @@ class TranslatableObject(models.Model):
             translation_key=self.translation_key, locale_id=pk(locale)
         ).exists()
 
-    def get_instance(self, locale):
+    def get_instance(self, locale) -> models.Model:
         """
         Returns a model instance for this object in the given locale.
 
@@ -222,7 +222,7 @@ class TranslatableObject(models.Model):
             translation_key=self.translation_key, locale_id=pk(locale)
         )
 
-    def get_instance_or_none(self, locale):
+    def get_instance_or_none(self, locale) -> models.Model | None:
         """
         Returns a model instance for this object in the given locale.
 
@@ -335,7 +335,7 @@ class TranslationSource(models.Model):
         return f"TranslationSource: {self.object_id}, {self.specific_content_type_id}, {self.locale}"
 
     @classmethod
-    def get_or_create_from_instance(cls, instance):
+    def get_or_create_from_instance(cls, instance) -> tuple["TranslationSource", bool]:
         """
         Creates or gets a TranslationSource for the given instance.
 
@@ -348,7 +348,7 @@ class TranslationSource(models.Model):
                 instance for.
 
         Returns:
-            tuple[TranslationSource, boolean]: A two-tuple, the first component is the TranslationSource object, and
+            tuple[TranslationSource, bool]: A two-tuple, the first component is the TranslationSource object, and
                 the second component is a boolean that is True if the TranslationSource was created.
         """
         # Make sure we're using the specific version of pages
@@ -394,7 +394,9 @@ class TranslationSource(models.Model):
         return source, created
 
     @classmethod
-    def update_or_create_from_instance(cls, instance):
+    def update_or_create_from_instance(
+        cls, instance
+    ) -> tuple["TranslationSource", bool]:
         """
         Creates or updates a TranslationSource for the given instance.
 
@@ -406,7 +408,7 @@ class TranslationSource(models.Model):
                 from.
 
         Returns:
-            tuple[TranslationSource, boolean]: A two-tuple, the first component is the TranslationSource object, and
+            tuple[TranslationSource, bool]: A two-tuple, the first component is the TranslationSource object, and
                 the second component is a boolean that is True if the TranslationSource was created.
         """
         # Make sure we're using the specific version of pages
@@ -481,7 +483,7 @@ class TranslationSource(models.Model):
         )
         self.refresh_segments()
 
-    def get_source_instance(self):
+    def get_source_instance(self) -> models.Model:
         """
         This gets the live version of instance that the source data was extracted from.
 
@@ -512,7 +514,7 @@ class TranslationSource(models.Model):
             translation_key=self.object_id, locale_id=pk(locale)
         )
 
-    def as_instance(self):
+    def as_instance(self) -> models.Model:
         """
         Builds an instance of the object with the content of this source.
 
@@ -586,7 +588,7 @@ class TranslationSource(models.Model):
             id__in=seen_overridable_segment_ids
         ).delete()
 
-    def export_po(self):
+    def export_po(self) -> polib.POFile:
         """
         Exports all translatable strings from this source.
 
@@ -595,6 +597,7 @@ class TranslationSource(models.Model):
         Returns:
             polib.POFile: A POFile object containing the source translatable strings.
         """
+
         # Get messages
         messages = []
 
@@ -710,7 +713,7 @@ class TranslationSource(models.Model):
 
     def create_or_update_translation(
         self, locale, user=None, publish=True, copy_parent_pages=False, fallback=False
-    ):
+    ) -> models.Model:
         """
         Creates/updates a translation of the object into the specified locale
         based on the content of this source and the translated strings
@@ -876,7 +879,7 @@ class TranslationSource(models.Model):
 
         return translation, created
 
-    def get_ephemeral_translated_instance(self, locale, fallback=False):
+    def get_ephemeral_translated_instance(self, locale, fallback=False) -> models.Model:
         """
         Returns an instance with the translations added which is not intended to be saved.
 
@@ -1092,7 +1095,7 @@ class Translation(models.Model):
     def __str__(self):
         return f"Translation: {self.uuid}, {self.source_id}, {self.target_locale_id}, (enabled: {self.enabled})"
 
-    def get_target_instance(self):
+    def get_target_instance(self) -> models.Model:
         """
         Fetches the translated instance from the database.
 
@@ -1104,7 +1107,7 @@ class Translation(models.Model):
         """
         return self.source.get_translated_instance(self.target_locale)
 
-    def get_target_instance_edit_url(self):
+    def get_target_instance_edit_url(self) -> str:
         """
         Returns the URL to edit the target instance.
 
@@ -1116,11 +1119,11 @@ class Translation(models.Model):
         """
         return get_edit_url(self.get_target_instance())
 
-    def get_progress(self):
+    def get_progress(self) -> tuple[int, int]:
         """
         Gets the current translation progress.
 
-        Returns
+        Returns:
             tuple[int, int]: A two-tuple of integers. First integer is the total number of string segments to be translated.
                 The second integer is the number of string segments that have been translated so far.
         """
@@ -1154,7 +1157,7 @@ class Translation(models.Model):
 
         return aggs["total_segments"], aggs["translated_segments"]
 
-    def get_status_display(self):
+    def get_status_display(self) -> str:
         """
         Returns a string to describe the current status of this translation to a user.
 
@@ -1167,7 +1170,7 @@ class Translation(models.Model):
         else:
             return _("Waiting for translations")
 
-    def export_po(self):
+    def export_po(self) -> polib.POFile:
         """
         Exports all translatable strings with any translations that have already been made.
 
@@ -1241,7 +1244,7 @@ class Translation(models.Model):
     @transaction.atomic
     def import_po(
         self, po, delete=False, user=None, translation_type="manual", tool_name=""
-    ):
+    ) -> list:
         """
         Imports all translatable strings with any translations that have already been made.
 
@@ -1334,7 +1337,7 @@ class Translation(models.Model):
 
         return warnings
 
-    def save_target(self, user=None, publish=True):
+    def save_target(self, user=None, publish=True) -> models.Model:
         """
         Saves the target page/snippet using the current translations.
 
@@ -1351,7 +1354,7 @@ class Translation(models.Model):
         Returns:
             Model: The translated instance.
         """
-        self.source.create_or_update_translation(
+        return self.source.create_or_update_translation(
             self.target_locale,
             user=user,
             publish=publish,
@@ -1393,7 +1396,7 @@ class TranslationLog(models.Model):
             f"TranslationLog: {self.source_id}, {self.locale_id}, {self.revision_id} "
         )
 
-    def get_instance(self):
+    def get_instance(self) -> "models.Model":
         """
         Gets the instance of the translated object, if it still exists.
 
@@ -1401,7 +1404,7 @@ class TranslationLog(models.Model):
             Model.DoesNotExist: if the translated object no longer exists.
 
         Returns:
-            The translated object.
+            models.Model: The translated object.
         """
         return self.source.object.get_instance(self.locale)
 
@@ -1451,12 +1454,12 @@ class String(models.Model):
         return uuid.uuid5(cls.UUID_NAMESPACE, data)
 
     @classmethod
-    def from_value(cls, locale, stringvalue):
+    def from_value(cls, locale, stringvalue) -> "String":
         """
         Gets or creates a String instance from a StringValue object.
 
         Args:
-            locale (ForeignKey to Locale) The locale of the string.
+            locale (ForeignKey to Locale): The locale of the string.
             stringvalue (StringValue): The value of the string.
 
         Returns:
@@ -1470,7 +1473,7 @@ class String(models.Model):
 
         return string
 
-    def as_value(self):
+    def as_value(self) -> StringValue:
         """
         Creates a StringValue object from the contents of this string.
 
@@ -1699,7 +1702,7 @@ class StringTranslation(models.Model):
                 self.save(update_fields=["has_error"])
 
     @classmethod
-    def from_text(cls, translation_of, locale, context, data):
+    def from_text(cls, translation_of, locale, context, data) -> "StringTranslation":
         """
         Gets or creates a StringTranslation instance from the given parameters.
 
@@ -1711,7 +1714,7 @@ class StringTranslation(models.Model):
             data (TextField): The translation.
 
         Returns:
-            String: The String instance that corresponds with the given stringvalue and locale.
+            StringTranslation: The StringTranslation instance that corresponds with the given parameters.
         """
         segment, created = cls.objects.get_or_create(
             translation_of=translation_of,
@@ -1738,7 +1741,7 @@ class StringTranslation(models.Model):
         self.field_error = error[0].messages[0]
         self.save(update_fields=["has_error", "field_error"])
 
-    def get_error(self):
+    def get_error(self) -> str | None:
         """
         Returns a string containing any validation errors on the saved value.
 
@@ -1760,7 +1763,7 @@ class StringTranslation(models.Model):
         if self.context is not None and self.field_error:
             return self.field_error
 
-    def get_comment(self):
+    def get_comment(self) -> str | None:
         """
         Returns a comment to display to the user containing info on how and when the string was translated.
 
@@ -1829,7 +1832,7 @@ class Template(models.Model):
         return f"Template: {self.uuid}, {self.template_format}, {self.string_count}"
 
     @classmethod
-    def from_value(cls, template_value):
+    def from_value(cls, template_value) -> "Template":
         """
         Gets or creates a Template instance from a TemplateValue object.
 
@@ -1910,18 +1913,14 @@ class SegmentOverride(models.Model):
 
     def set_field_error(self, error):
         """
-        Returns a string containing any validation errors on the saved value.
-
-        Returns:
-            str: The validation error if there is one.
-            None: If there isn't an error.
+        Sets a validation error on this segment override.
         """
         self.has_error = True
         # TODO (someday): We currently only support one error at a time
         self.field_error = error[0].messages[0]
         self.save(update_fields=["has_error", "field_error"])
 
-    def get_error(self):
+    def get_error(self) -> str | None:
         """
         Returns a string containing any validation errors on the saved value.
 
@@ -2031,16 +2030,16 @@ class StringSegment(BaseSegment):
         return f"StringSegment from String({self.string_id})"
 
     @classmethod
-    def from_value(cls, source, language, value):
+    def from_value(cls, source, language, value) -> "StringSegment":
         """
-        Gets or creates a TemplateSegment instance from a TemplateValue object.
+        Gets or creates a StringSegment instance from a StringSegmentValue object.
 
         Args:
-            source (TranslationSource): The source the template value was extracted from.
-            template_value (TemplateValue): The value of the template.
+            source (TranslationSource): The source the string value was extracted from.
+            value (StringValue): The value of the string.
 
         Returns:
-            TemplateSegment: The TemplateSegment instance that corresponds with the given template_value and source.
+            StringSegment: The StringSegment instance that corresponds with the given value and source.
         """
         string = String.from_value(language, value.string)
         context, context_created = TranslationContext.objects.get_or_create(
@@ -2078,13 +2077,13 @@ class TemplateSegment(BaseSegment):
         return f"TemplateSegment({self.pk}) from Template({self.template_id})"
 
     @classmethod
-    def from_value(cls, source, value):
+    def from_value(cls, source, value) -> "TemplateSegment":
         """
         Gets or creates a TemplateSegment instance from a TemplateValue object.
 
         Args:
             source (TranslationSource): The source the template value was extracted from.
-            template_value (TemplateValue): The value of the template.
+            value (TemplateValue): The value of the template.
 
         Returns:
             TemplateSegment: The TemplateSegment instance that corresponds with the given template_value and source.

--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -1441,7 +1441,7 @@ class String(models.Model):
         return super().save(*args, **kwargs)
 
     @classmethod
-    def _get_data_hash(cls, data):
+    def _get_data_hash(cls, data) -> "uuid.UUID":
         """
         Generates a UUID from the given string.
 
@@ -1519,7 +1519,7 @@ class TranslationContext(models.Model):
         return super().save(*args, **kwargs)
 
     @classmethod
-    def _get_path_id(cls, path):
+    def _get_path_id(cls, path) -> "uuid.UUID":
         """
         Generates a UUID from the given content path.
 

--- a/wagtail_localize/segments/extract.py
+++ b/wagtail_localize/segments/extract.py
@@ -244,7 +244,7 @@ class StreamFieldSegmentExtractor:
         return segments
 
 
-def extract_segments(instance):
+def extract_segments(instance) -> list:
     """
     Extracts segments from the given model instance.
 

--- a/wagtail_localize/segments/ingest.py
+++ b/wagtail_localize/segments/ingest.py
@@ -22,7 +22,7 @@ def unquote_path_component(text):
     return text[1:-1].replace("\\'", "'").replace("\\\\", "\\")
 
 
-def organise_template_segments(segments):
+def organise_template_segments(segments) -> tuple[str, str, list[tuple[str, dict]]]:
     """
     Organises the segments for a RichTextField or RichTextBlock to prepare them for recombining.
 
@@ -67,7 +67,9 @@ def organise_template_segments(segments):
     )
 
 
-def handle_related_object(related_model, src_locale, tgt_locale, segments):
+def handle_related_object(
+    related_model, src_locale, tgt_locale, segments
+) -> models.Model:
     """
     Returns the instance of the related object that is referenced by the given segments.
 
@@ -279,7 +281,7 @@ def ingest_segments(original_obj, translated_obj, src_locale, tgt_locale, segmen
     Args:
         original_obj (Model): The original instance that the segments were extracted from.
         translated_obj (Model): The translated instance that we are ingesting segments into.
-        src_local (Locale): The locale of the source instance.
+        src_locale (Locale): The locale of the source instance.
         tgt_locale (Locale): The locale of the translated instance
         segments (list[StringSegmentValue, TemplateSegmentValue, RelatedObjectSegmentValue, or OverridableSegmentValue]):
             The segment values to ingest

--- a/wagtail_localize/segments/types.py
+++ b/wagtail_localize/segments/types.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.contrib.contenttypes.models import ContentType
 
 from wagtail_localize.strings import StringValue
@@ -96,7 +98,7 @@ class StringSegmentValue(BaseValue):
 
         super().__init__(path, **kwargs)
 
-    def clone(self):
+    def clone(self) -> "StringSegmentValue":
         """
         Makes an exact copy of this StringSegmentValue.
 
@@ -110,7 +112,7 @@ class StringSegmentValue(BaseValue):
         )
 
     @classmethod
-    def from_source_html(cls, path, html, **kwargs):
+    def from_source_html(cls, path, html, **kwargs) -> "StringSegmentValue":
         """
         Initialises a StringSegmentValue from a HTML string.
 
@@ -122,7 +124,7 @@ class StringSegmentValue(BaseValue):
         string, attrs = StringValue.from_source_html(html)
         return cls(path, string, attrs=attrs, **kwargs)
 
-    def render_text(self):
+    def render_text(self) -> str:
         """
         Returns a plain text representation of the segment value.
 
@@ -133,7 +135,7 @@ class StringSegmentValue(BaseValue):
         """
         return self.string.render_text()
 
-    def render_html(self):
+    def render_html(self) -> str:
         """
         Returns a HTML representation of the segment value.
 
@@ -144,12 +146,12 @@ class StringSegmentValue(BaseValue):
         """
         return self.string.render_html(self.attrs)
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """
         Returns True if the StringValue is blank.
 
         Returns:
-            boolean: True if the StringValue is blank.
+            bool: True if the StringValue is blank.
         """
         return self.string.data in ["", None]
 
@@ -194,7 +196,7 @@ class TemplateSegmentValue(BaseValue):
 
         super().__init__(path, **kwargs)
 
-    def clone(self):
+    def clone(self) -> "TemplateSegmentValue":
         """
         Makes an exact copy of this TemplateSegmentValue.
 
@@ -207,12 +209,12 @@ class TemplateSegmentValue(BaseValue):
             self.path, self.format, self.template, self.string_count, order=self.order
         )
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """
         Returns True if the template is blank.
 
         Returns:
-            boolean: True if the template is blank.
+            bool: True if the template is blank.
         """
         return self.template in ["", None]
 
@@ -256,7 +258,7 @@ class RelatedObjectSegmentValue(BaseValue):
         super().__init__(path, **kwargs)
 
     @classmethod
-    def from_instance(cls, path, instance):
+    def from_instance(cls, path, instance) -> "RelatedObjectSegmentValue":
         """
         Initialises a new RelatedObjectSegmentValue from a model instance.
 
@@ -278,7 +280,7 @@ class RelatedObjectSegmentValue(BaseValue):
             path, ContentType.objects.get_for_model(model), instance.translation_key
         )
 
-    def get_instance(self, locale):
+    def get_instance(self, locale) -> Any:
         """
         Gets an instance of the referenced translatable object for the given locale.
 
@@ -294,7 +296,7 @@ class RelatedObjectSegmentValue(BaseValue):
             translation_key=self.translation_key, locale_id=pk(locale)
         )
 
-    def clone(self):
+    def clone(self) -> "RelatedObjectSegmentValue":
         """
         Makes an exact copy of this RelatedObjectSegmentValue.
 
@@ -307,12 +309,12 @@ class RelatedObjectSegmentValue(BaseValue):
             self.path, self.content_type, self.translation_key, order=self.order
         )
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """
         Returns True if the related object is null.
 
         Returns:
-            boolean: True if the related object is null.
+            bool: True if the related object is null.
         """
         return self.content_type is None and self.translation_key is None
 
@@ -335,7 +337,7 @@ class OverridableSegmentValue(BaseValue):
     Attributes:
         path (str): The content path of the segment.
         data (any): The value of the field in the source. Must be JSON-serializable.
-        order (int): The index that this segment appears on a page.
+        order (int, optional): The index that this segment appears on a page.
     """
 
     def __init__(self, path, data, **kwargs):
@@ -351,7 +353,7 @@ class OverridableSegmentValue(BaseValue):
 
         super().__init__(path, **kwargs)
 
-    def clone(self):
+    def clone(self) -> "OverridableSegmentValue":
         """
         Makes an exact copy of this OverridableSegmentValue.
 
@@ -362,12 +364,12 @@ class OverridableSegmentValue(BaseValue):
         """
         return OverridableSegmentValue(self.path, self.data, order=self.order)
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """
         Returns True if the data is empty.
 
         Returns:
-            boolean: True if the data is empty.
+            bool: True if the data is empty.
         """
         return self.data in ["", None]
 

--- a/wagtail_localize/strings.py
+++ b/wagtail_localize/strings.py
@@ -77,7 +77,7 @@ class StringValue:
         self.data = data
 
     @classmethod
-    def from_plaintext(cls, text):
+    def from_plaintext(cls, text) -> "StringValue":
         """
         Initialises a StringValue from a plain text string.
 
@@ -103,7 +103,7 @@ class StringValue:
         return cls(str(BeautifulSoup("".join(elements), "html.parser")))
 
     @classmethod
-    def from_source_html(cls, html):
+    def from_source_html(cls, html) -> tuple["StringValue", dict]:
         """
         Initialises a StringValue from a HTML string.
 
@@ -145,7 +145,7 @@ class StringValue:
         return cls(str(soup)), attrs
 
     @classmethod
-    def from_translated_html(cls, html):
+    def from_translated_html(cls, html) -> "StringValue":
         """
         Initialises a StringValue from a HTML string.
 
@@ -164,7 +164,7 @@ class StringValue:
 
         return cls(str(soup))
 
-    def render_text(self):
+    def render_text(self) -> str:
         """
         Returns a plain text representation of the string.
 
@@ -191,7 +191,7 @@ class StringValue:
 
         return "".join(texts)
 
-    def render_soup(self, attrs):
+    def render_soup(self, attrs) -> BeautifulSoup:
         """
         Returns a BeautifulSoup instance containing the string.
 
@@ -222,7 +222,7 @@ class StringValue:
 
         return soup
 
-    def render_html(self, attrs):
+    def render_html(self, attrs) -> str:
         """
         Returns a HTML representation of the string.
 
@@ -233,7 +233,7 @@ class StringValue:
         """
         return str(self.render_soup(attrs))
 
-    def get_translatable_html(self):
+    def get_translatable_html(self) -> str:
         """
         Returns a HTML string without restoring any HTML attributes.
 
@@ -254,7 +254,7 @@ class StringValue:
         return hash(self.data)
 
 
-def extract_strings(html):
+def extract_strings(html) -> tuple[str, list[tuple[StringValue, dict]]]:
     """
     This function extracts translatable strings from an HTML fragment.
 
@@ -458,7 +458,7 @@ def extract_strings(html):
     return str(soup), strings
 
 
-def restore_strings(template, strings):
+def restore_strings(template, strings) -> str:
     """
     Inserts a list of strings into the template.
 


### PR DESCRIPTION
It fixes the _Read the Docs_ issues in recent builds; check them out:
https://app.readthedocs.org/projects/wagtail-localize/builds/31585372/

### Description

**Documentation improvements and corrections:**

* Updated all internal documentation links from absolute paths to relative `.md` files for consistency and to ensure proper navigation in the docs. [[1]](diffhunk://#diff-5daedcdb89fc2fbd061f9a4b67dab27244c6a3c1af9a42fcdab1ad79247b2910L95-R95) [[2]](diffhunk://#diff-6f9b4160a920b4ef516fe0a03322f8fd2671ce6d4c380687c69f947600cc39aeL8-R8) [[3]](diffhunk://#diff-9870eddf008e8bbab2dd419039ba4ec4c001b3fb81fd3097d40279a150291162L8-R8) [[4]](diffhunk://#diff-332b0b1133d716ff9e83e48b48b3804b9ef0a9de744de252cc00fce9792440e5L157-R158)
* Fixed a typo in the code example in `docs/how-to/configure-background-tasks.md` by correcting the import from `BaseJobBacked` to `BaseJobBackend`.
* Added a new "Tips" section to the documentation navigation for easier access to helpful information.

**API documentation structure simplification:**

* Refactored API reference documentation for models by splitting each model's documentation into its own section, removing the use of `selection:` and `filters:` for clarity and maintainability. [[1]](diffhunk://#diff-876c5b3ce49a305572d9439897a94a1dac88926b902249d4d771cac233bd2bfaL21-R23) [[2]](diffhunk://#diff-06154a557ef3a66079af794c3487c5265c469c6d57e643e717758117ff7b7097L14-R14) [[3]](diffhunk://#diff-171cab937497edbb8b3df5ab801f58285b0b940e4d653fdcef9adce21a37bca0L24-R32) [[4]](diffhunk://#diff-f846503f11140d3fae14d90e4c64de53e42d5dd4e5cb280c3c60e9670eac5c9bL20-R26) [[5]](diffhunk://#diff-74f0d7e6c26180e00a12c7297c58a9b189e122b4c23410fbf6223848912d1cbcL18-R24)

**Development and build configuration:**

* Updated documentation dependencies in `pyproject.toml` to use newer versions of MkDocs and related plugins, improving compatibility and feature support.
* Removed unnecessary Django setup commands from the MkDocs configuration, streamlining the documentation build process.


### AI usage

Has been used only for search the documentation build errors.


