### PR TITLE
Optimize PageIndex.from_database() to a constant query count

### DIFF
--- a/wagtail_localize/synctree.py
+++ b/wagtail_localize/synctree.py
@@ -63,31 +63,26 @@ class PageIndex:
         ]
 
         @classmethod
-        def from_page_instance(cls, page):
+        def from_page_instance(
+            cls, page, locales_by_key, aliased_locales_by_key, translation_key_by_path
+        ):
             """
             Initialises an Entry from the given page instance.
             """
             # Get parent, but only if the parent is not the root page. We consider the
             # homepage of each langauge tree to be the roots
-            parent_page = page.get_parent() if page.depth > 2 else None
+            parent_path = page.path[: -Page.steplen] if page.depth > 2 else None
+            parent_translation_key = (
+                translation_key_by_path.get(parent_path) if parent_path else None
+            )
 
             return cls(
                 page.content_type,
                 page.translation_key,
                 page.locale,
-                parent_page.translation_key if parent_page else None,
-                list(
-                    Page.objects.filter(
-                        translation_key=page.translation_key,
-                        alias_of__isnull=True,
-                    ).values_list("locale", flat=True)
-                ),
-                list(
-                    Page.objects.filter(
-                        translation_key=page.translation_key,
-                        alias_of__isnull=False,
-                    ).values_list("locale", flat=True)
-                ),
+                parent_translation_key,
+                locales_by_key.get(page.translation_key, []),
+                aliased_locales_by_key.get(page.translation_key, []),
             )
 
     def __init__(self, pages):
