### PR TITLE
Handle deleted images in translation editor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,21 @@ env:
   PYTHON_LATEST: '3.13'
 
 jobs:
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+
   test-sqlite:
     runs-on: ubuntu-latest
     strategy:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "main": "src/main.ts",
   "scripts": {
     "build": "webpack --mode=production",
-    "start": "webpack --mode=development --watch"
+    "start": "webpack --mode=development --watch",
+    "test": "node scripts/test-image-chooser.js"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/test-image-chooser.js
+++ b/scripts/test-image-chooser.js
@@ -1,0 +1,79 @@
+/* eslint-env node */
+/* eslint-disable @typescript-eslint/no-var-requires, import/no-extraneous-dependencies, import/no-unresolved */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const ts = require('typescript');
+const vm = require('vm');
+
+const sourcePath = path.resolve(
+    __dirname,
+    '../wagtail_localize/static_src/common/components/ImageChooser/api/index.ts'
+);
+const source = fs.readFileSync(sourcePath, 'utf8');
+const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2018,
+    },
+});
+const testModule = { exports: {} };
+
+vm.runInNewContext(compiled.outputText, {
+    module: testModule,
+    exports: testModule.exports,
+    fetch: (...args) => global.fetch(...args),
+});
+
+const { fetchImageInfo } = testModule.exports;
+const originalFetch = global.fetch;
+
+const validImage = {
+    id: 42,
+    title: 'Landscape',
+    thumbnail: {
+        url: '/media/images/landscape.max-165x165.jpg',
+        width: 165,
+        height: 110,
+    },
+};
+
+const run = async () => {
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => validImage,
+    });
+    assert.deepStrictEqual(await fetchImageInfo('/admin/', 42), validImage);
+
+    let parsedNotFoundResponse = false;
+    global.fetch = async () => ({
+        ok: false,
+        json: async () => {
+            parsedNotFoundResponse = true;
+            return { message: 'Not found' };
+        },
+    });
+    assert.strictEqual(await fetchImageInfo('/admin/', 42), null);
+    assert.strictEqual(parsedNotFoundResponse, false);
+
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => ({ message: 'Unexpected response' }),
+    });
+    assert.strictEqual(await fetchImageInfo('/admin/', 42), null);
+
+    global.fetch = async () => {
+        throw new Error('Network failure');
+    };
+    assert.strictEqual(await fetchImageInfo('/admin/', 42), null);
+};
+
+run()
+    .finally(() => {
+        global.fetch = originalFetch;
+    })
+    .catch((error) => {
+        process.stderr.write(`${error.stack || error}\n`);
+        process.exitCode = 1;
+    });

--- a/wagtail_localize/static_src/common/components/ImageChooser/api/index.ts
+++ b/wagtail_localize/static_src/common/components/ImageChooser/api/index.ts
@@ -1,0 +1,48 @@
+export interface ImageAPI {
+    id: number;
+    title: string;
+    thumbnail: {
+        url: string;
+        width: number;
+        height: number;
+    };
+}
+
+const isImageAPI = (value: unknown): value is ImageAPI => {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    const image = value as Partial<ImageAPI>;
+    const { thumbnail } = image;
+
+    return (
+        typeof image.id === 'number' &&
+        typeof image.title === 'string' &&
+        typeof thumbnail === 'object' &&
+        thumbnail !== null &&
+        typeof thumbnail.url === 'string' &&
+        typeof thumbnail.width === 'number' &&
+        typeof thumbnail.height === 'number'
+    );
+};
+
+export const fetchImageInfo = async (
+    adminBaseUrl: string,
+    imageId: number
+): Promise<ImageAPI | null> => {
+    try {
+        const response = await fetch(
+            `${adminBaseUrl}api/main/images/${imageId}/`
+        );
+
+        if (!response.ok) {
+            return null;
+        }
+
+        const image = await response.json();
+        return isImageAPI(image) ? image : null;
+    } catch {
+        return null;
+    }
+};

--- a/wagtail_localize/static_src/common/components/ImageChooser/index.tsx
+++ b/wagtail_localize/static_src/common/components/ImageChooser/index.tsx
@@ -1,15 +1,13 @@
+/* eslint-disable react/prop-types */
+
 import React, { FunctionComponent } from 'react';
+// gettext is provided as a Wagtail runtime external.
+// eslint-disable-next-line import/no-unresolved
 import gettext from 'gettext';
 
-interface ImageAPI {
-    id: number;
-    title: string;
-    thumbnail: {
-        url: string;
-        width: number;
-        height: number;
-    };
-}
+// TypeScript resolves the directory's index module.
+// eslint-disable-next-line import/extensions
+import { fetchImageInfo, ImageAPI } from './api';
 
 interface ImageChooserProps {
     adminBaseUrl: string;
@@ -21,22 +19,43 @@ const ImageChooser: FunctionComponent<ImageChooserProps> = ({
     imageId,
 }) => {
     const [imageInfo, setImageInfo] = React.useState<ImageAPI | null>(null);
+    const [imageInfoUnavailable, setImageInfoUnavailable] =
+        React.useState(false);
 
     React.useEffect(() => {
+        let cancelled = false;
+
         setImageInfo(null);
+        setImageInfoUnavailable(false);
 
         if (imageId) {
-            fetch(`${adminBaseUrl}api/main/images/${imageId}/`)
-                .then((response) => response.json())
-                .then(setImageInfo);
+            fetchImageInfo(adminBaseUrl, imageId).then((image) => {
+                if (!cancelled) {
+                    setImageInfo(image);
+                    setImageInfoUnavailable(image === null);
+                }
+            });
         }
-    }, [imageId]);
+
+        return () => {
+            cancelled = true;
+        };
+    }, [adminBaseUrl, imageId]);
 
     // Render
-    let classNames = ['chooser', 'image-chooser'];
+    const classNames = ['chooser', 'image-chooser'];
     let inner;
     if (imageId) {
-        if (imageInfo) {
+        if (imageInfoUnavailable) {
+            inner = (
+                <p>
+                    {gettext('Image %s no longer exists.').replace(
+                        '%s',
+                        imageId.toString()
+                    )}
+                </p>
+            );
+        } else if (imageInfo) {
             inner = (
                 <div className="chosen">
                     <div className="preview-image">


### PR DESCRIPTION
## Summary

- reject non-successful and malformed image API responses before they reach the chooser render path
- show a local missing-image message instead of crashing the whole translation editor
- ignore stale async responses when the selected image changes
- add a dependency-free regression test and run frontend tests/builds in CI

## Root cause

The chooser parsed every API response and stored it as image metadata. A deleted image returns a non-2xx error payload without `thumbnail`, so rendering `imageInfo.thumbnail.url` threw and unmounted the editor.

Fixes #769.

## Validation

- `npm test`
- `./node_modules/.bin/tsc --noEmit`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- Node 14.21.3 Docker gate: regression test, TypeScript compile, and production build
- Prettier 2.7.1 and the repository ESLint stack on changed frontend files
- `git diff --check`

## AI disclosure

I used OpenAI Codex to help investigate the issue, implement the fix, and run validation. I reviewed the resulting code and test coverage before submission.