### PR TITLE
Compatibility fixes for Wagtail 8.0

### DIFF
--- a/wagtail_localize/templates/wagtail_localize/admin/edit_translation.html
+++ b/wagtail_localize/templates/wagtail_localize/admin/edit_translation.html
@@ -47,7 +47,7 @@
 {% endblock %}
 
 {% block extra_js %}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
+    {% hook_output 'insert_editor_js' %}
     <script>
         if (typeof window.chooserUrls === "undefined") {
             window.chooserUrls = {

--- a/wagtail_localize/test/models.py
+++ b/wagtail_localize/test/models.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
 from wagtail import VERSION as WAGTAIL_VERSION
-from wagtail import blocks, telepath
+from wagtail import blocks
 from wagtail.admin.panels import (
     FieldPanel,
     InlinePanel,
@@ -32,6 +32,12 @@ from wagtail_localize.components import register_translation_component
 from wagtail_localize.fields import SynchronizedField, TranslatableField
 from wagtail_localize.models import TranslationSource
 from wagtail_localize.segments import StringSegmentValue
+
+
+try:
+    from wagtail.admin import telepath
+except ImportError:  # Wagtail <7.1
+    from wagtail import telepath
 
 
 if WAGTAIL_VERSION >= (6, 3):

--- a/wagtail_localize/tests/test_get_translatable_fields.py
+++ b/wagtail_localize/tests/test_get_translatable_fields.py
@@ -17,7 +17,7 @@ class TestGetTranslatableFields(TestCase):
             TestGenerateTranslatableFieldsPage
         )
 
-        self.assertEqual(
+        self.assertCountEqual(
             translatable_fields,
             [
                 TranslatableField("title"),
@@ -48,7 +48,7 @@ class TestOverrideTranslatableFields(TestCase):
             TestOverrideTranslatableFieldsPage
         )
 
-        self.assertEqual(
+        self.assertCountEqual(
             translatable_fields,
             [
                 TranslatableField("title"),


### PR DESCRIPTION
### Description

Fix failing tests against Wagtail main (8.0):

- update outdated import of `wagtail.telepath` to `wagtail.admin.telepath`
- remove reference to dead template `wagtailadmin/pages/_editor_js.html`

This is intended to be applied at the same time as dropping support for Wagtail <7.0 (as implemented in #921) - I can't vouch for its correctness against older releases. Also, this depends on the corresponding removal of `wagtailadmin/pages/_editor_js.html` from wagtail-modeladmin, which happened in https://github.com/wagtail-nest/wagtail-modeladmin/pull/63 but has not yet made it into a release.

### AI usage

None