@@ -148,11 +143,32 @@ class PageIndex:
         Populates the index from the database.
         """
         pages = []
+        translation_key_by_path = {}
+        locales_by_key = defaultdict(list)
+        aliased_locales_by_key = defaultdict(list)
 
-        for page in Page.objects.filter(alias_of__isnull=True, depth__gt=1).only(
-            *PageIndex.Entry.REQUIRED_PAGE_FIELDS
+        for translation_key, locale_id, alias_of_id, path in Page.objects.values_list(
+            "translation_key", "locale_id", "alias_of_id", "path"
         ):
-            pages.append(PageIndex.Entry.from_page_instance(page))
+            translation_key_by_path[path] = translation_key
+            if alias_of_id is None:
+                locales_by_key[translation_key].append(locale_id)
+            else:
+                aliased_locales_by_key[translation_key].append(locale_id)
+
+        for page in (
+            Page.objects.filter(alias_of__isnull=True, depth__gt=1)
+            .select_related("content_type", "locale")
+            .only(*PageIndex.Entry.REQUIRED_PAGE_FIELDS)
+        ):
+            pages.append(
+                PageIndex.Entry.from_page_instance(
+                    page,
+                    locales_by_key,
+                    aliased_locales_by_key,
+                    translation_key_by_path,
+                )
+            )
 
         return PageIndex(pages)
 

--- a/wagtail_localize/tests/test_synctree.py
+++ b/wagtail_localize/tests/test_synctree.py
@@ -268,15 +268,6 @@ class TestSignalsAndHooks(TestCase, WagtailTestUtils):
 
 
 class TestPageIndexQueryCount(TestCase):
-    # Each unit is 3 pages sharing one translation_key: an original, its
-    # translation, and an alias. from_database() indexes only non-alias pages,
-    # so a unit contributes 2 indexed pages (original + translation).
-    NON_ALIAS_PAGES_PER_UNIT = 2
-    # Each indexed page costs at least 2 queries: the locales and aliased_locales
-    # lookups. Other per-page queries exist but aren't guaranteed, so the
-    # threshold below counts only this floor.
-    MIN_QUERIES_PER_PAGE = 2
-
     def setUp(self):
         self.en_locale = Locale.objects.get(language_code="en")
         self.fr_locale = Locale.objects.create(language_code="fr")
@@ -307,14 +298,10 @@ class TestPageIndexQueryCount(TestCase):
 
         return len(ctx.captured_queries)
 
-    def test_from_database_query_count_scales_with_localization_units(self):
-        # Subtracting the two counts cancels the fixed overhead and isolates the
-        # marginal per-unit cost. In the N+1 version each non-alias page adds at
-        # least its two per-page lookups (locales + aliased_locales).
+    def test_from_database_query_count_is_constant_with_localization_units(self):
+        # from_database() should issue the same number of queries regardless
+        # of how many localization units exist in the tree.
         small = self._count_index_queries(num_units=3)
         large = self._count_index_queries(num_units=12)
 
-        self.assertGreaterEqual(
-            large - small,
-            (12 - 3) * self.NON_ALIAS_PAGES_PER_UNIT * self.MIN_QUERIES_PER_PAGE,
-        )
+        self.assertEqual(small, large)

--- a/wagtail_localize/tests/test_synctree.py
+++ b/wagtail_localize/tests/test_synctree.py
@@ -1,5 +1,3 @@
-import time
-
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.test import TestCase
@@ -270,64 +268,53 @@ class TestSignalsAndHooks(TestCase, WagtailTestUtils):
 
 
 class TestPageIndexQueryCount(TestCase):
+    # Each unit is 3 pages sharing one translation_key: an original, its
+    # translation, and an alias. from_database() indexes only non-alias pages,
+    # so a unit contributes 2 indexed pages (original + translation).
+    NON_ALIAS_PAGES_PER_UNIT = 2
+    # Each indexed page costs at least 2 queries: the locales and aliased_locales
+    # lookups. Other per-page queries exist but aren't guaranteed, so the
+    # threshold below counts only this floor.
+    MIN_QUERIES_PER_PAGE = 2
+
     def setUp(self):
         self.en_locale = Locale.objects.get(language_code="en")
         self.fr_locale = Locale.objects.create(language_code="fr")
         self.fr_ca_locale = Locale.objects.create(language_code="fr-CA")
-        self.es_locale = Locale.objects.create(language_code="es")
 
+    def _count_index_queries(self, num_units):
+        # Rebuild the tree from scratch so each measurement is independent,
+        # then add num_units localization units under the homepage.
         root_page = Page.objects.get(id=1)
         root_page.get_children().delete()
         root_page.refresh_from_db()
-        self.en_homepage = root_page.add_child(instance=TestHomePage(title="Home"))
 
-    def test_from_database_query_count_single_page(self):
-        # Clear ContentType cache to ensure consistent query count regardless of test execution order
-        ContentType.objects.clear_cache()
-        with CaptureQueriesContext(connection) as ctx:
-            start = time.perf_counter()
-            PageIndex.from_database()
-            elapsed = time.perf_counter() - start
+        en_homepage = root_page.add_child(instance=TestHomePage(title="Home"))
+        fr_homepage = en_homepage.copy_for_translation(self.fr_locale)
+        fr_homepage.copy_for_translation(self.fr_ca_locale)
 
-        print(f"from_database() baseline (single page): {elapsed:.4f}s")
-
-        # 5 queries: fetch all pages, content type lookup, locale lookup, locales, aliases
-        self.assertEqual(len(ctx.captured_queries), 5)
-
-    def test_from_database_query_count_multiple_pages(self):
-        fr_homepage = self.en_homepage.copy_for_translation(self.fr_locale)
-        fr_ca_homepage = fr_homepage.copy_for_translation(self.fr_ca_locale)
-
-        en_aboutpage = self.en_homepage.add_child(
-            instance=TestPage(
-                title="About",
-                slug="about",
+        # Each unit is an original page, its translation, and an alias, so the
+        # measurement exercises both the locales and aliased_locales grouping.
+        for i in range(num_units):
+            en_page = en_homepage.add_child(
+                instance=TestPage(title=f"Page {i}", slug=f"page-{i}")
             )
-        )
+            fr_page = en_page.copy_for_translation(self.fr_locale)
+            fr_page.copy_for_translation(self.fr_ca_locale, alias=True)
 
-        fr_aboutpage = en_aboutpage.copy_for_translation(self.fr_locale)
-        fr_aboutpage.copy_for_translation(self.fr_ca_locale, alias=True)
-
-        fr_ca_homepage.refresh_from_db()
-        fr_ca_homepage.add_child(
-            instance=TestPage(
-                title="Only Canada",
-                slug="only-canada",
-                locale=self.fr_ca_locale,
-            )
-        )
-
-        ContentType.objects.clear_cache()
         with CaptureQueriesContext(connection) as ctx:
-            start = time.perf_counter()
             PageIndex.from_database()
-            elapsed = time.perf_counter() - start
 
-        print(f"from_database() baseline (multiple pages): {elapsed:.4f}s")
+        return len(ctx.captured_queries)
 
-        # Baseline query count for 6 non-alias pages (3 at depth=2, 3 at depth=3):
-        # 1 (fetch all pages)
-        # + 3 * 4 (depth=2 pages: content type + locale + locales + aliased_locales)
-        # + 3 * 5 (depth=3 pages: get_parent + content type + locale + locales + aliased_locales)
-        # = 28
-        self.assertEqual(len(ctx.captured_queries), 28)
+    def test_from_database_query_count_scales_with_localization_units(self):
+        # Subtracting the two counts cancels the fixed overhead and isolates the
+        # marginal per-unit cost. In the N+1 version each non-alias page adds at
+        # least its two per-page lookups (locales + aliased_locales).
+        small = self._count_index_queries(num_units=3)
+        large = self._count_index_queries(num_units=12)
+
+        self.assertGreaterEqual(
+            large - small,
+            (12 - 3) * self.NON_ALIAS_PAGES_PER_UNIT * self.MIN_QUERIES_PER_PAGE,
+        )

--- a/wagtail_localize/tests/test_synctree.py
+++ b/wagtail_localize/tests/test_synctree.py
@@ -1,5 +1,9 @@
+import time
+
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from wagtail.models import Locale, Page
 from wagtail.test.utils import WagtailTestUtils
@@ -263,3 +267,67 @@ class TestSignalsAndHooks(TestCase, WagtailTestUtils):
         self.assertTrue(new_en_homepage.has_translation(self.fr_locale))
         self.assertTrue(new_en_homepage.has_translation(self.fr_ca_locale))
         self.assertTrue(new_en_homepage.has_translation(self.es_locale))
+
+
+class TestPageIndexQueryCount(TestCase):
+    def setUp(self):
+        self.en_locale = Locale.objects.get(language_code="en")
+        self.fr_locale = Locale.objects.create(language_code="fr")
+        self.fr_ca_locale = Locale.objects.create(language_code="fr-CA")
+        self.es_locale = Locale.objects.create(language_code="es")
+
+        root_page = Page.objects.get(id=1)
+        root_page.get_children().delete()
+        root_page.refresh_from_db()
+        self.en_homepage = root_page.add_child(instance=TestHomePage(title="Home"))
+
+    def test_from_database_query_count_single_page(self):
+        # Clear ContentType cache to ensure consistent query count regardless of test execution order
+        ContentType.objects.clear_cache()
+        with CaptureQueriesContext(connection) as ctx:
+            start = time.perf_counter()
+            PageIndex.from_database()
+            elapsed = time.perf_counter() - start
+
+        print(f"from_database() baseline (single page): {elapsed:.4f}s")
+
+        # 5 queries: fetch all pages, content type lookup, locale lookup, locales, aliases
+        self.assertEqual(len(ctx.captured_queries), 5)
+
+    def test_from_database_query_count_multiple_pages(self):
+        fr_homepage = self.en_homepage.copy_for_translation(self.fr_locale)
+        fr_ca_homepage = fr_homepage.copy_for_translation(self.fr_ca_locale)
+
+        en_aboutpage = self.en_homepage.add_child(
+            instance=TestPage(
+                title="About",
+                slug="about",
+            )
+        )
+
+        fr_aboutpage = en_aboutpage.copy_for_translation(self.fr_locale)
+        fr_aboutpage.copy_for_translation(self.fr_ca_locale, alias=True)
+
+        fr_ca_homepage.refresh_from_db()
+        fr_ca_homepage.add_child(
+            instance=TestPage(
+                title="Only Canada",
+                slug="only-canada",
+                locale=self.fr_ca_locale,
+            )
+        )
+
+        ContentType.objects.clear_cache()
+        with CaptureQueriesContext(connection) as ctx:
+            start = time.perf_counter()
+            PageIndex.from_database()
+            elapsed = time.perf_counter() - start
+
+        print(f"from_database() baseline (multiple pages): {elapsed:.4f}s")
+
+        # Baseline query count for 6 non-alias pages (3 at depth=2, 3 at depth=3):
+        # 1 (fetch all pages)
+        # + 3 * 4 (depth=2 pages: content type + locale + locales + aliased_locales)
+        # + 3 * 5 (depth=3 pages: get_parent + content type + locale + locales + aliased_locales)
+        # = 28
+        self.assertEqual(len(ctx.captured_queries), 28)


### PR DESCRIPTION
Closes #927

### Description

This PR includes several commits to document and fix the query behaviour of `PageIndex.from_database()`.

The first commit adds a characterization test showing that the number of queries grows with the number of pages in the tree.

The next commit optimizes `from_database()`: instead of issuing per-page queries inside the main loop, it does a single bulk query up front and builds lookup dictionaries (`locales`, `aliased_locales`, and parent resolution via `path` instead of `get_parent()`), plus `select_related("content_type", "locale")` to avoid per-page FK queries.

### Tests

The characterization test is updated to assert that the query count stays the same regardless of tree size (`assertEqual(small, large)`), instead of asserting that it grows. The 4 other existing tests in `test_synctree.py` still pass, confirming behaviour is preserved.

### AI usage

Used AI assistance to find the cause of the query growth and to draft the fix and its test. I reviewed, tested and understood every change.