### PR TITLE
Add performance benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ or, you can run them for a specific environment `tox -e python3.13-django5.2-wag
 
 To run the test app interactively, use `tox -e interactive`, visit `http://127.0.0.1:8020/admin/` and log in with `admin`/`changeme`.
 
+### Performance benchmarks
+
+See [`benchmarks/README.md`](benchmarks/README.md) for the benchmark catalog,
+methodology, and commands for reproducible before/after measurements.
+
 ## Support
 
 For support, please use [GitHub Discussions](https://github.com/wagtail/wagtail-localize/discussions) or ask a question on the `#multi-language` channel on [Wagtail's Slack instance](https://wagtail.org/slack/).

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ To run the test app interactively, use `tox -e interactive`, visit `http://127.0
 
 ### Performance benchmarks
 
-See [`benchmarks/README.md`](benchmarks/README.md) for the benchmark catalog,
-methodology, and commands for reproducible before/after measurements.
+See [`benchmarks/README.md`](https://github.com/wagtail/wagtail-localize/blob/main/benchmarks/README.md)
+for the benchmark catalog, methodology, and commands for reproducible
+before/after measurements.
 
 ## Support
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,133 @@
+# Performance benchmarks
+
+This directory contains a small benchmark harness for measuring representative
+wagtail-localize processes. It reports database query counts and elapsed time
+for a fixed synthetic fixture, and verifies that every run completed the
+workload it claims to measure.
+
+The harness is intended for reproducible before/after comparisons. It is not an
+exhaustive performance suite, a profiler, or a CI performance gate. Use a
+profiler or a query-analysis tool to explain a result; use this harness to show
+the effect of a change at a stable boundary.
+
+## Running the benchmarks
+
+Run the harness from the repository root in an environment where
+wagtail-localize and its testing dependencies are installed.
+
+List the catalog without setting up Django or creating a database:
+
+```console
+python benchmarks/run.py --list
+```
+
+Run every size of one flow, one particular size, or the complete catalog:
+
+```console
+python benchmarks/run.py edit_translation_get
+python benchmarks/run.py edit_translation_get --size small
+python benchmarks/run.py all
+```
+
+The catalog listing is the authoritative description of the available flows,
+their entry points, scale points, and expected workloads. A flow with scale
+points runs all of them when `--size` is omitted. A flow without scale points
+runs once.
+
+For a comparison that includes timing, repeat each complete execution and
+write a machine-readable report:
+
+```console
+python benchmarks/run.py all \
+    --repeat 5 \
+    --json /tmp/wagtail-localize-benchmark.json
+```
+
+The JSON file's parent directory must already exist. `--repeat 1` is the
+default and is useful while developing a flow; repeated runs are preferable
+for results that will be shared.
+
+## Measurement method
+
+The parent process creates a temporary directory and asks a child process to
+build an empty migrated SQLite database. For every repetition it then:
+
+1. copies that template database;
+2. starts a fresh child process;
+3. builds the fixed fixture and runs the flow's setup outside the measurement;
+4. measures only the flow's `run` callable;
+5. runs verification after measurement has stopped.
+
+There is no warm-up and no state is reused between repetitions. This matters
+for mutating operations: running the operation twice against the same database
+would measure a different workload on the second pass.
+
+The measured region records elapsed wall-clock time and the number of SQL
+queries seen by Django. Verification may query freely because it runs after
+the measured region. For scaled flows it also returns the observed workload;
+the runner rejects an execution when that value differs from the catalog's
+expected workload.
+
+Every repetition of a flow and size must agree on query count, workload unit,
+expected workload, and observed workload. A disagreement is reported as a
+failed execution rather than averaged away. Elapsed time is summarized as the
+median, minimum, and maximum across all repetitions; no observation is
+discarded.
+
+The temporary directory and databases are removed when the parent exits. An
+internal token prevents the child modes from being pointed at a database the
+harness did not create.
+
+## JSON reports and comparisons
+
+`--json` writes schema-versioned provenance alongside the executions:
+
+- UTC run time, Git commit, branch, and working-tree cleanliness;
+- Python, Django, Wagtail, and wagtail-localize versions;
+- selected flow, size, and repetition count;
+- status, query count, expected and observed workload, and timing summary.
+
+A run containing any failed execution is still written, but its top-level
+status is `incomplete`. Only a report with `status: complete`, a clean working
+tree, matching workloads, and the intended versions should be used as a
+baseline.
+
+Query counts are the primary result: compare the same flow and scale point in
+equivalent environments, and inspect the small-to-large slope as well as the
+absolute totals. Timings are machine-dependent and noisier. Compare timing
+with adjacent A and B runs on the same machine, using the same repeat count,
+fixture, and dependency versions.
+
+## Scope and limitations
+
+- The fixture is deliberately fixed and synthetic. Results describe these
+  workloads, not every possible site or content model.
+- SQLite keeps local runs cheap and reproducible, but query cost and database
+  behavior can differ in production.
+- A query count says how many statements ran, not how expensive each statement
+  was.
+- Timing includes cold Python and framework state for the measured operation;
+  it does not model concurrent traffic or warmed application workers.
+- Core probes exist only when they isolate a selected optimization that a full
+  process would hide. They are not a second catalog of internal functions.
+- The harness detects a scaling result but does not attribute its cause. Use
+  query inspection or a diagnostic tool for that separate task.
+
+## Changing the catalog
+
+Each `Flow` in `catalog.py` declares its purpose and entry point, plus optional
+small and large `ScalePoint` values. Its responsibilities are deliberately
+separated:
+
+- `setup` asserts or establishes the pre-measurement scenario;
+- `run` performs only the operation being measured;
+- `verify` proves the operation happened and returns the observed workload.
+
+Keep fixture construction and verification outside `run`. Prefer properties
+such as stable workload and a flat small-to-large query slope over absolute
+query-count assertions in product tests. Run the harness tests after changing
+the runner, fixture, or catalog:
+
+```console
+python testmanage.py test tests.test_benchmarks_harness
+```

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -98,6 +98,69 @@ absolute totals. Timings are machine-dependent and noisier. Compare timing
 with adjacent A and B runs on the same machine, using the same repeat count,
 fixture, and dependency versions.
 
+## Explaining a result with Django Query Doctor
+
+The harness says how much work a flow does. It does not say why: a query count
+is a total, and a total does not name the loop that produced it.
+`run_query_doctor.py` is a separate, manual command for that second question.
+It runs a flow from the same catalog, against the same fixture, with the same
+process isolation, but inside
+[Django Query Doctor](https://pypi.org/project/django-query-doctor/) instead of
+inside a stopwatch. What it prints is a diagnosis: N+1 patterns, duplicate
+queries, and the call sites they came from.
+
+It is deliberately a second command rather than a flag on the first.
+`benchmarks/run.py` does not import Query Doctor, does not know this file
+exists, and runs unchanged in an environment where the tool is not installed.
+Nothing in CI uses it.
+
+### The optional diagnostic environment
+
+Query Doctor is not a project dependency: nothing in the package, the test
+suite, or CI installs or imports it, and it is needed only to run or debug this
+benchmark's diagnostic command. Install it into a separate environment, so the
+environment the benchmarks run in stays the environment the project declares:
+
+```console
+python3 -m venv .venv-query-doctor
+.venv-query-doctor/bin/python -m pip install -e ".[testing]"
+.venv-query-doctor/bin/python -m pip install -r benchmarks/requirements-query-doctor.txt
+```
+
+`benchmarks/requirements-query-doctor.txt` pins the version the harness was
+verified against, so a diagnosis run later reproduces the one run today.
+
+Running the diagnostic command from an environment without the tool prints
+what is missing and stops before creating a database.
+
+### Running a diagnosis
+
+```console
+.venv-query-doctor/bin/python benchmarks/run_query_doctor.py --list
+.venv-query-doctor/bin/python benchmarks/run_query_doctor.py core_page_index --size small
+.venv-query-doctor/bin/python benchmarks/run_query_doctor.py all
+```
+
+Flow names, sizes, and selection rules are the harness's own: `--list` prints
+the same catalog, a scaled flow diagnoses every size when `--size` is omitted,
+and `all` covers the same executions in the same order. `--list` needs neither
+Django nor Query Doctor.
+
+Each execution builds the fixture, runs the flow's `setup`, diagnoses only the
+flow's `run`, and then verifies. As in the harness, an execution whose observed
+workload differs from the catalog's expected workload fails: a diagnosis of a
+scenario that did not build explains something else.
+
+### Reading the output
+
+Output is diagnostic, not a baseline. Query Doctor wraps every cursor and walks
+the stack for each query, so its timings include that overhead and are not
+comparable with `run.py`'s. Its query total is real, but the numbers that
+belong in a before/after comparison are the harness's.
+
+A prescription is a hypothesis with a call site attached, not a verdict. Use it
+to find where to look; use `run.py` to show that a change moved the number.
+
 ## Scope and limitations
 
 - The fixture is deliberately fixed and synthetic. Results describe these
@@ -111,7 +174,8 @@ fixture, and dependency versions.
 - Core probes exist only when they isolate a selected optimization that a full
   process would hide. They are not a second catalog of internal functions.
 - The harness detects a scaling result but does not attribute its cause. Use
-  query inspection or a diagnostic tool for that separate task.
+  query inspection or a diagnostic tool for that separate task, such as the
+  Query Doctor command described above.
 
 ## Changing the catalog
 
@@ -130,4 +194,7 @@ the runner, fixture, or catalog:
 
 ```console
 python testmanage.py test tests.test_benchmarks_harness
+python testmanage.py test tests.test_benchmarks_query_doctor
 ```
+
+Both suites run without Query Doctor installed.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,7 +13,10 @@ the effect of a change at a stable boundary.
 ## Running the benchmarks
 
 Run the harness from the repository root in an environment where
-wagtail-localize and its testing dependencies are installed.
+wagtail-localize and its testing dependencies are installed, with the project
+installed editable (`pip install -e ".[testing]"`). The harness measures the
+checkout, but a report's versions come from the installed package's metadata:
+a non-editable install can name one version while another is being measured.
 
 List the catalog without setting up Django or creating a database:
 
@@ -122,10 +125,16 @@ benchmark's diagnostic command. Install it into a separate environment, so the
 environment the benchmarks run in stays the environment the project declares:
 
 ```console
-python3 -m venv .venv-query-doctor
-.venv-query-doctor/bin/python -m pip install -e ".[testing]"
-.venv-query-doctor/bin/python -m pip install -r benchmarks/requirements-query-doctor.txt
+python3 -m venv ~/.venvs/wl-query-doctor
+~/.venvs/wl-query-doctor/bin/python -m pip install -e ".[testing]"
+~/.venvs/wl-query-doctor/bin/python -m pip install -r benchmarks/requirements-query-doctor.txt
 ```
+
+The location and name are yours to choose; what matters is that it is a
+separate environment and that it does not live inside the checkout. An
+untracked directory in the repository would leave `git status` dirty, and with
+it the `working_tree_clean` field that decides whether a report can serve as a
+baseline.
 
 `benchmarks/requirements-query-doctor.txt` pins the version the harness was
 verified against, so a diagnosis run later reproduces the one run today.
@@ -136,9 +145,9 @@ what is missing and stops before creating a database.
 ### Running a diagnosis
 
 ```console
-.venv-query-doctor/bin/python benchmarks/run_query_doctor.py --list
-.venv-query-doctor/bin/python benchmarks/run_query_doctor.py core_page_index --size small
-.venv-query-doctor/bin/python benchmarks/run_query_doctor.py all
+~/.venvs/wl-query-doctor/bin/python benchmarks/run_query_doctor.py --list
+~/.venvs/wl-query-doctor/bin/python benchmarks/run_query_doctor.py core_page_index --size small
+~/.venvs/wl-query-doctor/bin/python benchmarks/run_query_doctor.py all
 ```
 
 Flow names, sizes, and selection rules are the harness's own: `--list` prints

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -170,21 +170,105 @@ belong in a before/after comparison are the harness's.
 A prescription is a hypothesis with a call site attached, not a verdict. Use it
 to find where to look; use `run.py` to show that a change moved the number.
 
+## Attributing a result with the harness itself
+
+`run_attribution.py` answers the same second question from a different angle. A
+diagnostic tool inspects one execution and applies a heuristic to decide which
+queries look repeated. This command compares the two scale points a flow already
+declares and reports which groups of queries grew with the workload. Growth with
+the workload is not a sign of the cost this project looks for; it is that cost,
+which is why the comparison needs calibrated sizes and cannot be done against a
+single run.
+
+It runs the flow's own call in an isolated child process, once per size, with a
+`connection.execute_wrapper` installed. Each cursor invocation becomes an event
+carrying the statement's normalised shape, the nearest `wagtail_localize` frame
+below it, the arity of any `IN` list, and the batch size of an `executemany`.
+No parameter value enters an event or the JSON report; the run itself still
+holds interpolated SQL in Django's query log while the debug cursor is on.
+Events are grouped by shape and frame, and groups are ranked by how fast each
+grows per unit of workload:
+
+```console
+python benchmarks/run_attribution.py core_page_index
+python benchmarks/run_attribution.py submit_page_post --json report.json
+```
+
+The unit is the flow, not one execution of it, so the command takes no `--size`
+and accepts only a flow declaring exactly two scale points. `--list` prints the
+whole catalog, including flows this command cannot attribute; asking for one of
+those fails immediately and says why.
+
+The command needs no extra dependency: `execute_wrapper` is Django's own. It is
+still separate from `run.py` for the reason `run_query_doctor.py` is separate. A
+baseline comes from one stable, minimal counter, and diagnostic instrumentation
+never produces one.
+
+### Reading the output
+
+The report opens with a reconciliation, because a report that does not add up to
+the number it explains is describing something else:
+
+```
+  small   519 queries  = 515 attributed + 4 outside execute_wrapper
+```
+
+The gap is not a loss. Django's `_commit()` and `_rollback()` call the database
+connection directly and append a synthetic record to the query log, so
+`CaptureQueriesContext` counts them and no wrapper can see them. They are real
+work with a real cost; they have no call site this command can honestly name, so
+it states them instead of dropping them.
+
+Each group then shows its rate, its count at both sizes, and where it ran:
+
+```
+  +1.00/indexed_pages   24 -> 64   synctree.py:77 in from_page_instance
+```
+
+A rate is the secant between two points, not proof that the growth is linear:
+any two points fit a line exactly. Where the two counts imply a non-zero cost at
+zero workload, the row also shows that estimate. It is a description of these
+two points and nothing more: a positive value can be a genuine fixed cost paid
+once, a negative one can mean the group runs for only part of the workload, and
+neither reading is available from the two numbers alone.
+
+A group whose shape hides a width carries it as a side note, because a count
+cannot show it: `[IN arity 2 -> 40]` is one statement carrying twenty times as
+many values, and `[batch …]` is the same for an `executemany`. What that costs
+the database is a separate question this harness does not answer; what it shows
+is that the statement absorbed work the query count no longer reflects.
+
+Groups that shrank are listed separately, and the tail the report does not print
+is summarised with both its net and its gross movement, so churn between two
+sizes stays visible even when it cancels out.
+
+Two limits are worth stating. The frame on each row is the nearest
+`wagtail_localize` frame still on the stack when the statement ran, which is
+neither always where the queryset was built nor always where the SQL came from:
+a queryset created in a method and evaluated later in a loop, a template, or a
+serialiser is attributed to the evaluation, and SQL issued inside Wagtail or
+Django is attributed to the product call that entered them. And a group that
+grows with the workload is not by that fact a defect. A flow that creates one
+object per page is supposed to cost one insert per page. What the report gives
+is a lead, ranked; deciding which leads are legitimate is the reader's.
+
 ## Scope and limitations
 
 - The fixture is deliberately fixed and synthetic. Results describe these
   workloads, not every possible site or content model.
 - SQLite keeps local runs cheap and reproducible, but query cost and database
   behavior can differ in production.
-- A query count says how many statements ran, not how expensive each statement
-  was.
+- A query count is the number of entries in Django's query log, not the number
+  of statements the database ran and not a measure of what each one cost: a
+  commit is one entry, and so is an `executemany` however many rows it carries.
 - Timing includes cold Python and framework state for the measured operation;
   it does not model concurrent traffic or warmed application workers.
 - Core probes exist only when they isolate a selected optimization that a full
   process would hide. They are not a second catalog of internal functions.
-- The harness detects a scaling result but does not attribute its cause. Use
-  query inspection or a diagnostic tool for that separate task, such as the
-  Query Doctor command described above.
+- `run.py` detects a scaling result but does not attribute its cause. That is a
+  separate task, and a separate command: `run_attribution.py` for where a flow's
+  own growth comes from, `run_query_doctor.py` for a second opinion from an
+  outside tool.
 
 ## Changing the catalog
 

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Performance benchmark harness."""

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -181,7 +181,7 @@ def prepare():
 
     locales = ensure_locales()
     snippets = build_snippet_pool(SNIPPETS, locales["en"])
-    _home, pages = build_tree(PAGES, locales["en"], snippets)
+    home, pages = build_tree(PAGES, locales["en"], snippets)
     client, user = _admin_client()
 
     existing_page = pages[0]
@@ -255,6 +255,10 @@ def prepare():
         large_target_page_id=_target_page_id(heavy_page_translation),
         small_segment_ids=small_segment_ids,
         large_segment_ids=large_segment_ids,
+        # Subtree roots. Leaf pages have no children, so the flows that walk a
+        # subtree need the home page or one of its categories.
+        subtree_root_large=home,
+        subtree_root_small=home.get_children().first(),
         submit_page=pages[-1],
         submit_snippet=snippets[-1],
         core_pages=pages[5 : 5 + CORE_PAGES],
@@ -601,6 +605,447 @@ SUBMIT_SNIPPET_POST = Flow(
 
 
 # ---------------------------------------------------------------------------
+# update_translations_get
+# ---------------------------------------------------------------------------
+
+
+def _enabled_translations(source):
+    """The source's enabled translations, ordered so comparisons are stable."""
+    return list(source.translations.filter(enabled=True).order_by("target_locale_id"))
+
+
+def _target_state(translations):
+    """Enough of each target's state to notice any write to it.
+
+    latest_revision_id and live catch a new revision and a change of live
+    state, but not republishing when the target was already live: Wagtail then
+    moves live_revision_id and last_published_at while those two stay put.
+    """
+    state = {}
+    for translation in translations:
+        target = translation.get_target_instance()
+        state[translation.id] = (
+            target.pk,
+            target.live,
+            target.latest_revision_id,
+            target.live_revision_id,
+            target.last_published_at,
+        )
+    return state
+
+
+def _update_translations_get_setup(ctx, size):
+    """Put the source at the number of enabled translations this size measures.
+
+    The view calls get_target_instance() twice per translation and that method
+    does not cache, so the cost tracks the count. `large` creates the second
+    translation here, outside the measured region, rather than in prepare():
+    it belongs to this size, and building it globally would change `small`.
+    """
+    source = ctx.existing_page_source
+    spanish = ctx.locales["es"]
+
+    if _translation_to(ctx.existing_page, spanish) is not None:
+        raise RuntimeError("the source already has a Spanish translation.")
+    if size == "large":
+        _create_translation(ctx.existing_page, spanish, user=ctx.user)
+
+    expected = 1 if size == "small" else 2
+    enabled = _enabled_translations(source)
+    if len(enabled) != expected:
+        raise RuntimeError(
+            f"the source has {len(enabled)} enabled translations, not the "
+            f"{expected} this size measures."
+        )
+
+    # Snapshot for the no-write check: counting revisions on the source would
+    # not notice a target being revised or republished. Verification state, not
+    # workload.
+    ctx.translations_before = {translation.id for translation in enabled}
+    ctx.targets_before = _target_state(enabled)
+
+
+def _update_translations_get_run(ctx, size):
+    """GET the update-translations screen, and return the response unexamined."""
+    from django.urls import reverse
+
+    return ctx.client.get(
+        reverse(
+            "wagtail_localize:update_translations",
+            args=[ctx.existing_page_source.id],
+        )
+    )
+
+
+def _update_translations_get_verify(ctx, size, response):
+    """Check every enabled translation is listed, and that nothing was written."""
+    from django.urls import reverse
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"the update screen returned {response.status_code}, not 200"
+        )
+
+    body = response.content.decode()
+    enabled = _enabled_translations(ctx.existing_page_source)
+
+    # The screen links to each target's editor, which is what proves it listed
+    # the translation rather than merely rendering the page.
+    for translation in enabled:
+        target = translation.get_target_instance()
+        if reverse("wagtailadmin_pages:edit", args=[target.id]) not in body:
+            raise RuntimeError(
+                f"the screen does not link to the {translation.target_locale} "
+                f"target, so it did not list that translation."
+            )
+
+    if {translation.id for translation in enabled} != ctx.translations_before:
+        raise RuntimeError("opening the screen changed the set of translations.")
+
+    after = _target_state(enabled)
+    if after != ctx.targets_before:
+        raise RuntimeError(
+            f"opening the screen changed a target: {ctx.targets_before} became "
+            f"{after}. A GET must not revise or publish anything."
+        )
+
+    return len(enabled)
+
+
+UPDATE_TRANSLATIONS_GET = Flow(
+    name="update_translations_get",
+    group="updating",
+    why=(
+        "Opening the screen that lists a source's existing translations, the "
+        "step before deciding whether to republish them."
+    ),
+    entrypoint="UpdateTranslationsView.get/get_context_data",
+    covers=(
+        "enabled translation listing",
+        "Translation.get_target_instance per translation",
+        "target edit URL construction",
+    ),
+    workload_unit="enabled_translations",
+    scale_points=(
+        ScalePoint(
+            label="small",
+            why="One translation: the fixed cost of the screen.",
+            expected_workload=1,
+        ),
+        ScalePoint(
+            label="large",
+            why=(
+                "Two translations, so the per-translation cost of resolving "
+                "each target separates from the fixed cost."
+            ),
+            expected_workload=2,
+        ),
+    ),
+    setup=_update_translations_get_setup,
+    run=_update_translations_get_run,
+    verify=_update_translations_get_verify,
+)
+
+
+# ---------------------------------------------------------------------------
+# update_translations_post_publish
+# ---------------------------------------------------------------------------
+
+# Deterministic, so a failure names the value it expected rather than a
+# timestamp nobody can predict.
+UPDATE_MARKERS = {
+    "small": "benchmark-update-small",
+    "large": "benchmark-update-large",
+}
+
+
+def _update_source(size, ctx):
+    """The page and source this size updates."""
+    if size == "small":
+        return ctx.existing_page, ctx.existing_page_source
+    return ctx.heavy_page, ctx.heavy_page_source
+
+
+def _update_translations_post_setup(ctx, size):
+    """Make the source stale, so the POST has real reconciliation to do.
+
+    The marker goes in a synchronized field: those are copied to the target
+    verbatim by copy_synchronised_fields, so it arrives without needing a
+    translation. A translatable field would become a segment and stay in the
+    source language.
+    """
+    page, source = _update_source(size, ctx)
+    marker = UPDATE_MARKERS[size]
+
+    # The POST republishes every enabled translation, so its cost tracks that
+    # number too. The declared workload is segments, so the count is pinned
+    # here rather than left to whatever the fixture happens to hold.
+    enabled = _enabled_translations(source)
+    if len(enabled) != 1:
+        raise RuntimeError(
+            f"the source has {len(enabled)} enabled translations; this flow "
+            f"measures updating exactly one."
+        )
+    if enabled[0].target_locale_id != ctx.locales["fr"].id:
+        raise RuntimeError(
+            f"the enabled translation targets {enabled[0].target_locale}, not French."
+        )
+
+    target = page.get_translation_or_none(ctx.locales["fr"])
+    if target is None:
+        raise RuntimeError("the page has no French target to republish.")
+    if target.test_synchronized_charfield == marker:
+        raise RuntimeError("the target already carries the marker.")
+
+    page.test_synchronized_charfield = marker
+    page.save_revision().publish()
+
+
+def _update_translations_post_run(ctx, size):
+    """POST the update form with publish, and return the response unexamined."""
+    from django.urls import reverse
+
+    _page, source = _update_source(size, ctx)
+    return ctx.client.post(
+        reverse("wagtail_localize:update_translations", args=[source.id]),
+        {"publish_translations": "on"},
+    )
+
+
+def _update_translations_post_verify(ctx, size, response):
+    """Check the source was refreshed and the marker reached the live target."""
+    if response.status_code != 302:
+        raise RuntimeError(
+            f"the update view returned {response.status_code}, not a redirect"
+        )
+
+    page, source = _update_source(size, ctx)
+    marker = UPDATE_MARKERS[size]
+
+    target = page.get_translation_or_none(ctx.locales["fr"])
+    if target is None:
+        raise RuntimeError("the French target disappeared.")
+    if target.test_synchronized_charfield != marker:
+        raise RuntimeError(
+            f"the target carries {target.test_synchronized_charfield!r}, not "
+            f"{marker!r}: the source change was not copied across."
+        )
+    if not target.live:
+        raise RuntimeError("the target was not published.")
+
+    source.refresh_from_db()
+    return source.stringsegment_set.count()
+
+
+UPDATE_TRANSLATIONS_POST_PUBLISH = Flow(
+    name="update_translations_post_publish",
+    group="updating",
+    why=(
+        "Pushing a change made to the original out to its translations and "
+        "publishing them, the update half of the translation cycle."
+    ),
+    entrypoint="UpdateTranslationsView.form_valid",
+    covers=(
+        "TranslationSource.update_from_db",
+        "TranslationSource.refresh_segments",
+        "Translation.save_target",
+        "copy_synchronised_fields",
+    ),
+    workload_unit="string_segments",
+    scale_points=(
+        ScalePoint(
+            label="small",
+            why="An ordinary page: the fixed cost of refreshing and publishing.",
+            expected_workload=1,
+        ),
+        ScalePoint(
+            label="large",
+            why=(
+                "The StreamField-heavy page, where re-extracting segments "
+                "dominates the fixed cost."
+            ),
+            expected_workload=41,
+        ),
+    ),
+    setup=_update_translations_post_setup,
+    run=_update_translations_post_run,
+    verify=_update_translations_post_verify,
+)
+
+
+# ---------------------------------------------------------------------------
+# translate_page_subtree
+# ---------------------------------------------------------------------------
+
+
+def _subtree_root(ctx, size):
+    return ctx.subtree_root_small if size == "small" else ctx.subtree_root_large
+
+
+def _french_state(page, french):
+    """Classify a page's French state from all three facts at once.
+
+    The target alone does not say what Localize knows about the page, so the
+    TranslationSource and the Translation are read with it. Only three
+    combinations are states the subtree flow understands; anything else means
+    the fixture is not what the scenario assumes, and is raised rather than
+    quietly counted as one of them.
+    """
+    specific = page.specific
+    target = specific.get_translation_or_none(french)
+    source = _translation_source(specific) is not None
+    translation = _translation_to(specific, french) is not None
+
+    if target is not None and not target.alias_of_id and source and translation:
+        return "translated"
+    if target is not None and target.alias_of_id and not source and not translation:
+        return "alias"
+    if target is None and not source and not translation:
+        return "untranslated"
+
+    raise RuntimeError(
+        f"{page.slug} is in no state this flow recognises: "
+        f"target={'alias' if target is not None and target.alias_of_id else target is not None}, "
+        f"source={source}, translation={translation}."
+    )
+
+
+# The mix prepare() leaves under each root. Frozen because the cost of the walk
+# depends on it: a subtree of already-translated pages is not the same work as
+# one of untranslated pages, and a run against a different mix would measure
+# something else under the same name.
+SUBTREE_MIX = {
+    "small": {"translated": 2, "alias": 0, "untranslated": 1},
+    "large": {"translated": 6, "alias": 4, "untranslated": 6},
+}
+
+
+def _submit_subtree_setup(ctx, size):
+    """Freeze the scenario: the root, its size, and the mix underneath it."""
+    root, french = _subtree_root(ctx, size), ctx.locales["fr"]
+
+    descendants = list(root.get_descendants())
+    expected = sum(SUBTREE_MIX[size].values())
+    if len(descendants) != expected:
+        raise RuntimeError(
+            f"the {size} root has {len(descendants)} descendants, not the "
+            f"{expected} this size measures."
+        )
+
+    if _translation_source(root.specific) is not None:
+        raise RuntimeError("the root is already a translation source.")
+    if _french_state(root, french) != "alias":
+        raise RuntimeError(
+            "the root's French counterpart is not an alias, so this run would "
+            "not measure converting one into a real translation."
+        )
+
+    observed = {"translated": 0, "alias": 0, "untranslated": 0}
+    for page in descendants:
+        observed[_french_state(page, french)] += 1
+    if observed != SUBTREE_MIX[size]:
+        raise RuntimeError(
+            f"the {size} subtree holds {observed}, not {SUBTREE_MIX[size]}. "
+            f"The cost of the walk depends on this mix."
+        )
+
+
+def _submit_subtree_run(ctx, size):
+    """POST the submit form with the subtree included.
+
+    There is no URL of its own: translate_page_subtree is enqueued by the
+    submit view, and the harness settings leave the job backend on
+    ImmediateBackend, so the walk runs inside this request.
+    """
+    from django.urls import reverse
+
+    root = _subtree_root(ctx, size)
+    return ctx.client.post(
+        reverse("wagtail_localize:submit_page_translation", args=[root.id]),
+        {"locales": [ctx.locales["fr"].id], "include_subtree": "on"},
+    )
+
+
+def _submit_subtree_verify(ctx, size, response):
+    """Check the root and every descendant came out really translated."""
+    from django.urls import reverse
+
+    if response.status_code != 302:
+        raise RuntimeError(
+            f"the submit view returned {response.status_code}, not a redirect"
+        )
+
+    root, french = _subtree_root(ctx, size), ctx.locales["fr"]
+
+    for label, page in [
+        ("root", root),
+        *[("descendant", p) for p in root.get_descendants()],
+    ]:
+        specific = page.specific
+        if _translation_source(specific) is None:
+            raise RuntimeError(f"a {label} has no TranslationSource: {page.slug}")
+        if _translation_to(specific, french) is None:
+            raise RuntimeError(f"a {label} was not translated: {page.slug}")
+        target = specific.get_translation_or_none(french)
+        if target is None:
+            raise RuntimeError(f"a {label} has no French target: {page.slug}")
+        if target.alias_of_id:
+            raise RuntimeError(
+                f"a {label} is still an alias rather than a real translation: "
+                f"{page.slug}"
+            )
+        if not target.live:
+            raise RuntimeError(f"a {label}'s target is not published: {page.slug}")
+
+    translated_root = root.specific.get_translation(french)
+    expected = reverse("wagtailadmin_pages:edit", args=[translated_root.id])
+    if response.url != expected:
+        raise RuntimeError(
+            f"the redirect went to {response.url}, not to the editor of the "
+            f"translated root ({expected})"
+        )
+
+    # The root is fixed cost measured alongside the walk, so it is not counted.
+    return root.get_descendants().count()
+
+
+TRANSLATE_PAGE_SUBTREE = Flow(
+    name="translate_page_subtree",
+    group="creation",
+    why=(
+        "Translating a page together with everything under it: one click that "
+        "walks a whole branch of the tree."
+    ),
+    entrypoint="SubmitPageTranslationView.form_valid -> translate_page_subtree",
+    covers=(
+        "translate_object on the root",
+        "translate_page_subtree recursive walk",
+        "TranslationCreator.create_translations per descendant",
+        "alias conversion into a real translation",
+    ),
+    workload_unit="pages_in_subtree",
+    scale_points=(
+        ScalePoint(
+            label="small",
+            why="A single category: three pages under one parent.",
+            expected_workload=3,
+        ),
+        ScalePoint(
+            label="large",
+            why=(
+                "The whole benchmark tree, where the walk crosses two levels "
+                "and a mix of translated, aliased and untouched pages."
+            ),
+            expected_workload=16,
+        ),
+    ),
+    setup=_submit_subtree_setup,
+    run=_submit_subtree_run,
+    verify=_submit_subtree_verify,
+)
+
+
+# ---------------------------------------------------------------------------
 # edit_translation_get
 # ---------------------------------------------------------------------------
 
@@ -695,7 +1140,10 @@ CATALOG = (
     SUBMIT_PAGE_GET,
     SUBMIT_PAGE_POST,
     SUBMIT_SNIPPET_POST,
+    TRANSLATE_PAGE_SUBTREE,
     EDIT_TRANSLATION_GET,
+    UPDATE_TRANSLATIONS_GET,
+    UPDATE_TRANSLATIONS_POST_PUBLISH,
 )
 
 BY_NAME = {flow.name: flow for flow in CATALOG}

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -1133,9 +1133,137 @@ EDIT_TRANSLATION_GET = Flow(
 )
 
 
-# Grouped by what a flow does, creation entrypoints before the editor. Not a
-# sequence: every execution runs against a fresh database, so no flow's result
-# feeds the next.
+# ---------------------------------------------------------------------------
+# core_refresh_segments
+#
+# A core probe rather than an admin flow: it calls one model method directly,
+# because the question is about that method and nothing else.
+# ---------------------------------------------------------------------------
+
+
+def _refresh_source(ctx, size):
+    return ctx.existing_page_source if size == "small" else ctx.heavy_page_source
+
+
+def _refresh_segment_state(source):
+    """Every segment row the source owns, per type, as ids in order.
+
+    Ids rather than counts, because the postcondition is that reconciling an
+    unchanged source leaves the rows alone: a count would pass a run that
+    deleted a segment and created another one in its place. Local to this
+    probe — the other flows check the objects they act on, not this shape.
+    """
+    from wagtail_localize.models import (
+        OverridableSegment,
+        RelatedObjectSegment,
+        StringSegment,
+        TemplateSegment,
+    )
+
+    return {
+        model.__name__: list(
+            model.objects.filter(source=source)
+            .order_by("order", "id")
+            .values_list("id", flat=True)
+        )
+        for model in (
+            StringSegment,
+            TemplateSegment,
+            RelatedObjectSegment,
+            OverridableSegment,
+        )
+    }
+
+
+def _core_refresh_setup(ctx, size):
+    """Freeze the state the refresh is supposed to reconcile against.
+
+    The source must already exist with its segments written: this probe
+    measures re-extraction over a source that is already reconciled, which is
+    the variant the characterization test covers. A first extraction is a
+    different operation, and submit_page_post already measures it.
+    """
+    source = _refresh_source(ctx, size)
+    if source is None or source.pk is None:
+        raise RuntimeError(f"prepare() left no saved {size} source to refresh.")
+
+    state = _refresh_segment_state(source)
+    if not state["StringSegment"]:
+        raise RuntimeError(
+            f"the {size} source holds no string segments, so refreshing it "
+            f"would measure a first extraction instead of a reconciliation."
+        )
+    ctx.core_refresh_state = state
+
+
+def _core_refresh_run(ctx, size):
+    """Reconcile the source's segments, and nothing else."""
+    _refresh_source(ctx, size).refresh_segments()
+
+
+def _core_refresh_verify(ctx, size, artifacts):
+    """Check the reconciliation left every segment row where it was.
+
+    Refreshing a source whose content has not changed has to be a no-op in the
+    data: the same rows, in the same order, none deleted and none recreated.
+    Returns the string segments the source holds, which is what the measured
+    queries scale with.
+    """
+    before = ctx.core_refresh_state
+    after = _refresh_segment_state(_refresh_source(ctx, size))
+
+    for name, ids in before.items():
+        if after[name] != ids:
+            raise RuntimeError(
+                f"reconciling an unchanged source changed its {name} rows: "
+                f"{ids} before, {after[name]} after."
+            )
+
+    return len(after["StringSegment"])
+
+
+CORE_REFRESH_SEGMENTS = Flow(
+    name="core_refresh_segments",
+    group="core",
+    why=(
+        "Re-extracting the segments of a source that already has them. It runs "
+        "inside submit, update and subtree translation, where its cost arrives "
+        "mixed with content extraction and target saving; called on its own it "
+        "shows the per-segment persistence on its own."
+    ),
+    entrypoint="TranslationSource.refresh_segments",
+    covers=(
+        "TranslationSource.as_instance",
+        "extract_segments over the stored content",
+        "String, TranslationContext and StringSegment get_or_create per segment",
+        "deletion of the segments the extraction no longer mentions",
+    ),
+    workload_unit="string_segments",
+    scale_points=(
+        ScalePoint(
+            label="small",
+            why="An ordinary page: one string segment, so the fixed cost dominates.",
+            expected_workload=1,
+        ),
+        ScalePoint(
+            label="large",
+            why=(
+                "The StreamField-heavy page, whose segments are the only "
+                "difference from the small one, so the subtraction leaves the "
+                "per-segment cost alone."
+            ),
+            expected_workload=41,
+        ),
+    ),
+    setup=_core_refresh_setup,
+    run=_core_refresh_run,
+    verify=_core_refresh_verify,
+)
+
+
+# Grouped by what a flow does, creation entrypoints before the editor, and the
+# core probes last. Not a sequence: every execution runs against a fresh
+# database, so no flow's result feeds the next.
 CATALOG = (
     SUBMIT_PAGE_GET,
     SUBMIT_PAGE_POST,
@@ -1144,6 +1272,7 @@ CATALOG = (
     EDIT_TRANSLATION_GET,
     UPDATE_TRANSLATIONS_GET,
     UPDATE_TRANSLATIONS_POST_PUBLISH,
+    CORE_REFRESH_SEGMENTS,
 )
 
 BY_NAME = {flow.name: flow for flow in CATALOG}

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -177,7 +177,7 @@ def prepare():
                   [1]        extra report-only translation
                   [3]        submit_snippet, left untranslated
     """
-    from seed import build_snippet_pool, build_tree, ensure_locales
+    from benchmarks.seed import build_snippet_pool, build_tree, ensure_locales
 
     locales = ensure_locales()
     snippets = build_snippet_pool(SNIPPETS, locales["en"])

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -262,6 +262,132 @@ def prepare():
 
 
 # ---------------------------------------------------------------------------
+# submit_page_post
+# ---------------------------------------------------------------------------
+
+
+def _translation_source(instance):
+    """The instance's TranslationSource, or None."""
+    from wagtail_localize.models import TranslationSource
+
+    return TranslationSource.objects.filter(
+        object_id=instance.translation_key, locale=instance.locale
+    ).first()
+
+
+def _translation_to(instance, locale):
+    """The instance's Translation into `locale`, or None.
+
+    Translated variants share a translation_key, so the source locale has to be
+    named too, or this matches a translation made from a different variant.
+    """
+    from wagtail_localize.models import Translation
+
+    return Translation.objects.filter(
+        source__object_id=instance.translation_key,
+        source__locale=instance.locale,
+        target_locale=locale,
+    ).first()
+
+
+def _submit_page_setup(ctx, size):
+    """Assert the state the flow starts from, without changing it.
+
+    The page and its snippet must be untranslated, or the POST reconciles an
+    existing translation instead of creating one and the flow measures a
+    different operation than it names.
+    """
+    if size is not None:
+        raise RuntimeError(f"submit_page_post takes no size; got {size!r}.")
+
+    page, snippet, french = ctx.submit_page, ctx.submit_snippet, ctx.locales["fr"]
+
+    if page.test_snippet_id != snippet.pk:
+        raise RuntimeError(
+            f"submit_page references snippet {page.test_snippet_id}, not "
+            f"submit_snippet ({snippet.pk}). The flow measures the related "
+            f"object fan-out, so the two have to be connected."
+        )
+
+    for label, instance in (("page", page), ("snippet", snippet)):
+        if _translation_source(instance) is not None:
+            raise RuntimeError(f"the {label} already has a TranslationSource.")
+        if _translation_to(instance, french) is not None:
+            raise RuntimeError(f"the {label} is already translated into French.")
+        if instance.get_translation_or_none(french) is not None:
+            raise RuntimeError(f"the {label} already has a French target.")
+
+
+def _submit_page_run(ctx, size):
+    """POST the submit-translation form, and return the response unexamined."""
+    from django.urls import reverse
+
+    return ctx.client.post(
+        reverse(
+            "wagtail_localize:submit_page_translation",
+            args=[ctx.submit_page.id],
+        ),
+        {"locales": [ctx.locales["fr"].id]},
+    )
+
+
+def _submit_page_verify(ctx, size, response):
+    """Check the page and its related snippet were both translated.
+
+    Queries name the object and locale rather than counting rows: prepare()
+    creates other translations, so a global count would pass whatever this POST
+    did. Returns None — the flow declares no workload, and the objects created
+    here are the shape of the operation, not a scale dimension.
+    """
+    from django.urls import reverse
+
+    if response.status_code != 302:
+        raise RuntimeError(
+            f"the submit view returned {response.status_code}, not a redirect, "
+            f"so the form was not accepted"
+        )
+
+    page, snippet, french = ctx.submit_page, ctx.submit_snippet, ctx.locales["fr"]
+
+    for label, instance in (("page", page), ("snippet", snippet)):
+        if _translation_source(instance) is None:
+            raise RuntimeError(f"no TranslationSource was created for the {label}.")
+        if _translation_to(instance, french) is None:
+            raise RuntimeError(f"the {label} was not translated into French.")
+        if instance.get_translation_or_none(french) is None:
+            raise RuntimeError(f"the {label} has no French target.")
+
+    target = page.get_translation(french)
+    expected = reverse("wagtailadmin_pages:edit", args=[target.id])
+    if response.url != expected:
+        raise RuntimeError(
+            f"the redirect went to {response.url}, not to the editor of the "
+            f"page it created ({expected})"
+        )
+
+
+SUBMIT_PAGE_POST = Flow(
+    name="submit_page_post",
+    group="creation",
+    why=(
+        "Creating a translation from the admin: the entry point an editor uses "
+        "to put a page into another locale for the first time."
+    ),
+    entrypoint="SubmitPageTranslationView.post/form_valid",
+    covers=(
+        "TranslationCreator.create_translations",
+        "TranslationSource.get_or_create_from_instance",
+        "TranslationSource.refresh_segments",
+        "Translation.save_target",
+        "related snippet translation",
+    ),
+    setup=_submit_page_setup,
+    run=_submit_page_run,
+    verify=_submit_page_verify,
+)
+
+
+# ---------------------------------------------------------------------------
 # edit_translation_get
 # ---------------------------------------------------------------------------
 
@@ -349,7 +475,8 @@ EDIT_TRANSLATION_GET = Flow(
 )
 
 
-CATALOG = (EDIT_TRANSLATION_GET,)
+# Creation before editing: a page is submitted before it is translated.
+CATALOG = (SUBMIT_PAGE_POST, EDIT_TRANSLATION_GET)
 
 BY_NAME = {flow.name: flow for flow in CATALOG}
 

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -1261,6 +1261,172 @@ CORE_REFRESH_SEGMENTS = Flow(
 )
 
 
+# ---------------------------------------------------------------------------
+# core_page_index
+#
+# The index reads the whole page table, so its scale cannot be chosen with a
+# root: the large size adds pages to the site instead.
+# ---------------------------------------------------------------------------
+
+# Plain pages the large size adds so the two sizes differ by a known amount.
+# Local to this probe: the shared fixture constants describe content the admin
+# flows act on, and these pages exist only to be counted.
+INDEX_FILLER_PAGES = 40
+
+
+def _indexable_pages():
+    """The pages PageIndex.from_database() walks: every page below the root
+    that is not an alias."""
+    from wagtail.models import Page
+
+    return Page.objects.filter(alias_of__isnull=True, depth__gt=1)
+
+
+def _index_entry(index, page):
+    """The index entry built from `page`, or None.
+
+    Matched on locale as well as translation key, because translated variants
+    share a key and the index holds one entry per variant.
+    """
+    for entry in index.pages:
+        if (
+            entry.translation_key == page.translation_key
+            and entry.source_locale.id == page.locale_id
+        ):
+            return entry
+    return None
+
+
+def _core_page_index_setup(ctx, size):
+    """Bring the site to the size being measured, and freeze what verify needs.
+
+    The large size creates its pages here, outside the measured region: the
+    probe measures reading the page table, not writing to it.
+    """
+    from wagtail.models import Page
+
+    from tests.testapp.models import TestPage
+
+    if size == "large":
+        # prepare() exports the English home as the large subtree root.
+        home = ctx.subtree_root_large
+        for number in range(INDEX_FILLER_PAGES):
+            home.add_child(
+                instance=TestPage(
+                    title=f"Index filler {number}",
+                    slug=f"bench-index-filler-{number}",
+                    locale=ctx.locales["en"],
+                )
+            )
+
+    expected = 24 if size == "small" else 24 + INDEX_FILLER_PAGES
+    indexable = _indexable_pages().count()
+    if indexable != expected:
+        raise RuntimeError(
+            f"the {size} size holds {indexable} indexable pages, not the "
+            f"{expected} it measures. The index reads the whole page table, so "
+            f"anything that creates or removes pages changes this number."
+        )
+
+    if not Page.objects.filter(alias_of__isnull=False).exists():
+        raise RuntimeError(
+            "the fixture holds no alias pages, so the index would never fill "
+            "aliased_locales and the scenario would be a weaker one than named."
+        )
+
+    # Read here rather than in verify so the expectation comes from the fixture
+    # and not from the index being checked against itself.
+    ctx.core_index_parent_key = ctx.existing_page.get_parent().translation_key
+
+
+def _core_page_index_run(ctx, size):
+    """Build the index. This is the whole measured region."""
+    from wagtail_localize.synctree import PageIndex
+
+    return PageIndex.from_database()
+
+
+def _core_page_index_verify(ctx, size, index):
+    """Check the index describes the site it was built from.
+
+    The three properties below are the ones 719447f stops computing per page
+    and starts resolving from preloaded maps, so an arm that reduced the query
+    count by losing information fails here rather than looking like a win.
+    """
+    indexable = _indexable_pages().count()
+    if len(index.pages) != indexable:
+        raise RuntimeError(
+            f"the index holds {len(index.pages)} entries for {indexable} "
+            f"indexable pages."
+        )
+
+    english, french = ctx.locales["en"], ctx.locales["fr"]
+
+    entry = _index_entry(index, ctx.existing_page)
+    if entry is None:
+        raise RuntimeError("the index has no entry for the translated page.")
+    if set(entry.locales) != {english.id, french.id}:
+        raise RuntimeError(
+            f"the translated page's entry lists locales {entry.locales}, not "
+            f"the English and French ones it exists in."
+        )
+    if entry.parent_translation_key != ctx.core_index_parent_key:
+        raise RuntimeError(
+            f"the translated page's entry points at parent "
+            f"{entry.parent_translation_key}, not at {ctx.core_index_parent_key}."
+        )
+
+    home_entry = _index_entry(index, ctx.subtree_root_large)
+    if home_entry is None:
+        raise RuntimeError("the index has no entry for the home page.")
+    if french.id not in home_entry.aliased_locales:
+        raise RuntimeError(
+            f"the home entry lists aliased locales {home_entry.aliased_locales}, "
+            f"without the French alias the fixture created."
+        )
+
+    return len(index.pages)
+
+
+CORE_PAGE_INDEX = Flow(
+    name="core_page_index",
+    group="core",
+    why=(
+        "Building the page index synchronize_tree walks. Inside the full sync "
+        "the index is a small part of a much larger copy operation, so on its "
+        "own is the only place where a per-page cost in the index is visible "
+        "at all."
+    ),
+    entrypoint="PageIndex.from_database",
+    covers=(
+        "PageIndex.from_database",
+        "PageIndex.Entry.from_page_instance per indexed page",
+        "the locales and aliased_locales lookups behind each entry",
+        "the parent lookup behind each entry",
+    ),
+    workload_unit="indexed_pages",
+    scale_points=(
+        ScalePoint(
+            label="small",
+            why="The benchmark site as the fixture builds it.",
+            expected_workload=24,
+        ),
+        ScalePoint(
+            label="large",
+            why=(
+                "The same site with forty more pages under the home, which is "
+                "the only difference between the two sizes, so the subtraction "
+                "leaves the per-page cost alone."
+            ),
+            expected_workload=24 + INDEX_FILLER_PAGES,
+        ),
+    ),
+    setup=_core_page_index_setup,
+    run=_core_page_index_run,
+    verify=_core_page_index_verify,
+)
+
+
 # Grouped by what a flow does, creation entrypoints before the editor, and the
 # core probes last. Not a sequence: every execution runs against a fresh
 # database, so no flow's result feeds the next.
@@ -1273,6 +1439,7 @@ CATALOG = (
     UPDATE_TRANSLATIONS_GET,
     UPDATE_TRANSLATIONS_POST_PUBLISH,
     CORE_REFRESH_SEGMENTS,
+    CORE_PAGE_INDEX,
 )
 
 BY_NAME = {flow.name: flow for flow in CATALOG}

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -88,9 +88,6 @@ class Flow:
 
 PAGES = 12
 SNIPPETS = 4
-# Extra pages the core operations flows walk, kept disjoint from the pages the
-# admin flows act on so they do not collide with each other's preconditions.
-CORE_PAGES = 5
 # Page translations pre-created so the report view renders several rows.
 REPORT_PAGE_TRANSLATIONS = 5
 # StreamField blocks loaded onto the dedicated heavy page, so the flows that
@@ -178,12 +175,14 @@ def prepare():
 
         pages:    [0]        existing_page
                   [1:5]      extra report-only translations
-                  [5:10]     core_pages, untouched by the admin flows
+                  [5:10]     tree filler; named by no flow, but counted by
+                             core_page_index and walked by the subtree flow
                   [10]       heavy StreamField page, shared by every `large`
                   [11]       submit_page, left untranslated
         snippets: [0]        existing_snippet
                   [1]        extra report-only translation
-                  [3]        submit_snippet, left untranslated
+                  [2]        submit_related_snippets, with [3]
+                  [3]        submit_snippet, also in submit_related_snippets
     """
     from benchmarks.seed import build_snippet_pool, build_tree, ensure_locales
 
@@ -273,7 +272,6 @@ def prepare():
         # their sources and French targets inside its measured POST. Keeping
         # this set fixed is what makes 2 vs 40 references a clean scale.
         submit_related_snippets=(snippets[-2], snippets[-1]),
-        core_pages=pages[5 : 5 + CORE_PAGES],
     )
 
 

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -100,6 +100,14 @@ REFRESH_SEGMENT_BLOCKS = 40
 # How many segments the per-segment save flow writes at each size.
 STRING_SAVES_SMALL = 5
 STRING_SAVES_LARGE = REFRESH_SEGMENT_BLOCKS
+# The page-submission flow keeps two distinct related snippets at both sizes
+# and changes only how many times they are referenced. That separates repeated
+# related-object work from the fixed cost of translating another distinct
+# object.
+SUBMIT_RELATED_REFERENCES = {
+    "small": 2,
+    "large": REFRESH_SEGMENT_BLOCKS,
+}
 
 
 def _admin_client():
@@ -261,6 +269,10 @@ def prepare():
         subtree_root_small=home.get_children().first(),
         submit_page=pages[-1],
         submit_snippet=snippets[-1],
+        # Both are untouched by prepare(): the submit-page flow must create
+        # their sources and French targets inside its measured POST. Keeping
+        # this set fixed is what makes 2 vs 40 references a clean scale.
+        submit_related_snippets=(snippets[-2], snippets[-1]),
         core_pages=pages[5 : 5 + CORE_PAGES],
     )
 
@@ -299,25 +311,63 @@ def _translation_to(instance, locale):
 
 
 def _submit_page_setup(ctx, size):
-    """Assert the state the flow starts from, without changing it.
+    """Build the related-reference workload and freeze its starting state.
 
-    The page and its snippet must be untranslated, or the POST reconciles an
-    existing translation instead of creating one and the flow measures a
-    different operation than it names.
+    Both sizes reference the same two snippets. Only repetitions change, so
+    the query difference belongs to the related-object loops rather than to
+    translating more distinct dependencies. Publishing the workload belongs
+    in setup: the measured operation is submitting that stored page, not
+    editing it.
     """
-    if size is not None:
-        raise RuntimeError(f"submit_page_post takes no size; got {size!r}.")
+    expected = SUBMIT_RELATED_REFERENCES.get(size)
+    if expected is None:
+        raise RuntimeError(f"submit_page_post has no size {size!r}.")
 
-    page, snippet, french = ctx.submit_page, ctx.submit_snippet, ctx.locales["fr"]
+    page = ctx.submit_page
+    snippets = ctx.submit_related_snippets
+    french = ctx.locales["fr"]
 
-    if page.test_snippet_id != snippet.pk:
+    if page.test_snippet_id != snippets[-1].pk:
         raise RuntimeError(
             f"submit_page references snippet {page.test_snippet_id}, not "
-            f"submit_snippet ({snippet.pk}). The flow measures the related "
-            f"object fan-out, so the two have to be connected."
+            f"submit_snippet ({snippets[-1].pk})."
         )
 
-    for label, instance in (("page", page), ("snippet", snippet)):
+    # The direct FK is one reference; StreamField supplies the rest. Start the
+    # alternating sequence with the other snippet so small contains both.
+    page.test_streamfield = [
+        ("test_snippetchooserblock", snippets[number % len(snippets)])
+        for number in range(expected - 1)
+    ]
+    page.save_revision().publish()
+    page.refresh_from_db()
+
+    stream_references = [
+        block.value
+        for block in page.test_streamfield
+        if block.block_type == "test_snippetchooserblock"
+    ]
+    references = [page.test_snippet, *stream_references]
+    if len(references) != expected:
+        raise RuntimeError(
+            f"the {size} page holds {len(references)} related references, not "
+            f"the {expected} this scale measures."
+        )
+    expected_keys = {snippet.translation_key for snippet in snippets}
+    actual_keys = {snippet.translation_key for snippet in references}
+    if actual_keys != expected_keys:
+        raise RuntimeError(
+            f"the {size} page references objects {actual_keys}, not the fixed "
+            f"two-object pool {expected_keys}."
+        )
+
+    for label, instance in (
+        ("page", page),
+        *(
+            (f"related snippet {number}", snippet)
+            for number, snippet in enumerate(snippets)
+        ),
+    ):
         if _translation_source(instance) is not None:
             raise RuntimeError(f"the {label} already has a TranslationSource.")
         if _translation_to(instance, french) is not None:
@@ -340,13 +390,15 @@ def _submit_page_run(ctx, size):
 
 
 def _submit_page_verify(ctx, size, response):
-    """Check the page and its related snippet were both translated.
+    """Check every source reference became the corresponding French one.
 
     Queries name the object and locale rather than counting rows: prepare()
     creates other translations, so a global count would pass whatever this POST
-    did. Returns None — the flow declares no workload, and the objects created
-    here are the shape of the operation, not a scale dimension.
+    did. The returned workload is the source's related segment count, while the
+    target checks prevent a faster run that simply stopped ingesting them.
     """
+    from collections import Counter
+
     from django.urls import reverse
 
     if response.status_code != 302:
@@ -355,9 +407,17 @@ def _submit_page_verify(ctx, size, response):
             f"so the form was not accepted"
         )
 
-    page, snippet, french = ctx.submit_page, ctx.submit_snippet, ctx.locales["fr"]
+    page = ctx.submit_page
+    snippets = ctx.submit_related_snippets
+    french = ctx.locales["fr"]
 
-    for label, instance in (("page", page), ("snippet", snippet)):
+    for label, instance in (
+        ("page", page),
+        *(
+            (f"related snippet {number}", snippet)
+            for number, snippet in enumerate(snippets)
+        ),
+    ):
         if _translation_source(instance) is None:
             raise RuntimeError(f"no TranslationSource was created for the {label}.")
         if _translation_to(instance, french) is None:
@@ -365,13 +425,64 @@ def _submit_page_verify(ctx, size, response):
         if instance.get_translation_or_none(french) is None:
             raise RuntimeError(f"the {label} has no French target.")
 
-    target = page.get_translation(french)
+    source = _translation_source(page)
+    related_segments = list(
+        source.relatedobjectsegment_set.select_related("object").order_by("order", "id")
+    )
+    expected = SUBMIT_RELATED_REFERENCES[size]
+    if len(related_segments) != expected:
+        raise RuntimeError(
+            f"the submitted source holds {len(related_segments)} related "
+            f"segments, not the {expected} declared by {size}."
+        )
+    source_stream_references = [
+        block.value
+        for block in page.test_streamfield
+        if block.block_type == "test_snippetchooserblock"
+    ]
+    source_references = [page.test_snippet, *source_stream_references]
+    source_reference_keys = [snippet.translation_key for snippet in source_references]
+    segment_keys = [segment.object.translation_key for segment in related_segments]
+    if Counter(segment_keys) != Counter(source_reference_keys):
+        raise RuntimeError(
+            "the source's related segments do not preserve its references: "
+            f"{segment_keys} versus {source_reference_keys}."
+        )
+
+    target = page.get_translation(french).specific
+    if not target.live or target.alias_of_id:
+        raise RuntimeError(
+            "the French page was not published as a real translated page."
+        )
+
+    stream_references = [
+        block.value
+        for block in target.test_streamfield
+        if block.block_type == "test_snippetchooserblock"
+    ]
+    target_references = [target.test_snippet, *stream_references]
+    if len(target_references) != expected:
+        raise RuntimeError(
+            f"the French target holds {len(target_references)} related "
+            f"references, not the source's {expected}."
+        )
+    if any(snippet.locale_id != french.id for snippet in target_references):
+        raise RuntimeError("the French page still references a source-locale snippet.")
+    target_reference_keys = [snippet.translation_key for snippet in target_references]
+    if target_reference_keys != source_reference_keys:
+        raise RuntimeError(
+            "the French page changed the order or identity of its related "
+            f"references: {target_reference_keys} versus {source_reference_keys}."
+        )
+
     expected = reverse("wagtailadmin_pages:edit", args=[target.id])
     if response.url != expected:
         raise RuntimeError(
             f"the redirect went to {response.url}, not to the editor of the "
             f"page it created ({expected})"
         )
+
+    return len(related_segments)
 
 
 # ---------------------------------------------------------------------------
@@ -384,7 +495,9 @@ SUBMIT_PAGE_POST = Flow(
     group="creation",
     why=(
         "Creating a translation from the admin: the entry point an editor uses "
-        "to put a page into another locale for the first time."
+        "to put a page into another locale for the first time. Repeating a "
+        "fixed set of related snippets exposes both the creation fan-out and "
+        "the related-object checks while saving the target."
     ),
     entrypoint="SubmitPageTranslationView.post/form_valid",
     covers=(
@@ -392,120 +505,27 @@ SUBMIT_PAGE_POST = Flow(
         "TranslationSource.get_or_create_from_instance",
         "TranslationSource.refresh_segments",
         "Translation.save_target",
-        "related snippet translation",
+        "related snippet fan-out and target ingestion",
+    ),
+    workload_unit="related_object_segments",
+    scale_points=(
+        ScalePoint(
+            label="small",
+            why="Two distinct snippets, each referenced once.",
+            expected_workload=SUBMIT_RELATED_REFERENCES["small"],
+        ),
+        ScalePoint(
+            label="large",
+            why=(
+                "The same two snippets repeated forty times, so the difference "
+                "is repeated related-object work rather than more dependencies."
+            ),
+            expected_workload=SUBMIT_RELATED_REFERENCES["large"],
+        ),
     ),
     setup=_submit_page_setup,
     run=_submit_page_run,
     verify=_submit_page_verify,
-)
-
-
-# ---------------------------------------------------------------------------
-# submit_page_get
-# ---------------------------------------------------------------------------
-
-
-def _locale_choices(body):
-    """The locale ids offered as translation targets in a rendered form.
-
-    A small regex rather than a parser: the form renders the choices as
-    checkboxes named "locales", and nothing else in the page uses that name.
-    One check on one form does not justify a reusable HTML helper.
-    """
-    import re
-
-    return {
-        int(match.group(1))
-        for tag in re.findall(r"<input[^>]*name=\"locales\"[^>]*>", body)
-        if (match := re.search(r'value="(\d+)"', tag))
-    }
-
-
-def _submit_page_get_setup(ctx, size):
-    """Assert the page is still untranslated, so the form offers every target.
-
-    Shares nothing with the POST's setup beyond the idea: this flow does not
-    care about the related snippet, because rendering the form does not reach
-    it.
-    """
-    if size is not None:
-        raise RuntimeError(f"submit_page_get takes no size; got {size!r}.")
-
-    page = ctx.submit_page
-    if _translation_source(page) is not None:
-        raise RuntimeError(
-            "submit_page is already translated, so the form would offer fewer "
-            "locales than the scenario expects."
-        )
-    for code in ("fr", "es"):
-        if page.get_translation_or_none(ctx.locales[code]) is not None:
-            raise RuntimeError(f"submit_page already has a {code} target.")
-
-
-def _submit_page_get_run(ctx, size):
-    """GET the submit-translation form, and return the response unexamined."""
-    from django.urls import reverse
-
-    return ctx.client.get(
-        reverse(
-            "wagtail_localize:submit_page_translation",
-            args=[ctx.submit_page.id],
-        )
-    )
-
-
-def _submit_page_get_verify(ctx, size, response):
-    """Check the form rendered, offered the right locales, and wrote nothing."""
-    if response.status_code != 200:
-        raise RuntimeError(f"the submit form returned {response.status_code}, not 200")
-
-    body = response.content.decode()
-    offered = _locale_choices(body)
-    if not offered:
-        raise RuntimeError(
-            "the response carries no locale checkboxes, so the submit form did "
-            "not render"
-        )
-
-    expected = {ctx.locales["fr"].id, ctx.locales["es"].id}
-    if offered != expected:
-        raise RuntimeError(
-            f"the form offered locales {sorted(offered)}, expected {sorted(expected)}"
-        )
-    if ctx.submit_page.locale_id in offered:
-        raise RuntimeError(
-            "the form offered the page's own locale as a translation target"
-        )
-
-    # A GET must not write. Without this the flow would still pass if the view
-    # started creating state on render, so it checks every locale the form just
-    # offered, not one of them.
-    page = ctx.submit_page
-    if _translation_source(page) is not None:
-        raise RuntimeError("rendering the form created a TranslationSource.")
-    for code in ("fr", "es"):
-        locale = ctx.locales[code]
-        if _translation_to(page, locale) is not None:
-            raise RuntimeError(f"rendering the form created a {code} Translation.")
-        if page.get_translation_or_none(locale) is not None:
-            raise RuntimeError(f"rendering the form created a {code} target.")
-
-
-SUBMIT_PAGE_GET = Flow(
-    name="submit_page_get",
-    group="creation",
-    why=(
-        "Rendering the form that starts a page translation: what an editor "
-        "sees before anything is created."
-    ),
-    entrypoint="SubmitPageTranslationView.get/get_context_data",
-    covers=(
-        "SubmitTranslationForm construction",
-        "available target locale query",
-    ),
-    setup=_submit_page_get_setup,
-    run=_submit_page_get_run,
-    verify=_submit_page_get_verify,
 )
 
 
@@ -1431,7 +1451,6 @@ CORE_PAGE_INDEX = Flow(
 # core probes last. Not a sequence: every execution runs against a fresh
 # database, so no flow's result feeds the next.
 CATALOG = (
-    SUBMIT_PAGE_GET,
     SUBMIT_PAGE_POST,
     SUBMIT_SNIPPET_POST,
     TRANSLATE_PAGE_SUBTREE,

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -262,7 +262,11 @@ def prepare():
 
 
 # ---------------------------------------------------------------------------
-# submit_page_post
+# Translation state, named per object rather than counted
+#
+# prepare() creates several translations, so every check has to identify the
+# object, its own locale and the target locale. A count would pass whatever the
+# flow did.
 # ---------------------------------------------------------------------------
 
 
@@ -366,6 +370,11 @@ def _submit_page_verify(ctx, size, response):
         )
 
 
+# ---------------------------------------------------------------------------
+# submit_page_post
+# ---------------------------------------------------------------------------
+
+
 SUBMIT_PAGE_POST = Flow(
     name="submit_page_post",
     group="creation",
@@ -384,6 +393,210 @@ SUBMIT_PAGE_POST = Flow(
     setup=_submit_page_setup,
     run=_submit_page_run,
     verify=_submit_page_verify,
+)
+
+
+# ---------------------------------------------------------------------------
+# submit_page_get
+# ---------------------------------------------------------------------------
+
+
+def _locale_choices(body):
+    """The locale ids offered as translation targets in a rendered form.
+
+    A small regex rather than a parser: the form renders the choices as
+    checkboxes named "locales", and nothing else in the page uses that name.
+    One check on one form does not justify a reusable HTML helper.
+    """
+    import re
+
+    return {
+        int(match.group(1))
+        for tag in re.findall(r"<input[^>]*name=\"locales\"[^>]*>", body)
+        if (match := re.search(r'value="(\d+)"', tag))
+    }
+
+
+def _submit_page_get_setup(ctx, size):
+    """Assert the page is still untranslated, so the form offers every target.
+
+    Shares nothing with the POST's setup beyond the idea: this flow does not
+    care about the related snippet, because rendering the form does not reach
+    it.
+    """
+    if size is not None:
+        raise RuntimeError(f"submit_page_get takes no size; got {size!r}.")
+
+    page = ctx.submit_page
+    if _translation_source(page) is not None:
+        raise RuntimeError(
+            "submit_page is already translated, so the form would offer fewer "
+            "locales than the scenario expects."
+        )
+    for code in ("fr", "es"):
+        if page.get_translation_or_none(ctx.locales[code]) is not None:
+            raise RuntimeError(f"submit_page already has a {code} target.")
+
+
+def _submit_page_get_run(ctx, size):
+    """GET the submit-translation form, and return the response unexamined."""
+    from django.urls import reverse
+
+    return ctx.client.get(
+        reverse(
+            "wagtail_localize:submit_page_translation",
+            args=[ctx.submit_page.id],
+        )
+    )
+
+
+def _submit_page_get_verify(ctx, size, response):
+    """Check the form rendered, offered the right locales, and wrote nothing."""
+    if response.status_code != 200:
+        raise RuntimeError(f"the submit form returned {response.status_code}, not 200")
+
+    body = response.content.decode()
+    offered = _locale_choices(body)
+    if not offered:
+        raise RuntimeError(
+            "the response carries no locale checkboxes, so the submit form did "
+            "not render"
+        )
+
+    expected = {ctx.locales["fr"].id, ctx.locales["es"].id}
+    if offered != expected:
+        raise RuntimeError(
+            f"the form offered locales {sorted(offered)}, expected {sorted(expected)}"
+        )
+    if ctx.submit_page.locale_id in offered:
+        raise RuntimeError(
+            "the form offered the page's own locale as a translation target"
+        )
+
+    # A GET must not write. Without this the flow would still pass if the view
+    # started creating state on render, so it checks every locale the form just
+    # offered, not one of them.
+    page = ctx.submit_page
+    if _translation_source(page) is not None:
+        raise RuntimeError("rendering the form created a TranslationSource.")
+    for code in ("fr", "es"):
+        locale = ctx.locales[code]
+        if _translation_to(page, locale) is not None:
+            raise RuntimeError(f"rendering the form created a {code} Translation.")
+        if page.get_translation_or_none(locale) is not None:
+            raise RuntimeError(f"rendering the form created a {code} target.")
+
+
+SUBMIT_PAGE_GET = Flow(
+    name="submit_page_get",
+    group="creation",
+    why=(
+        "Rendering the form that starts a page translation: what an editor "
+        "sees before anything is created."
+    ),
+    entrypoint="SubmitPageTranslationView.get/get_context_data",
+    covers=(
+        "SubmitTranslationForm construction",
+        "available target locale query",
+    ),
+    setup=_submit_page_get_setup,
+    run=_submit_page_get_run,
+    verify=_submit_page_get_verify,
+)
+
+
+# ---------------------------------------------------------------------------
+# submit_snippet_post
+# ---------------------------------------------------------------------------
+
+
+def _snippet_url_parts(snippet):
+    """The app label, model name and pk the snippet admin URLs are built from."""
+    meta = type(snippet)._meta
+    return meta.app_label, meta.model_name, snippet.pk
+
+
+def _submit_snippet_setup(ctx, size):
+    """Assert the snippet starts untranslated, so the POST creates rather than
+    reconciles."""
+    if size is not None:
+        raise RuntimeError(f"submit_snippet_post takes no size; got {size!r}.")
+
+    snippet, french = ctx.submit_snippet, ctx.locales["fr"]
+    if _translation_source(snippet) is not None:
+        raise RuntimeError("submit_snippet already has a TranslationSource.")
+    if _translation_to(snippet, french) is not None:
+        raise RuntimeError("submit_snippet is already translated into French.")
+    if snippet.get_translation_or_none(french) is not None:
+        raise RuntimeError("submit_snippet already has a French target.")
+
+
+def _submit_snippet_run(ctx, size):
+    """POST the snippet submit form, and return the response unexamined."""
+    from django.urls import reverse
+
+    app_label, model_name, pk = _snippet_url_parts(ctx.submit_snippet)
+    return ctx.client.post(
+        reverse(
+            "wagtail_localize:submit_snippet_translation",
+            args=[app_label, model_name, pk],
+        ),
+        {"locales": [ctx.locales["fr"].id]},
+    )
+
+
+def _submit_snippet_verify(ctx, size, response):
+    """Check the snippet was translated and the redirect names that translation."""
+    from django.contrib.admin.utils import quote
+    from django.urls import reverse
+
+    if response.status_code != 302:
+        raise RuntimeError(
+            f"the submit view returned {response.status_code}, not a redirect"
+        )
+
+    snippet, french = ctx.submit_snippet, ctx.locales["fr"]
+    if _translation_source(snippet) is None:
+        raise RuntimeError("no TranslationSource was created for the snippet.")
+    if _translation_to(snippet, french) is None:
+        raise RuntimeError("the snippet was not translated into French.")
+
+    target = snippet.get_translation_or_none(french)
+    if target is None:
+        raise RuntimeError("the snippet has no French target.")
+    if target.field != snippet.field:
+        raise RuntimeError(
+            f"the French target carries {target.field!r}, not the source's "
+            f"{snippet.field!r}: the content was not copied across."
+        )
+
+    app_label, model_name, _pk = _snippet_url_parts(snippet)
+    expected = reverse(
+        f"wagtailsnippets_{app_label}_{model_name}:edit", args=[quote(target.pk)]
+    )
+    if response.url != expected:
+        raise RuntimeError(
+            f"the redirect went to {response.url}, not to the editor of the "
+            f"translation it created ({expected})"
+        )
+
+
+SUBMIT_SNIPPET_POST = Flow(
+    name="submit_snippet_post",
+    group="creation",
+    why=(
+        "Creating a snippet translation from the admin: the same translation "
+        "core reached from a different entry point than pages."
+    ),
+    entrypoint="SubmitSnippetTranslationView.post/form_valid",
+    covers=(
+        "TranslationCreator.create_translations",
+        "TranslationSource.get_or_create_from_instance",
+        "Translation.save_target",
+    ),
+    setup=_submit_snippet_setup,
+    run=_submit_snippet_run,
+    verify=_submit_snippet_verify,
 )
 
 
@@ -475,8 +688,15 @@ EDIT_TRANSLATION_GET = Flow(
 )
 
 
-# Creation before editing: a page is submitted before it is translated.
-CATALOG = (SUBMIT_PAGE_POST, EDIT_TRANSLATION_GET)
+# Grouped by what a flow does, creation entrypoints before the editor. Not a
+# sequence: every execution runs against a fresh database, so no flow's result
+# feeds the next.
+CATALOG = (
+    SUBMIT_PAGE_GET,
+    SUBMIT_PAGE_POST,
+    SUBMIT_SNIPPET_POST,
+    EDIT_TRANSLATION_GET,
+)
 
 BY_NAME = {flow.name: flow for flow in CATALOG}
 

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -1,0 +1,359 @@
+"""The catalog of wagtail-localize flows the harness measures.
+
+This module declares WHAT is measured. It runs no measurement, imports no
+measuring tool, and defers every Django import into a function — so importing
+it, and printing the catalog, costs nothing and needs no database.
+
+Coverage is not exhaustive and must not be assumed to be. A flow belongs here
+when it represents a process worth watching; anything absent is absent on
+purpose or not yet added.
+
+A Flow is one process. A Flow that compares scales declares its ScalePoints,
+and the runner expands the pair into one execution per point. A Flow without
+scale points runs once, with size None.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# The model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScalePoint:
+    """One input size a flow is measured at.
+
+    `expected_workload` is the amount of work this size is supposed to produce,
+    counted in the flow's `workload_unit`. It is data rather than a check
+    buried inside verify() so the catalog can be read, listed and tested
+    without executing anything — and so a scenario that quietly stops
+    producing its workload fails loudly instead of measuring a smaller one.
+    """
+
+    label: str
+    why: str
+    expected_workload: int
+
+
+@dataclass(frozen=True)
+class Flow:
+    """One process worth measuring, plus the metadata that makes it legible.
+
+    `run` performs the operation and returns its raw artifacts — a response, a
+    list of responses, or None. It does not count, parse or query: it executes
+    inside the measured region, so anything it does lands in the numbers.
+
+    `verify` runs after the measurement is closed. It may parse artifacts and
+    query freely. It raises if the scenario did not really happen, and returns
+    the observed workload for flows that declare a unit.
+
+    `setup`, when present, establishes the expected prior state before the
+    measurement and raises if the fixture is not in it.
+    """
+
+    name: str
+    group: str
+    why: str
+    entrypoint: str
+    covers: tuple[str, ...]
+    run: Callable[[Any, str | None], Any]
+    verify: Callable[[Any, str | None, Any], int | None]
+    workload_unit: str | None = None
+    scale_points: tuple[ScalePoint, ...] = ()
+    setup: Callable[[Any, str | None], None] | None = None
+
+    def sizes(self):
+        """The size labels this flow expands to. A flow without scale points
+        yields a single execution whose size is None."""
+        return tuple(point.label for point in self.scale_points) or (None,)
+
+    def scale_point(self, size):
+        for point in self.scale_points:
+            if point.label == size:
+                return point
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+#
+# Sizes are fixed. Big enough to fan out across snippets and locales, small
+# enough to build in a second or two.
+# ---------------------------------------------------------------------------
+
+PAGES = 12
+SNIPPETS = 4
+# Extra pages the core operations flows walk, kept disjoint from the pages the
+# admin flows act on so they do not collide with each other's preconditions.
+CORE_PAGES = 5
+# Page translations pre-created so the report view renders several rows.
+REPORT_PAGE_TRANSLATIONS = 5
+# StreamField blocks loaded onto the dedicated heavy page, so the flows that
+# scale with segment count fan out over many segments instead of the handful an
+# ordinary page carries.
+REFRESH_SEGMENT_BLOCKS = 40
+# How many segments the per-segment save flow writes at each size.
+STRING_SAVES_SMALL = 5
+STRING_SAVES_LARGE = REFRESH_SEGMENT_BLOCKS
+
+
+def _admin_client():
+    """A logged-in superuser client, so admin views authorize normally."""
+    from django.contrib.auth import get_user_model
+    from django.test import Client
+
+    user_model = get_user_model()
+    user, _created = user_model.objects.update_or_create(
+        username="benchmark-admin",
+        defaults={
+            "email": "benchmark-admin@example.com",
+            "is_staff": True,
+            "is_active": True,
+            "is_superuser": True,
+        },
+    )
+    client = Client()
+    client.force_login(user)
+    return client, user
+
+
+def _create_translation(instance, target_locale, *, user=None):
+    """Give `instance` a real, published target translation, so the flows that
+    act on an existing translation have one."""
+    from wagtail_localize.models import Translation, TranslationSource
+
+    source, _created = TranslationSource.get_or_create_from_instance(instance)
+    translation, _created = Translation.objects.get_or_create(
+        source=source,
+        target_locale=target_locale,
+        defaults={"enabled": True},
+    )
+    translation.save_target(user=user, publish=True)
+    return source, translation
+
+
+def _target_page_id(translation):
+    """The id of the translated page a Translation produced.
+
+    The editor is Wagtail's own page-edit view, intercepted for the target
+    page, so the editor flows need the target's id and not the source's.
+    """
+    return translation.get_target_instance().id
+
+
+def _segment_ids(source):
+    """A source's StringSegment ids in page order, resolved during setup so the
+    flows that save segments do not spend measured queries finding them."""
+    from wagtail_localize.models import StringSegment
+
+    return list(
+        StringSegment.objects.filter(source=source)
+        .order_by("order")
+        .values_list("id", flat=True)
+    )
+
+
+def prepare():
+    """Build the fixture for one execution.
+
+    Runs in a child process holding a fresh copy of an empty migrated database,
+    so it never has to clear anything and results do not depend on execution
+    order.
+
+    Slices are disjoint across roles so flows do not collide with each other's
+    preconditions:
+
+        pages:    [0]        existing_page
+                  [1:5]      extra report-only translations
+                  [5:10]     core_pages, untouched by the admin flows
+                  [10]       heavy StreamField page, shared by every `large`
+                  [11]       submit_page, left untranslated
+        snippets: [0]        existing_snippet
+                  [1]        extra report-only translation
+                  [3]        submit_snippet, left untranslated
+    """
+    from seed import build_snippet_pool, build_tree, ensure_locales
+
+    locales = ensure_locales()
+    snippets = build_snippet_pool(SNIPPETS, locales["en"])
+    _home, pages = build_tree(PAGES, locales["en"], snippets)
+    client, user = _admin_client()
+
+    existing_page = pages[0]
+    existing_page_source, existing_page_translation = _create_translation(
+        existing_page, locales["fr"], user=user
+    )
+    existing_snippet = snippets[0]
+    existing_snippet_source, existing_snippet_translation = _create_translation(
+        existing_snippet, locales["fr"], user=user
+    )
+
+    # Extra translations so the report view has several rows across content
+    # types, not just the "existing" ones above.
+    for page in pages[1:REPORT_PAGE_TRANSLATIONS]:
+        _create_translation(page, locales["fr"], user=user)
+    _create_translation(snippets[1], locales["fr"], user=user)
+
+    # Shared heavy fixture for every large flow; its Translation and target are
+    # also visible to report and tree-sync. Publish the blocks before creating
+    # the source, because segments come from stored source content, not the
+    # live page. Editor flows need the Translation and its target, not only a
+    # TranslationSource.
+    heavy_page = pages[10]
+    heavy_page.test_streamfield = [
+        ("test_charblock", f"Heavy segment block {i}")
+        for i in range(REFRESH_SEGMENT_BLOCKS)
+    ]
+    heavy_page.save_revision().publish()
+    heavy_page_source, heavy_page_translation = _create_translation(
+        heavy_page, locales["fr"], user=user
+    )
+
+    # Relative properties shared by the fixture: enough segments to save, and a
+    # large page genuinely larger than the small one. Exact cardinalities belong
+    # to ScalePoint.expected_workload instead, so a model change fails visibly
+    # and forces a look at the catalog rather than measuring a smaller workload
+    # unnoticed.
+    small_segment_ids = _segment_ids(existing_page_source)
+    large_segment_ids = _segment_ids(heavy_page_source)
+    if len(large_segment_ids) < STRING_SAVES_LARGE:
+        raise RuntimeError(
+            f"The heavy benchmark page yields {len(large_segment_ids)} string "
+            f"segments, fewer than the {STRING_SAVES_LARGE} the large flows "
+            f"need. Check REFRESH_SEGMENT_BLOCKS and that the block type still "
+            f"extracts one segment per block."
+        )
+    if len(large_segment_ids) <= len(small_segment_ids):
+        raise RuntimeError(
+            f"The large benchmark page ({len(large_segment_ids)} segments) "
+            f"must yield more segments than the small one "
+            f"({len(small_segment_ids)}), or the two sizes measure the same "
+            f"thing and no slope is observable."
+        )
+
+    return SimpleNamespace(
+        locales=locales,
+        client=client,
+        user=user,
+        pages=pages,
+        snippets=snippets,
+        existing_page=existing_page,
+        existing_page_source=existing_page_source,
+        existing_page_translation=existing_page_translation,
+        existing_snippet=existing_snippet,
+        existing_snippet_source=existing_snippet_source,
+        existing_snippet_translation=existing_snippet_translation,
+        heavy_page=heavy_page,
+        heavy_page_source=heavy_page_source,
+        heavy_page_translation=heavy_page_translation,
+        small_target_page_id=_target_page_id(existing_page_translation),
+        large_target_page_id=_target_page_id(heavy_page_translation),
+        small_segment_ids=small_segment_ids,
+        large_segment_ids=large_segment_ids,
+        submit_page=pages[-1],
+        submit_snippet=snippets[-1],
+        core_pages=pages[5 : 5 + CORE_PAGES],
+    )
+
+
+# ---------------------------------------------------------------------------
+# edit_translation_get
+# ---------------------------------------------------------------------------
+
+# The container the translation editor renders its payload into. Wagtail's
+# ordinary page editor also uses data-props, so that attribute alone would not
+# prove which editor was served.
+EDITOR_MARKER = 'class="js-translation-editor" data-props="'
+
+
+def _editor_run(ctx, size):
+    """GET the translation editor, and return the response unexamined.
+
+    Reached through Wagtail's own page-edit URL, not a wagtail_localize one:
+    `before_edit_page` finds the enabled Translation and hands off to
+    `edit_translation`. That is the only way in.
+    """
+    from django.urls import reverse
+
+    page_id = ctx.small_target_page_id if size == "small" else ctx.large_target_page_id
+    return ctx.client.get(reverse("wagtailadmin_pages:edit", args=[page_id]))
+
+
+def _editor_verify(ctx, size, response):
+    """Check the editor really rendered, then count what it rendered.
+
+    Runs outside the measured region, so parsing costs nothing the numbers see.
+    Counts from the response body rather than response.context, which is None
+    without the test runner's instrumentation.
+    """
+    import html
+    import json
+    import re
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"the editor returned {response.status_code}, not 200 — the flow "
+            f"did not render the translation editor"
+        )
+
+    body = response.content.decode()
+    if EDITOR_MARKER not in body:
+        raise RuntimeError(
+            "the response does not carry the translation editor's container, "
+            "so the editor did not render — Wagtail's ordinary page editor was "
+            "probably served instead, and the measurement is of the wrong view"
+        )
+
+    match = re.search(re.escape(EDITOR_MARKER) + r"([^\"]+)", body)
+    props = json.loads(html.unescape(match.group(1)))
+    return len(props["segments"])
+
+
+EDIT_TRANSLATION_GET = Flow(
+    name="edit_translation_get",
+    group="editing",
+    why=(
+        "Rendering the translation editor: the view a translator works in, and "
+        "the one whose cost grows with the number of segments on the page."
+    ),
+    entrypoint="before_edit_page -> edit_translation.edit_translation",
+    covers=(
+        "before_edit_page hook dispatch",
+        "edit_translation view",
+        "TabHelper / get_segment_location_info",
+        "segment serialisation",
+    ),
+    workload_unit="rendered_segments",
+    scale_points=(
+        ScalePoint(
+            label="small",
+            why="An ordinary page, which gives the fixed cost of the view.",
+            expected_workload=2,
+        ),
+        ScalePoint(
+            label="large",
+            why=(
+                "The StreamField-heavy page, which makes the per-segment cost "
+                "visible instead of hiding it inside the fixed cost."
+            ),
+            expected_workload=42,
+        ),
+    ),
+    run=_editor_run,
+    verify=_editor_verify,
+)
+
+
+CATALOG = (EDIT_TRANSLATION_GET,)
+
+BY_NAME = {flow.name: flow for flow in CATALOG}
+
+
+def executions():
+    """Every (flow, size) pair the catalog expands to."""
+    return tuple((flow, size) for flow in CATALOG for size in flow.sizes())

--- a/benchmarks/env.py
+++ b/benchmarks/env.py
@@ -1,0 +1,36 @@
+"""Django bootstrap for the benchmark harness."""
+
+import os
+import sys
+
+
+ENV_VAR = "WL_BENCHMARK_DB"
+
+
+def bootstrap():
+    """Configure Django against the database named by WL_BENCHMARK_DB.
+
+    Idempotent: django.setup() is a no-op once the apps are loaded.
+    """
+    # The harness runs as a plain script, so neither the repo root nor src/ is
+    # on the path.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    for path in (repo_root, os.path.join(repo_root, "src")):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+    database = os.environ.get(ENV_VAR)
+    if not database:
+        raise RuntimeError(
+            f"{ENV_VAR} is not set. Run the harness through benchmarks/run.py."
+        )
+
+    # benchmarks/settings.py, not the demo site's: it overlays DEBUG=False so
+    # the measured code runs under the configuration a benchmark should use.
+    # Only reachable once repo_root is on the path, above.
+    os.environ["DJANGO_SETTINGS_MODULE"] = "benchmarks.settings"
+    os.environ["DATABASE_URL"] = f"sqlite:///{database}"
+
+    import django
+
+    django.setup()

--- a/benchmarks/requirements-query-doctor.txt
+++ b/benchmarks/requirements-query-doctor.txt
@@ -1,0 +1,10 @@
+# Optional diagnostic dependency for benchmarks/run_query_doctor.py.
+#
+# Not a project dependency: nothing in wagtail-localize, its test suite, or CI
+# installs or imports this. It is needed only to run or debug the benchmark's
+# diagnostic command, in the separate environment described in
+# benchmarks/README.md.
+#
+# Pinned to the version the harness was verified against, so a diagnosis run
+# later reproduces the one run today.
+django-query-doctor==2.1.1

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -3,6 +3,7 @@
     python benchmarks/run.py --list
     python benchmarks/run.py edit_translation_get
     python benchmarks/run.py edit_translation_get --size small
+    python benchmarks/run.py all
 
 Every execution runs in its own child process against its own fresh copy of an
 empty migrated database. That is what makes two executions comparable: copying
@@ -41,6 +42,9 @@ TOKEN_ENV_VAR = "WL_BENCHMARK_TOKEN"  # noqa: S105
 TOKEN_FILENAME = ".wl-benchmark-token"  # noqa: S105
 
 CHILD_FLAG = "--execute-in-child"
+
+# Reserved: it selects the whole catalog, so no flow may be called this.
+ALL = "all"
 
 # The child writes its result on one line with this prefix, so the parent reads
 # a line it can identify rather than guessing from the shape of the output.
@@ -288,6 +292,39 @@ def execute(name, size, template, directory, index, token):
     }
 
 
+def _executions_for(name, size):
+    """The (flow, size) pairs a command line selects, in catalog order.
+
+    Raises ValueError with the message the CLI should show. Kept apart from
+    main() so a selection can be checked without creating a database or a
+    process.
+    """
+    import catalog
+
+    if name == ALL:
+        if size is not None:
+            raise ValueError(f"--size cannot be used with {ALL}")
+        return list(catalog.executions())
+
+    if name not in catalog.BY_NAME:
+        raise ValueError(
+            f"unknown flow {name!r}. "
+            f"Known: {', '.join(sorted(catalog.BY_NAME))}, or {ALL}"
+        )
+
+    flow = catalog.BY_NAME[name]
+    if size is None:
+        return [(flow, declared) for declared in flow.sizes()]
+    if not flow.scale_points:
+        raise ValueError(f"{flow.name} takes no size")
+    if size not in flow.sizes():
+        raise ValueError(
+            f"{flow.name} has no size {size!r}. "
+            f"Declared: {', '.join(str(s) for s in flow.sizes())}"
+        )
+    return [(flow, size)]
+
+
 def print_catalog():
     import catalog
 
@@ -331,7 +368,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Measure wagtail-localize flows.",
     )
-    parser.add_argument("flow", nargs="?", help="flow name; omit with --list")
+    parser.add_argument("flow", nargs="?", help=f"flow name or {ALL}; omit with --list")
     parser.add_argument("--size", help="run only this scale point")
     parser.add_argument("--list", action="store_true", help="print the catalog")
     parser.add_argument(CHILD_FLAG, action="store_true", help=argparse.SUPPRESS)
@@ -352,34 +389,24 @@ def main():
         print_catalog()
         return 0
 
-    import catalog
-
     if not arguments.flow:
-        parser.error("give a flow name, or use --list")
-    if arguments.flow not in catalog.BY_NAME:
-        parser.error(
-            f"unknown flow {arguments.flow!r}. "
-            f"Known: {', '.join(sorted(catalog.BY_NAME))}"
-        )
+        parser.error(f"give a flow name or {ALL}, or use --list")
 
-    flow = catalog.BY_NAME[arguments.flow]
-    sizes = flow.sizes()
-    if arguments.size is not None:
-        if not flow.scale_points:
-            parser.error(f"{flow.name} takes no size")
-        if arguments.size not in sizes:
-            parser.error(
-                f"{flow.name} has no size {arguments.size!r}. "
-                f"Declared: {', '.join(str(s) for s in sizes)}"
-            )
-        sizes = (arguments.size,)
+    # Resolved before anything is created, so an impossible selection costs no
+    # temporary directory and no migration.
+    try:
+        plan = _executions_for(arguments.flow, arguments.size)
+    except ValueError as error:
+        parser.error(str(error))
 
     directory = tempfile.mkdtemp(prefix="wl-benchmark-")
     ok = True
     try:
         token = _own_directory(directory)
+        # One template per invocation; every execution copies it. The index is
+        # unique across the whole run, so no two executions share a database.
         template = _build_template(directory, token)
-        for index, size in enumerate(sizes):
+        for index, (flow, size) in enumerate(plan):
             ok &= report(execute(flow.name, size, template, directory, index, token))
     finally:
         shutil.rmtree(directory)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -365,6 +365,8 @@ def main():
     flow = catalog.BY_NAME[arguments.flow]
     sizes = flow.sizes()
     if arguments.size is not None:
+        if not flow.scale_points:
+            parser.error(f"{flow.name} takes no size")
         if arguments.size not in sizes:
             parser.error(
                 f"{flow.name} has no size {arguments.size!r}. "

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -4,6 +4,7 @@
     python benchmarks/run.py edit_translation_get
     python benchmarks/run.py edit_translation_get --size small
     python benchmarks/run.py all
+    python benchmarks/run.py all --repeat 5
 
 Every execution runs in its own child process against its own fresh copy of an
 empty migrated database. That is what makes two executions comparable: copying
@@ -31,6 +32,7 @@ import os
 import platform
 import secrets
 import shutil
+import statistics
 import subprocess
 import sys
 import tempfile
@@ -66,7 +68,17 @@ RESULT_PREFIX = "WL_BENCHMARK_RESULT="
 
 # Bump when the shape of the --json file changes, so a reader can tell whether
 # it understands a file before trusting it.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+
+# What every repetition of one (flow, size) has to agree on. Time is expected to
+# move between repetitions; these are not. A flow whose measurement moves is a
+# finding about that flow, so the run says so instead of averaging it away.
+STABLE_ACROSS_REPETITIONS = (
+    "queries",
+    "workload_unit",
+    "expected_workload",
+    "observed_workload",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -318,6 +330,73 @@ def execute(name, size, template, directory, index, token):
         }
 
 
+def _aggregate(name, size, results):
+    """One (flow, size) reduced from its repetitions to a single result.
+
+    Nothing is discarded and nothing is averaged: either every repetition
+    agreed on what it measured, in which case the time is summarised, or the
+    disagreement is the result.
+    """
+    repeats = len(results)
+    errors = [result["error"] for result in results if "error" in result]
+    if errors:
+        detail = "\n".join(errors)
+        return {
+            "process": name,
+            "size": size,
+            "repeats": repeats,
+            "error": f"{len(errors)} of {repeats} repetition(s) failed:\n{detail}",
+        }
+
+    for field in STABLE_ACROSS_REPETITIONS:
+        values = [result[field] for result in results]
+        if any(value != values[0] for value in values):
+            return {
+                "process": name,
+                "size": size,
+                "repeats": repeats,
+                "error": (
+                    f"{field} was not identical across {repeats} repetitions: "
+                    f"{values}. The flow is not deterministic, which is a "
+                    f"finding rather than noise to average."
+                ),
+            }
+
+    seconds = [result["seconds"] for result in results]
+    first = results[0]
+    return {
+        "process": name,
+        "size": size,
+        "repeats": repeats,
+        "queries": first["queries"],
+        "workload_unit": first["workload_unit"],
+        "expected_workload": first["expected_workload"],
+        "observed_workload": first["observed_workload"],
+        "seconds_median": statistics.median(seconds),
+        "seconds_min": min(seconds),
+        "seconds_max": max(seconds),
+    }
+
+
+def repeat(name, size, template, directory, index, token, repeats):
+    """Measure one (flow, size) `repeats` times, and aggregate.
+
+    A repetition is a whole execution: its own copy of the template, its own
+    child, its own setup and verify. There is no warm-up, because for a flow
+    that changes data a second pass over the same state would measure
+    reconciling rather than creating, and the harness makes every process cold
+    on purpose.
+    """
+    return _aggregate(
+        name,
+        size,
+        [
+            execute(name, size, template, directory, index + offset, token)
+            for offset in range(repeats)
+        ],
+    )
+
+
 def _git(*arguments):
     """A short git query.
 
@@ -407,29 +486,40 @@ def _provenance(selection):
 
 
 def _public_result(result):
-    """One execution, reduced to what belongs in a shared file.
+    """One (flow, size) reduced to what belongs in a shared file.
 
-    The database path and the child's pid are private to a run, and timings
-    from a single execution are not a signal this format publishes.
+    The database path and the child's pid are private to a run. So are the
+    individual timings: what this format publishes is the summary across
+    repetitions, and `repeats` says how many observations it stands on.
     """
     if "error" in result:
         return {
             "flow": result["process"],
             "size": result["size"],
             "status": "failed",
+            "repeats": result.get("repeats"),
             "queries": None,
             "workload_unit": None,
             "expected_workload": None,
             "observed_workload": None,
+            "seconds_median": None,
+            "seconds_min": None,
+            "seconds_max": None,
         }
     return {
         "flow": result["process"],
         "size": result["size"],
         "status": "ok",
+        "repeats": result["repeats"],
         "queries": result["queries"],
         "workload_unit": result["workload_unit"],
         "expected_workload": result["expected_workload"],
         "observed_workload": result["observed_workload"],
+        # Microseconds: finer than anything this measurement can distinguish,
+        # and it keeps the file readable.
+        "seconds_median": round(result["seconds_median"], 6),
+        "seconds_min": round(result["seconds_min"], 6),
+        "seconds_max": round(result["seconds_max"], 6),
     }
 
 
@@ -513,8 +603,14 @@ def report(result):
     size = result["size"] or "-"
     line = (
         f"{result['process']} [{size}]  "
-        f"{result['queries']} queries  {result['seconds'] * 1000:.1f} ms"
+        f"{result['queries']} queries  {result['seconds_median'] * 1000:.1f} ms"
     )
+    if result["repeats"] > 1:
+        line += (
+            f" median (min {result['seconds_min'] * 1000:.1f}, "
+            f"max {result['seconds_max'] * 1000:.1f}, "
+            f"{result['repeats']} repeats)"
+        )
     if result["workload_unit"]:
         line += (
             f"  {result['observed_workload']} {result['workload_unit']}"
@@ -524,6 +620,17 @@ def report(result):
     return True
 
 
+def _positive(value):
+    """An argparse type for a count that has to be at least one."""
+    try:
+        number = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from None
+    if number < 1:
+        raise argparse.ArgumentTypeError(f"{number} is not at least 1")
+    return number
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Measure wagtail-localize flows.",
@@ -531,6 +638,13 @@ def main():
     parser.add_argument("flow", nargs="?", help=f"flow name or {ALL}; omit with --list")
     parser.add_argument("--size", help="run only this scale point")
     parser.add_argument("--list", action="store_true", help="print the catalog")
+    parser.add_argument(
+        "--repeat",
+        type=_positive,
+        default=1,
+        metavar="N",
+        help="run each execution N times and summarise the time (default 1)",
+    )
     parser.add_argument(
         "--json", dest="json_path", metavar="PATH", help="also write the run to PATH"
     )
@@ -569,7 +683,13 @@ def main():
     if arguments.json_path:
         try:
             _check_json_path(arguments.json_path)
-            provenance = _provenance({"flow": arguments.flow, "size": arguments.size})
+            provenance = _provenance(
+                {
+                    "flow": arguments.flow,
+                    "size": arguments.size,
+                    "repeat": arguments.repeat,
+                }
+            )
         except (ValueError, LookupError, RuntimeError) as error:
             parser.error(f"--json: {error}")
 
@@ -578,11 +698,20 @@ def main():
     results = []
     try:
         token = _own_directory(directory)
-        # One template per invocation; every execution copies it. The index is
-        # unique across the whole run, so no two executions share a database.
+        # One template per invocation; every execution copies it. Indices are
+        # reserved in blocks of `--repeat`, so no two executions anywhere in the
+        # run share a database.
         template = _build_template(directory, token)
-        for index, (flow, size) in enumerate(plan):
-            result = execute(flow.name, size, template, directory, index, token)
+        for position, (flow, size) in enumerate(plan):
+            result = repeat(
+                flow.name,
+                size,
+                template,
+                directory,
+                position * arguments.repeat,
+                token,
+                arguments.repeat,
+            )
             results.append(result)
             ok &= report(result)
     finally:

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -590,6 +590,9 @@ def print_catalog():
             for point in flow.scale_points:
                 print(f"      {point.label:8}expects {point.expected_workload}")
         print(f"    entrypoint {flow.entrypoint}")
+        for index, covered in enumerate(flow.covers):
+            label = "covers" if index == 0 else ""
+            print(f"    {label:10} {covered}")
         print(f"    why        {flow.why}")
         print()
 
@@ -661,6 +664,8 @@ def main():
         return 0
 
     if arguments.list:
+        if arguments.flow:
+            parser.error("--list takes no flow name")
         if arguments.json_path:
             parser.error("--json has nothing to write with --list")
         print_catalog()

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -33,6 +33,17 @@ import sys
 import tempfile
 
 
+if __name__ == "__main__":
+    # Running this file directly puts benchmarks/ on sys.path, not the repo
+    # root, so `benchmarks.*` would not resolve. Imported as a package the root
+    # is already reachable, and inserting it would change sys.path for whoever
+    # imported us. The single identity matters: loaded flat and as a package,
+    # `catalog` and `benchmarks.catalog` are two objects with separate state.
+    _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _REPO_ROOT not in sys.path:
+        sys.path.insert(0, _REPO_ROOT)
+
+
 # The env var env.bootstrap() reads. Named here so the parent, which must not
 # import anything Django-adjacent, does not have to import env to set it.
 DB_ENV_VAR = "WL_BENCHMARK_DB"
@@ -100,7 +111,7 @@ def guard_database():
 
 def _select(name, size):
     """Validate and resolve a catalog selection before building the fixture."""
-    import catalog
+    from benchmarks import catalog
 
     if name not in catalog.BY_NAME:
         raise SystemExit(
@@ -140,7 +151,7 @@ def run_in_child(name, size):
     guard_database()
     catalog, flow, point = _select(name, size)
 
-    from env import bootstrap
+    from benchmarks.env import bootstrap
 
     bootstrap()
 
@@ -155,9 +166,10 @@ def run_in_child(name, size):
 
     # CaptureQueriesContext enables its own debug cursor, so DEBUG remains off
     # and the code under measurement runs under the benchmark's own settings.
-    # Clear the log first: connection.queries_log is a deque(maxlen=9000); once
-    # fixture setup fills it, captured positions can coincide and report zero
-    # queries with only a UserWarning.
+    # Under those settings the fixture does not fill connection.queries_log;
+    # this clears it in case setup or optional instrumentation turned query
+    # logging on, because the log is a deque(maxlen=9000) and a full one makes
+    # the captured positions coincide and report zero with only a UserWarning.
     reset_queries()
 
     with CaptureQueriesContext(connection) as captured:
@@ -237,9 +249,7 @@ def _build_template(directory, token):
 def build_template_in_child():
     guard_database()
 
-    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-    from env import bootstrap
+    from benchmarks.env import bootstrap
 
     bootstrap()
 
@@ -278,18 +288,27 @@ def execute(name, size, template, directory, index, token):
             ),
         }
 
-    payload = json.loads(lines[-1])
-    return {
-        "process": name,
-        "size": size,
-        "queries": payload["queries"],
-        "seconds": payload["seconds"],
-        "workload_unit": payload["workload_unit"],
-        "expected_workload": payload["expected_workload"],
-        "observed_workload": payload["observed_workload"],
-        "pid": payload["pid"],
-        "database": payload["database"],
-    }
+    # A child that printed something unusable is this execution's failure, not
+    # the whole run's: `all` has to reach the executions after it.
+    try:
+        payload = json.loads(lines[-1])
+        return {
+            "process": name,
+            "size": size,
+            "queries": payload["queries"],
+            "seconds": payload["seconds"],
+            "workload_unit": payload["workload_unit"],
+            "expected_workload": payload["expected_workload"],
+            "observed_workload": payload["observed_workload"],
+            "pid": payload["pid"],
+            "database": payload["database"],
+        }
+    except (ValueError, TypeError, KeyError) as error:
+        return {
+            "process": name,
+            "size": size,
+            "error": f"unusable {RESULT_PREFIX} line: {error}\n{lines[-1]}",
+        }
 
 
 def _executions_for(name, size):
@@ -299,7 +318,7 @@ def _executions_for(name, size):
     main() so a selection can be checked without creating a database or a
     process.
     """
-    import catalog
+    from benchmarks import catalog
 
     if name == ALL:
         if size is not None:
@@ -326,7 +345,7 @@ def _executions_for(name, size):
 
 
 def print_catalog():
-    import catalog
+    from benchmarks import catalog
 
     flows = catalog.CATALOG
     print(f"{len(flows)} process(es), {len(catalog.executions())} execution(s)\n")
@@ -374,8 +393,6 @@ def main():
     parser.add_argument(CHILD_FLAG, action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--build-template", action="store_true", help=argparse.SUPPRESS)
     arguments = parser.parse_args()
-
-    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
     if arguments.build_template:
         build_template_in_child()

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -24,8 +24,11 @@ parent, and a machine-readable output mode is a separate concern.
 """
 
 import argparse
+import datetime
+import importlib.metadata
 import json
 import os
+import platform
 import secrets
 import shutil
 import subprocess
@@ -60,6 +63,10 @@ ALL = "all"
 # The child writes its result on one line with this prefix, so the parent reads
 # a line it can identify rather than guessing from the shape of the output.
 RESULT_PREFIX = "WL_BENCHMARK_RESULT="
+
+# Bump when the shape of the --json file changes, so a reader can tell whether
+# it understands a file before trusting it.
+SCHEMA_VERSION = 1
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +318,140 @@ def execute(name, size, template, directory, index, token):
         }
 
 
+def _git(*arguments):
+    """A short git query.
+
+    Raises RuntimeError when git cannot answer: a document that says which
+    commit was measured is the point, and a null there would be a run nobody
+    can place.
+    """
+    # Partial path on purpose: the harness records whichever git the developer
+    # is already using, and a wrong answer only affects provenance, never a
+    # measurement.
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", *arguments],  # noqa: S607
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise RuntimeError(f"cannot run git: {error}") from error
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        raise RuntimeError(f"git {' '.join(arguments)}: {detail}")
+    return result.stdout.strip()
+
+
+# Public key in the document, and the distribution name the environment
+# records it under. The parent reads metadata rather than importing these, so
+# it still never initialises Django.
+MEASURED_PACKAGES = {
+    "django": "Django",
+    "wagtail": "wagtail",
+    "wagtail_localize": "wagtail-localize",
+}
+
+
+def _versions():
+    """The versions of the packages under measurement.
+
+    Raises LookupError naming what is missing: provenance that cannot say what
+    was measured is worse than no file at all.
+    """
+    versions = {"python": platform.python_version()}
+    missing = []
+    for key, distribution in MEASURED_PACKAGES.items():
+        try:
+            versions[key] = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            missing.append(distribution)
+    if missing:
+        raise LookupError(
+            f"no installed metadata for {', '.join(missing)}, so the run cannot "
+            f"record what it measured"
+        )
+    return versions
+
+
+def _check_json_path(path):
+    """Raise ValueError unless the run could write its results to `path`."""
+    if os.path.isdir(path):
+        raise ValueError(f"{path} is a directory")
+
+    parent = os.path.dirname(os.path.abspath(path))
+    if not os.path.isdir(parent):
+        raise ValueError(f"no directory {parent}")
+    if not os.access(parent, os.W_OK):
+        raise ValueError(f"{parent} is not writable")
+    if os.path.exists(path) and not os.access(path, os.W_OK):
+        raise ValueError(f"{path} is not writable")
+
+
+def _provenance(selection):
+    """What a reader needs to know before trusting the numbers."""
+    dirty = _git("status", "--porcelain")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "commit": _git("rev-parse", "HEAD"),
+        "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+        # Whatever git status reports for this checkout, under the ignore
+        # rules in force there: anything ignored is invisible here.
+        "working_tree_clean": dirty == "",
+        "versions": _versions(),
+        "selection": selection,
+    }
+
+
+def _public_result(result):
+    """One execution, reduced to what belongs in a shared file.
+
+    The database path and the child's pid are private to a run, and timings
+    from a single execution are not a signal this format publishes.
+    """
+    if "error" in result:
+        return {
+            "flow": result["process"],
+            "size": result["size"],
+            "status": "failed",
+            "queries": None,
+            "workload_unit": None,
+            "expected_workload": None,
+            "observed_workload": None,
+        }
+    return {
+        "flow": result["process"],
+        "size": result["size"],
+        "status": "ok",
+        "queries": result["queries"],
+        "workload_unit": result["workload_unit"],
+        "expected_workload": result["expected_workload"],
+        "observed_workload": result["observed_workload"],
+    }
+
+
+def _write_json(path, provenance, results):
+    """Write the run to `path`.
+
+    A run with a failed execution is written, but marked incomplete: it is a
+    record of what happened, never a baseline to compare against.
+    """
+    executions = [_public_result(result) for result in results]
+    document = {
+        **provenance,
+        "status": (
+            "complete" if all(e["status"] == "ok" for e in executions) else "incomplete"
+        ),
+        "executions": executions,
+    }
+    with open(path, "w") as handle:
+        json.dump(document, handle, indent=2, sort_keys=False)
+        handle.write("\n")
+
+
 def _executions_for(name, size):
     """The (flow, size) pairs a command line selects, in catalog order.
 
@@ -390,6 +531,9 @@ def main():
     parser.add_argument("flow", nargs="?", help=f"flow name or {ALL}; omit with --list")
     parser.add_argument("--size", help="run only this scale point")
     parser.add_argument("--list", action="store_true", help="print the catalog")
+    parser.add_argument(
+        "--json", dest="json_path", metavar="PATH", help="also write the run to PATH"
+    )
     parser.add_argument(CHILD_FLAG, action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--build-template", action="store_true", help=argparse.SUPPRESS)
     arguments = parser.parse_args()
@@ -403,6 +547,8 @@ def main():
         return 0
 
     if arguments.list:
+        if arguments.json_path:
+            parser.error("--json has nothing to write with --list")
         print_catalog()
         return 0
 
@@ -416,17 +562,37 @@ def main():
     except ValueError as error:
         parser.error(str(error))
 
+    # Everything about --json is settled before anything runs: a path that
+    # cannot be written should cost a message, not a run whose results are then
+    # thrown away.
+    provenance = None
+    if arguments.json_path:
+        try:
+            _check_json_path(arguments.json_path)
+            provenance = _provenance({"flow": arguments.flow, "size": arguments.size})
+        except (ValueError, LookupError, RuntimeError) as error:
+            parser.error(f"--json: {error}")
+
     directory = tempfile.mkdtemp(prefix="wl-benchmark-")
     ok = True
+    results = []
     try:
         token = _own_directory(directory)
         # One template per invocation; every execution copies it. The index is
         # unique across the whole run, so no two executions share a database.
         template = _build_template(directory, token)
         for index, (flow, size) in enumerate(plan):
-            ok &= report(execute(flow.name, size, template, directory, index, token))
+            result = execute(flow.name, size, template, directory, index, token)
+            results.append(result)
+            ok &= report(result)
     finally:
         shutil.rmtree(directory)
+
+    # Written from the results the run already produced: nothing is executed
+    # twice and the measured region is untouched.
+    if arguments.json_path:
+        _write_json(arguments.json_path, provenance, results)
+        print(f"wrote {arguments.json_path}", file=sys.stderr)
 
     return 0 if ok else 1
 

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,0 +1,389 @@
+"""Run the benchmark catalog.
+
+    python benchmarks/run.py --list
+    python benchmarks/run.py edit_translation_get
+    python benchmarks/run.py edit_translation_get --size small
+
+Every execution runs in its own child process against its own fresh copy of an
+empty migrated database. That is what makes two executions comparable: copying
+a file gives an identical starting state without deleting anything, and a new
+process leaves no warm caches behind — neither Django's, nor Wagtail's, nor
+Python's import cache.
+
+The parent never imports Django. It creates a temporary directory, has a child
+build the template database, then for each execution copies the template and
+launches a child. Because the parent holds no connection, there is nothing to
+close before copying, and no file outside its own temporary directory is
+modified. The children are launched with sys.executable, so the harness runs in
+whatever environment invoked it.
+
+The child prints one JSON line for the parent to read. That is an internal
+channel, not the reporting format: the console output below is built by the
+parent, and a machine-readable output mode is a separate concern.
+"""
+
+import argparse
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+# The env var env.bootstrap() reads. Named here so the parent, which must not
+# import anything Django-adjacent, does not have to import env to set it.
+DB_ENV_VAR = "WL_BENCHMARK_DB"
+# Not a secret: a per-invocation marker that says "this harness made this
+# directory". It guards against accident, not against anyone hostile.
+TOKEN_ENV_VAR = "WL_BENCHMARK_TOKEN"  # noqa: S105
+TOKEN_FILENAME = ".wl-benchmark-token"  # noqa: S105
+
+CHILD_FLAG = "--execute-in-child"
+
+# The child writes its result on one line with this prefix, so the parent reads
+# a line it can identify rather than guessing from the shape of the output.
+RESULT_PREFIX = "WL_BENCHMARK_RESULT="
+
+
+# ---------------------------------------------------------------------------
+# Child: the only side that touches Django
+# ---------------------------------------------------------------------------
+
+
+def guard_database():
+    """Validate that the database belongs to this harness invocation.
+
+    The token prevents accidentally running an internal child command against
+    another database. It is a safety guard, not a security boundary.
+
+    Returns the resolved path, or exits non-zero without opening the database.
+    """
+    database = os.environ.get(DB_ENV_VAR)
+    token = os.environ.get(TOKEN_ENV_VAR)
+
+    if not database:
+        raise SystemExit(f"{DB_ENV_VAR} is not set; start from run.py.")
+    if not token:
+        raise SystemExit(
+            f"{TOKEN_ENV_VAR} is not set. The child modes are internal: the "
+            f"parent passes a token so the harness cannot be pointed at a "
+            f"database it does not own. Start from run.py."
+        )
+
+    resolved = os.path.realpath(database)
+    directory = os.path.dirname(resolved)
+    token_file = os.path.join(directory, TOKEN_FILENAME)
+
+    if not os.path.isfile(token_file):
+        raise SystemExit(
+            f"refusing to use {resolved}: it is not inside a directory this "
+            f"harness created, so it may be a database you care about. "
+            f"The database was not opened or modified."
+        )
+
+    with open(token_file) as handle:
+        if handle.read().strip() != token:
+            raise SystemExit(
+                f"refusing to use {resolved}: the token does not match the one "
+                f"in {TOKEN_FILENAME}. The database was not opened or "
+                f"modified."
+            )
+
+    return resolved
+
+
+def _select(name, size):
+    """Validate and resolve a catalog selection before building the fixture."""
+    import catalog
+
+    if name not in catalog.BY_NAME:
+        raise SystemExit(
+            f"unknown flow {name!r}. Known: {', '.join(sorted(catalog.BY_NAME))}"
+        )
+
+    flow = catalog.BY_NAME[name]
+    declared = flow.sizes()
+
+    if flow.scale_points and size is None:
+        raise SystemExit(
+            f"{flow.name} declares scale points, so it needs a size. "
+            f"Declared: {', '.join(p.label for p in flow.scale_points)}"
+        )
+    if not flow.scale_points and size is not None:
+        raise SystemExit(
+            f"{flow.name} declares no scale points, so it takes no size; got {size!r}."
+        )
+    if size not in declared:
+        raise SystemExit(
+            f"{flow.name} has no size {size!r}. "
+            f"Declared: {', '.join(str(s) for s in declared)}"
+        )
+
+    return catalog, flow, flow.scale_point(size)
+
+
+def run_in_child(name, size):
+    """Prepare the fixture, measure one execution, verify it, report.
+
+    The measured region is exactly the flow's own call. Fixture construction
+    and the flow's setup happen before it; verification happens after the
+    context manager has closed, so neither lands in the numbers.
+    """
+    # Both run before Django exists: an invalid database must not be opened,
+    # and an invalid selection must not cost a fixture build.
+    guard_database()
+    catalog, flow, point = _select(name, size)
+
+    from env import bootstrap
+
+    bootstrap()
+
+    from time import perf_counter
+
+    from django.db import connection, reset_queries
+    from django.test.utils import CaptureQueriesContext
+
+    ctx = catalog.prepare()
+    if flow.setup:
+        flow.setup(ctx, size)
+
+    # CaptureQueriesContext enables its own debug cursor, so DEBUG remains off
+    # and the code under measurement runs under the benchmark's own settings.
+    # Clear the log first: connection.queries_log is a deque(maxlen=9000); once
+    # fixture setup fills it, captured positions can coincide and report zero
+    # queries with only a UserWarning.
+    reset_queries()
+
+    with CaptureQueriesContext(connection) as captured:
+        started = perf_counter()
+        artifacts = flow.run(ctx, size)
+        seconds = perf_counter() - started
+
+    observed = flow.verify(ctx, size, artifacts)
+
+    # Comparing here rather than inside each verify() means no flow can forget
+    # to check the cardinality it declared. A mismatch means the numbers
+    # describe a different workload than the one named.
+    if point is not None and observed != point.expected_workload:
+        raise SystemExit(
+            f"{name} [{size}] produced {observed} {flow.workload_unit}, but "
+            f"the scale point declares {point.expected_workload}. The fixture "
+            f"is not building the scenario this size is supposed to measure."
+        )
+
+    print(
+        RESULT_PREFIX
+        + json.dumps(
+            {
+                "pid": os.getpid(),
+                "database": os.environ[DB_ENV_VAR],
+                "queries": len(captured),
+                "seconds": seconds,
+                "observed_workload": observed,
+                "expected_workload": point.expected_workload if point else None,
+                "workload_unit": flow.workload_unit,
+            }
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parent: temporary database, child processes, results
+# ---------------------------------------------------------------------------
+
+
+def _own_directory(directory):
+    """Mark `directory` as belonging to this invocation, and return its token."""
+    token = secrets.token_hex(16)
+    with open(os.path.join(directory, TOKEN_FILENAME), "w") as handle:
+        handle.write(token)
+    return token
+
+
+def _child(args, database, token):
+    """Run this file again as a child, pointed at `database`."""
+    environment = dict(os.environ, **{DB_ENV_VAR: database, TOKEN_ENV_VAR: token})
+    # The command is this interpreter running this file: no shell, and no part
+    # of it comes from anywhere but the harness itself.
+    return subprocess.run(  # noqa: S603
+        [sys.executable, os.path.abspath(__file__), *args],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _build_template(directory, token):
+    """Have a child create the migrated, empty database every execution copies.
+
+    Done in a child because the parent must not initialise Django: an
+    initialised parent would hold a connection to the template, and a file with
+    an open connection is not safe to copy.
+    """
+    template = os.path.join(directory, "template.sqlite3")
+    result = _child(["--build-template"], template, token)
+    if result.returncode != 0:
+        raise SystemExit(f"could not create the template database:\n{result.stderr}")
+    return template
+
+
+def build_template_in_child():
+    guard_database()
+
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+    from env import bootstrap
+
+    bootstrap()
+
+    from django.core.management import call_command
+
+    call_command("migrate", verbosity=0)
+    # A Locale post_save receiver in Wagtail clears a cached value, so without
+    # this table the fixture dies on its first locale.
+    call_command("createcachetable", verbosity=0)
+
+
+def execute(name, size, template, directory, index, token):
+    """Copy the template and run one execution in a fresh child."""
+    database = os.path.join(directory, f"run-{index:02d}.sqlite3")
+    shutil.copy(template, database)
+
+    arguments = [CHILD_FLAG, name]
+    if size is not None:
+        arguments += ["--size", size]
+    result = _child(arguments, database, token)
+
+    if result.returncode != 0:
+        return {"process": name, "size": size, "error": result.stderr.strip()}
+
+    lines = [
+        line[len(RESULT_PREFIX) :]
+        for line in result.stdout.splitlines()
+        if line.startswith(RESULT_PREFIX)
+    ]
+    if not lines:
+        return {
+            "process": name,
+            "size": size,
+            "error": (
+                f"the child produced no {RESULT_PREFIX} line:\n{result.stdout.strip()}"
+            ),
+        }
+
+    payload = json.loads(lines[-1])
+    return {
+        "process": name,
+        "size": size,
+        "queries": payload["queries"],
+        "seconds": payload["seconds"],
+        "workload_unit": payload["workload_unit"],
+        "expected_workload": payload["expected_workload"],
+        "observed_workload": payload["observed_workload"],
+        "pid": payload["pid"],
+        "database": payload["database"],
+    }
+
+
+def print_catalog():
+    import catalog
+
+    flows = catalog.CATALOG
+    print(f"{len(flows)} process(es), {len(catalog.executions())} execution(s)\n")
+    for flow in flows:
+        sizes = ", ".join(point.label for point in flow.scale_points) or "—"
+        print(f"{flow.name}")
+        print(f"    group      {flow.group}")
+        print(f"    sizes      {sizes}")
+        if flow.workload_unit:
+            print(f"    workload   {flow.workload_unit}")
+            for point in flow.scale_points:
+                print(f"      {point.label:8}expects {point.expected_workload}")
+        print(f"    entrypoint {flow.entrypoint}")
+        print(f"    why        {flow.why}")
+        print()
+
+
+def report(result):
+    if "error" in result:
+        print(f"{result['process']} [{result['size'] or '-'}]  FAILED", file=sys.stderr)
+        print(result["error"], file=sys.stderr)
+        return False
+
+    size = result["size"] or "-"
+    line = (
+        f"{result['process']} [{size}]  "
+        f"{result['queries']} queries  {result['seconds'] * 1000:.1f} ms"
+    )
+    if result["workload_unit"]:
+        line += (
+            f"  {result['observed_workload']} {result['workload_unit']}"
+            f" (expected {result['expected_workload']})"
+        )
+    print(line)
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Measure wagtail-localize flows.",
+    )
+    parser.add_argument("flow", nargs="?", help="flow name; omit with --list")
+    parser.add_argument("--size", help="run only this scale point")
+    parser.add_argument("--list", action="store_true", help="print the catalog")
+    parser.add_argument(CHILD_FLAG, action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--build-template", action="store_true", help=argparse.SUPPRESS)
+    arguments = parser.parse_args()
+
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+    if arguments.build_template:
+        build_template_in_child()
+        return 0
+
+    if arguments.execute_in_child:
+        run_in_child(arguments.flow, arguments.size)
+        return 0
+
+    if arguments.list:
+        print_catalog()
+        return 0
+
+    import catalog
+
+    if not arguments.flow:
+        parser.error("give a flow name, or use --list")
+    if arguments.flow not in catalog.BY_NAME:
+        parser.error(
+            f"unknown flow {arguments.flow!r}. "
+            f"Known: {', '.join(sorted(catalog.BY_NAME))}"
+        )
+
+    flow = catalog.BY_NAME[arguments.flow]
+    sizes = flow.sizes()
+    if arguments.size is not None:
+        if arguments.size not in sizes:
+            parser.error(
+                f"{flow.name} has no size {arguments.size!r}. "
+                f"Declared: {', '.join(str(s) for s in sizes)}"
+            )
+        sizes = (arguments.size,)
+
+    directory = tempfile.mkdtemp(prefix="wl-benchmark-")
+    ok = True
+    try:
+        token = _own_directory(directory)
+        template = _build_template(directory, token)
+        for index, size in enumerate(sizes):
+            ok &= report(execute(flow.name, size, template, directory, index, token))
+    finally:
+        shutil.rmtree(directory)
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/run_attribution.py
+++ b/benchmarks/run_attribution.py
@@ -1,0 +1,592 @@
+"""Attribute a benchmark flow's query count to the code that produced it.
+
+    python benchmarks/run_attribution.py core_page_index
+    python benchmarks/run_attribution.py submit_page_post --json report.json
+    python benchmarks/run_attribution.py --list
+
+benchmarks/run.py says how much work a flow does. It cannot say where that work
+came from: its measured region is one block, and a total does not name the loop
+inside it. This command answers the second question for a flow with two scale
+points, by running both sizes and reporting which groups of queries grew with
+the workload.
+
+Growth with the workload is not a heuristic for an N+1: it is the definition of
+the cost this project is looking for. That is why this command needs the
+harness's calibrated sizes and cannot be replaced by a general-purpose detector
+running against a single execution.
+
+Like run_query_doctor.py this is a manual diagnostic command, separate from
+run.py on purpose. The rule is not that run.py installs nothing -- it already
+enables Django's debug cursor through CaptureQueriesContext -- but that a
+baseline is produced by one stable, minimal counter, and diagnostic
+instrumentation never produces one.
+
+What it reports is a lead for a person to follow. Some queries grow with the
+workload because the work does: a flow that creates one object per page is
+supposed to cost one insert per page. Nothing here can tell those apart from a
+defect, and it does not try to.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+if __name__ == "__main__":
+    # Same reason as in run.py: run as a script this file's directory is on
+    # sys.path, not the repo root, and `benchmarks.*` has to resolve to the one
+    # package everything else already loaded.
+    _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _REPO_ROOT not in sys.path:
+        sys.path.insert(0, _REPO_ROOT)
+
+
+from benchmarks import run
+
+
+CHILD_FLAG = "--attribute-in-child"
+EVENTS_ENV_VAR = "WAGTAIL_LOCALIZE_ATTRIBUTION_EVENTS"
+
+# How many product frames an event carries. The nearest one is the default
+# grouping key; the rest are kept so a caller can be identified later without
+# measuring again.
+STACK_DEPTH = 5
+
+# How far up the stack to look for a product frame before giving up. Deep
+# rendering and serialisation stacks are the reason this is not smaller.
+STACK_LIMIT = 80
+
+# Groups shown before the tail is summarised, expressed as a share of the total
+# absolute movement between the two sizes. Ranking decides what matters; this
+# only decides where a long report stops.
+COVERAGE = 0.95
+
+# Constant groups listed under the drivers, as the fixed cost of the flow.
+FIXED_SHOWN = 10
+
+# Distinct callers kept per group in the JSON report. The report itself shows
+# one line of product code; this is what a reader needs to ask who reached it.
+CALLERS = 5
+
+
+# ---------------------------------------------------------------------------
+# Shapes
+# ---------------------------------------------------------------------------
+
+# A parenthesised placeholder list belonging to IN / NOT IN. Restricted to IN on
+# purpose: collapsing every placeholder run would also merge INSERT ... VALUES
+# lists of different widths, which are different statements.
+_IN_LIST = re.compile(r"\b(NOT\s+IN|IN)\s*\(\s*%s(?:\s*,\s*%s)*\s*\)", re.IGNORECASE)
+
+# Savepoint identifiers are generated per savepoint, so they would give every
+# savepoint its own shape.
+_SAVEPOINT_NAME = re.compile(
+    r"\b(SAVEPOINT|RELEASE(?:\s+SAVEPOINT)?|ROLLBACK\s+TO(?:\s+SAVEPOINT)?)\s+\S+",
+    re.IGNORECASE,
+)
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def in_arity(sql):
+    """How many placeholders the statement's IN lists hold, or None.
+
+    Kept beside the shape rather than inside it: a query batching 2 keys and the
+    same query batching 40 are one family whose width is worth seeing.
+    """
+    widths = [match.group(0).count("%s") for match in _IN_LIST.finditer(sql)]
+    return sum(widths) if widths else None
+
+
+def shape(sql):
+    """Collapse a statement to the form it shares with its repetitions.
+
+    Only known-volatile syntax is normalised. In particular numeric literals are
+    left alone: Django inlines structural numbers such as LIMIT 1 versus
+    LIMIT 21, and merging those would conflate .get(), .exists() and pagination.
+    Parameters never reach here -- execute_wrapper receives the statement before
+    interpolation -- so no value is being hidden by this.
+    """
+    collapsed = _WHITESPACE.sub(" ", sql).strip()
+    collapsed = _IN_LIST.sub(lambda m: f"{m.group(1).upper()} (%s, ...)", collapsed)
+    collapsed = _SAVEPOINT_NAME.sub(lambda m: m.group(1).upper(), collapsed)
+    return collapsed
+
+
+def batch_size(params, many):
+    """How many parameter sets an executemany carried, when that is knowable.
+
+    DB-API allows an iterable without __len__, and consuming one here to count
+    it would empty it before the driver ever saw it. An unknown size is reported
+    as unknown rather than paid for.
+    """
+    if not many or params is None:
+        return None
+    try:
+        return len(params)
+    except TypeError:
+        return None
+
+
+def kind(sql):
+    """Transaction control, savepoint, or a plain statement.
+
+    ROLLBACK TO SAVEPOINT undoes part of a transaction and ROLLBACK undoes all
+    of it, so they are not the same event even though they share a first word.
+    """
+    head = sql.lstrip()[:24].upper()
+    # ROLLBACK TO is tested first: it undoes part of a transaction, where a bare
+    # ROLLBACK undoes all of it.
+    if head.startswith(("SAVEPOINT", "RELEASE", "ROLLBACK TO")):
+        return "savepoint"
+    if head.startswith(("BEGIN", "COMMIT", "ROLLBACK")):
+        return "transaction"
+    return "query"
+
+
+# ---------------------------------------------------------------------------
+# Stacks
+# ---------------------------------------------------------------------------
+
+_PRODUCT = f"{os.sep}wagtail_localize{os.sep}"
+_HARNESS = f"{os.sep}benchmarks{os.sep}"
+
+OUTSIDE = "<outside wagtail_localize>"
+
+
+def product_stack():
+    """The product frames below this call, nearest first.
+
+    "Nearest product frame" is where the statement was executed, which is not
+    always where its queryset was built: a queryset created in one method and
+    evaluated in a loop, a template, or a serialiser is attributed to the
+    evaluation. The frames above it are kept for that reason.
+    """
+    frames = []
+    frame = sys._getframe(1)
+    depth = 0
+    while frame is not None and depth < STACK_LIMIT and len(frames) < STACK_DEPTH:
+        path = frame.f_code.co_filename
+        if _PRODUCT in path and _HARNESS not in path:
+            module = path.split(_PRODUCT, 1)[1]
+            frames.append(f"{module}:{frame.f_lineno} in {frame.f_code.co_name}")
+        frame = frame.f_back
+        depth += 1
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Child: one execution, instrumented
+# ---------------------------------------------------------------------------
+
+
+def attribute_in_child(name, size):
+    """Run one execution, record an event per cursor invocation, write them out.
+
+    The instrumented region is exactly the flow's own call, the same region
+    run.py measures, so the two describe the same work. CaptureQueriesContext
+    wraps the execute_wrapper rather than replacing it: it is the harness's
+    counter and therefore the authoritative total, while the wrapper is what can
+    see a statement's shape and stack.
+    """
+    run.guard_database()
+    catalog, flow, point = run._select(name, size)
+
+    from benchmarks.env import bootstrap
+
+    bootstrap()
+
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    ctx = catalog.prepare()
+    if flow.setup:
+        flow.setup(ctx, size)
+
+    events = []
+
+    def record(execute, sql, params, many, context):
+        events.append(
+            {
+                "shape": shape(sql),
+                "kind": kind(sql),
+                "stack": product_stack(),
+                "in_arity": in_arity(sql),
+                "batch": batch_size(params, many),
+            }
+        )
+        return execute(sql, params, many, context)
+
+    with (
+        CaptureQueriesContext(connection) as captured,
+        connection.execute_wrapper(record),
+    ):
+        artifacts = flow.run(ctx, size)
+
+    observed = flow.verify(ctx, size, artifacts)
+
+    # The same rule the harness applies: attributing a scenario that did not
+    # build would explain something else.
+    if point is not None and observed != point.expected_workload:
+        raise SystemExit(
+            f"{name} [{size}] produced {observed} {flow.workload_unit}, but the "
+            f"scale point declares {point.expected_workload}. The fixture is not "
+            f"building the scenario this size is supposed to explain."
+        )
+
+    with open(os.environ[EVENTS_ENV_VAR], "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "size": size,
+                "observed_workload": observed,
+                "total": len(captured),
+                "events": events,
+            },
+            handle,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Grouping and reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _span(values):
+    """The range a group's events covered, or None if none carried the value."""
+    seen = [value for value in values if value is not None]
+    if not seen:
+        return None
+    return [min(seen), max(seen)]
+
+
+def group(execution):
+    """Collapse an execution's events into one entry per (shape, nearest frame).
+
+    Arity and batch size stay out of the key and are reported as the range the
+    group covered: a query batching 2 keys and the same query batching 40 are
+    one family whose width is what makes the batching visible.
+    """
+    grouped = {}
+    for event in execution["events"]:
+        key = (event["shape"], event["stack"][0] if event["stack"] else OUTSIDE)
+        entry = grouped.setdefault(
+            key, {"count": 0, "kind": event["kind"], "in_arity": [], "batch": []}
+        )
+        entry["count"] += 1
+        entry["in_arity"].append(event["in_arity"])
+        entry["batch"].append(event["batch"])
+        # The frames above the nearest one, kept per distinct caller. A group is
+        # one line of product code; who reaches it is the next question a reader
+        # asks, and answering it from the report costs nothing extra to record.
+        caller = " <- ".join(event["stack"][1:]) or OUTSIDE
+        entry.setdefault("callers", {})
+        entry["callers"][caller] = entry["callers"].get(caller, 0) + 1
+
+    return {
+        key: {
+            "count": entry["count"],
+            "kind": entry["kind"],
+            "in_arity": _span(entry["in_arity"]),
+            "batch": _span(entry["batch"]),
+            "callers": dict(
+                sorted(entry["callers"].items(), key=lambda item: -item[1])[:CALLERS]
+            ),
+        }
+        for key, entry in grouped.items()
+    }
+
+
+def unattributed(execution):
+    """Statements the harness counted that the wrapper could not see.
+
+    Django's _commit() and _rollback() call the database connection directly and
+    append a synthetic record to the query log, so CaptureQueriesContext counts
+    them and execute_wrapper never runs. They are real work with a real cost;
+    they simply have no call site this command can honestly name.
+    """
+    return execution["total"] - len(execution["events"])
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def build(small_exec, large_exec):
+    """Everything the report and the JSON artifact are derived from."""
+    small = group(small_exec)
+    large = group(large_exec)
+    span = large_exec["observed_workload"] - small_exec["observed_workload"]
+
+    empty = {
+        "count": 0,
+        "kind": None,
+        "in_arity": None,
+        "batch": None,
+        "callers": {},
+    }
+    rows = []
+    for key in set(small) | set(large):
+        in_small = small.get(key, empty)
+        in_large = large.get(key, empty)
+        a = in_small["count"]
+        b = in_large["count"]
+        rate = (b - a) / span
+        rows.append(
+            {
+                "shape": key[0],
+                "frame": key[1],
+                "small": a,
+                "large": b,
+                "delta": b - a,
+                "rate": rate,
+                # What the two counts imply at zero workload. A summary of these
+                # two points, not evidence of linearity: any two points fit a
+                # line exactly, and the zero-workload end may describe a state
+                # the flow never reaches.
+                "fixed": a - rate * small_exec["observed_workload"],
+                "kind": in_large["kind"] or in_small["kind"],
+                "in_arity": {
+                    "small": in_small["in_arity"],
+                    "large": in_large["in_arity"],
+                },
+                "batch": {"small": in_small["batch"], "large": in_large["batch"]},
+                "callers": {
+                    "small": in_small["callers"],
+                    "large": in_large["callers"],
+                },
+            }
+        )
+
+    rows.sort(key=lambda row: (-row["delta"], row["frame"], row["shape"]))
+    return rows
+
+
+def print_report(name, flow, small_exec, large_exec, rows):
+    growing = [row for row in rows if row["delta"] > 0]
+    shrinking = [row for row in rows if row["delta"] < 0]
+    constant = [row for row in rows if row["delta"] == 0]
+
+    movement = sum(abs(row["delta"]) for row in rows)
+    unit = flow.workload_unit
+
+    print(
+        f"\n{name}: {small_exec['observed_workload']} -> "
+        f"{large_exec['observed_workload']} {unit}"
+    )
+
+    # Reconciliation first: a report that does not add up to the number it
+    # explains is describing something else.
+    for label, execution in (("small", small_exec), ("large", large_exec)):
+        gap = unattributed(execution)
+        print(
+            f"  {label:<5} {execution['total']:>5} queries  "
+            f"= {len(execution['events'])} attributed "
+            f"+ {gap} outside execute_wrapper"
+        )
+
+    shown, covered = [], 0.0
+    for row in growing:
+        shown.append(row)
+        covered += abs(row["delta"])
+        if movement and covered / movement >= COVERAGE:
+            break
+
+    print(f"\n  Growth drivers ({len(shown)} of {len(growing)} growing groups)")
+    _print_rows(shown, unit)
+
+    if shrinking:
+        print(f"\n  Groups that shrank ({len(shrinking)})")
+        _print_rows(shrinking, unit)
+
+    fixed_shown = min(FIXED_SHOWN, len(constant))
+    print(f"\n  Largest fixed cost ({fixed_shown} of {len(constant)} constant groups)")
+    _print_rows(
+        sorted(constant, key=lambda row: -row["small"])[:FIXED_SHOWN], unit, rate=False
+    )
+
+    # Every group that shrank is printed above, so only growing groups the
+    # coverage cut left out are unseen. Counting the shrinking ones here as
+    # well would tell a reader something is hidden that they have just read.
+    hidden = [row for row in growing if row not in shown]
+    if hidden:
+        net = sum(row["delta"] for row in hidden)
+        gross = sum(abs(row["delta"]) for row in hidden)
+        print(
+            f"\n  {len(hidden)} further changed group(s) not shown: "
+            f"net {net:+d}, gross movement {gross}"
+        )
+
+
+def _width(label, spans):
+    """One side note per group for the widths its shape hides.
+
+    A collapsed IN list and an executemany both mean one statement doing a
+    variable amount of work, which a count alone cannot show.
+    """
+    small, large = spans["small"], spans["large"]
+    if small is None and large is None:
+        return ""
+
+    def side(span):
+        if span is None:
+            return "-"
+        return str(span[0]) if span[0] == span[1] else f"{span[0]}-{span[1]}"
+
+    return f"  [{label} {side(small)} -> {side(large)}]"
+
+
+def _print_rows(rows, unit, rate=True):
+    if not rows:
+        print("    none")
+        return
+    for row in rows:
+        if rate:
+            head = f"    {row['rate']:+6.2f}/{unit}"
+        else:
+            head = f"    {row['small']:>6} fixed "
+        fixed = f"  (fixed {row['fixed']:.0f})" if rate and row["fixed"] else ""
+        print(f"{head}  {row['small']:>5} -> {row['large']:<5}  {row['frame']}{fixed}")
+        shape_text = row["shape"]
+        if len(shape_text) > 96:
+            shape_text = shape_text[:96] + "..."
+        notes = _width("IN arity", row["in_arity"]) + _width("batch", row["batch"])
+        print(f"{'':>13}{shape_text}{notes}")
+
+
+# ---------------------------------------------------------------------------
+# Parent: temporary database, child processes
+# ---------------------------------------------------------------------------
+
+
+def _child(arguments, database, token, events):
+    environment = dict(
+        os.environ,
+        **{
+            run.DB_ENV_VAR: database,
+            run.TOKEN_ENV_VAR: token,
+            EVENTS_ENV_VAR: events,
+        },
+    )
+    # This interpreter running this file: no shell, and nothing in the command
+    # comes from anywhere but the runner itself.
+    return subprocess.run(  # noqa: S603
+        [sys.executable, os.path.abspath(__file__), *arguments],
+        env=environment,
+        check=False,
+    )
+
+
+def attribute(name, size, template, directory, index, token):
+    """Copy the template and instrument one execution in a fresh child."""
+    database = os.path.join(directory, f"attribution-{index:02d}.sqlite3")
+    events = os.path.join(directory, f"events-{index:02d}.json")
+    shutil.copy(template, database)
+
+    result = _child([CHILD_FLAG, name, "--size", size], database, token, events)
+    if result.returncode != 0:
+        return None
+
+    with open(events, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Attribute a wagtail-localize benchmark flow's query count to the "
+            "code that produced it. Diagnostic output only: use "
+            "benchmarks/run.py for numbers."
+        ),
+    )
+    parser.add_argument("flow", nargs="?", help="flow name; omit with --list")
+    parser.add_argument("--size", help=argparse.SUPPRESS)
+    parser.add_argument("--json", help="write the full grouping to this path")
+    parser.add_argument("--list", action="store_true", help="print the catalog")
+    parser.add_argument(CHILD_FLAG, action="store_true", help=argparse.SUPPRESS)
+    arguments = parser.parse_args()
+
+    if arguments.attribute_in_child:
+        attribute_in_child(arguments.flow, arguments.size)
+        return 0
+
+    if arguments.list:
+        run.print_catalog()
+        return 0
+
+    if not arguments.flow:
+        parser.error("give a flow name, or use --list")
+
+    # Resolved from the catalog rather than through run._select, which resolves
+    # one execution and therefore wants a size: this command's unit is the flow.
+    from benchmarks import catalog as catalog_module
+
+    if arguments.flow not in catalog_module.BY_NAME:
+        parser.error(
+            f"unknown flow {arguments.flow!r}. "
+            f"Known: {', '.join(sorted(catalog_module.BY_NAME))}"
+        )
+    flow = catalog_module.BY_NAME[arguments.flow]
+
+    # Two sizes are the whole method: with one there is nothing to compare, and
+    # a group's count on its own says nothing about whether it scales.
+    if len(flow.scale_points) != 2:
+        raise SystemExit(
+            f"{flow.name} declares {len(flow.scale_points)} scale point(s). "
+            f"Attribution compares two, because what it reports is the "
+            f"difference between them."
+        )
+
+    directory = tempfile.mkdtemp(prefix="wl-attribution-")
+    try:
+        token = run._own_directory(directory)
+        template = run._build_template(directory, token)
+        executions = []
+        for index, point in enumerate(flow.scale_points):
+            execution = attribute(
+                flow.name, point.label, template, directory, index, token
+            )
+            if execution is None:
+                print(f"{flow.name} [{point.label}]  FAILED", file=sys.stderr)
+                return 1
+            executions.append(execution)
+    finally:
+        shutil.rmtree(directory)
+
+    small_exec, large_exec = executions
+    rows = build(small_exec, large_exec)
+    print_report(flow.name, flow, small_exec, large_exec, rows)
+
+    if arguments.json:
+        with open(arguments.json, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "flow": flow.name,
+                    "sizes": {
+                        point.label: {
+                            "observed_workload": execution["observed_workload"],
+                            "total": execution["total"],
+                            "attributed": len(execution["events"]),
+                            "unattributed": unattributed(execution),
+                        }
+                        for point, execution in zip(
+                            flow.scale_points, executions, strict=True
+                        )
+                    },
+                    "groups": rows,
+                },
+                handle,
+                indent=2,
+            )
+        print(f"\nwrote {arguments.json}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/run_query_doctor.py
+++ b/benchmarks/run_query_doctor.py
@@ -1,0 +1,300 @@
+"""Diagnose one catalog flow with Django Query Doctor.
+
+    python benchmarks/run_query_doctor.py --list
+    python benchmarks/run_query_doctor.py core_page_index --size small
+    python benchmarks/run_query_doctor.py all
+
+run.py says how much work a flow does. It does not say why, and it must not
+learn: a measurement taken under instrumentation is a measurement of the
+instrumentation too. This runner answers the second question separately —
+same catalog, same fixture, same isolation, but the flow runs inside Query
+Doctor instead of inside a stopwatch, and what it prints is a diagnosis rather
+than a number anyone should record.
+
+Nothing here is a baseline. Query Doctor wraps every cursor, walks the stack
+for each query, and analyses the lot afterwards; the query count it reports is
+real, but its timings carry that overhead. Compare numbers with run.py and
+explanations with this.
+
+The structure of an execution is deliberately identical to run.py's: a parent
+that never imports Django, a template database built by a child, and one fresh
+child per execution against its own copy. That is what makes the two commands
+comparable, and it is reused from run.py rather than restated here, so the two
+cannot drift apart. The dependency only points this way: run.py knows nothing
+about this file or about Query Doctor.
+"""
+
+import argparse
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+if __name__ == "__main__":
+    # Same reason as in run.py: run as a script this file's directory is on
+    # sys.path, not the repo root, and `benchmarks.*` has to resolve to the one
+    # package everything else already loaded.
+    _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _REPO_ROOT not in sys.path:
+        sys.path.insert(0, _REPO_ROOT)
+
+
+from benchmarks import run
+
+
+CHILD_FLAG = "--diagnose-in-child"
+
+# Said the same way wherever it is discovered: by the parent before it builds
+# anything, and by the child if the two ever run in different environments.
+MISSING_QUERY_DOCTOR = (
+    "django-query-doctor is not installed in this environment.\n"
+    "It is a diagnostic dependency, deliberately kept out of the project's "
+    "requirements and out of benchmarks/run.py, so the benchmark harness runs "
+    "without it.\n"
+    "Use the optional diagnostic environment described in benchmarks/README.md, "
+    "or install django-query-doctor into the environment you are running from."
+)
+
+# Worst first, so a long report opens with the finding worth reading. Keyed by
+# value rather than by enum member: a version that adds a severity should sort
+# it last, not fail.
+_SEVERITY_ORDER = {"critical": 0, "warning": 1, "info": 2}
+
+
+# ---------------------------------------------------------------------------
+# Query Doctor, imported only where it is used
+# ---------------------------------------------------------------------------
+
+
+def _query_doctor_installed():
+    """Whether Query Doctor could be imported, without importing it.
+
+    The parent runs this. find_spec locates the module and stops, so the parent
+    keeps its one important property: it initialises nothing.
+    """
+    return importlib.util.find_spec("query_doctor") is not None
+
+
+def _diagnose_queries():
+    """Query Doctor's context manager, imported at the point of use.
+
+    Deferred so that --list, an invalid selection, and importing this module
+    all cost nothing and work in an environment without the tool.
+    """
+    try:
+        from query_doctor import diagnose_queries
+    except ImportError as error:
+        raise SystemExit(f"{MISSING_QUERY_DOCTOR}\n({error})") from error
+    return diagnose_queries
+
+
+# ---------------------------------------------------------------------------
+# Child: the only side that touches Django
+# ---------------------------------------------------------------------------
+
+
+def _prescription_lines(prescription):
+    """One diagnosed issue, as the lines that describe it."""
+    severity = prescription.severity.value.upper()
+    issue = prescription.issue_type.value
+    count = prescription.query_count
+
+    header = f"  {severity}  {issue}"
+    if count:
+        header += f"  ({count} queries)"
+
+    lines = [header, f"    {prescription.description}"]
+    if prescription.fix_suggestion:
+        lines.append(f"    fix: {prescription.fix_suggestion}")
+
+    callsite = prescription.callsite
+    if callsite is not None:
+        lines.append(
+            f"    at {callsite.filepath}:{callsite.line_number} "
+            f"in {callsite.function_name}"
+        )
+    return lines
+
+
+def print_report(name, size, flow, observed, report):
+    """The diagnosis, under the execution it belongs to.
+
+    A report that did not name its flow, size and observed workload would be a
+    page of prescriptions nobody can place: the same flow diagnoses differently
+    at each scale point, which is usually the whole point of running it.
+    """
+    workload = "—"
+    if flow.workload_unit:
+        workload = f"{observed} {flow.workload_unit}"
+
+    print(f"\n{name} [{size or '-'}]  {workload}")
+    print(
+        f"  {report.total_queries} queries, "
+        f"{report.total_time_ms:.1f} ms of database time under diagnosis"
+    )
+
+    if not report.prescriptions:
+        print("  no prescriptions")
+        return
+
+    prescriptions = sorted(
+        report.prescriptions,
+        key=lambda p: (
+            _SEVERITY_ORDER.get(p.severity.value, len(_SEVERITY_ORDER)),
+            -p.query_count,
+        ),
+    )
+    print(f"  {len(prescriptions)} prescription(s)")
+    for prescription in prescriptions:
+        print()
+        for line in _prescription_lines(prescription):
+            print(line)
+
+
+def diagnose_in_child(name, size):
+    """Prepare the fixture, diagnose one execution, verify it, report.
+
+    The diagnosed region is exactly the flow's own call, for the same reason
+    run.py measures exactly that call: fixture construction and setup are
+    scaffolding, and their queries would drown the ones being explained.
+    Verification runs after the diagnosis has closed, so what it queries is not
+    attributed to the flow.
+    """
+    # Both before Django exists, and both borrowed from run.py so the two
+    # commands cannot disagree about what a valid selection is.
+    run.guard_database()
+    catalog, flow, point = run._select(name, size)
+
+    from benchmarks.env import bootstrap
+
+    bootstrap()
+
+    diagnose_queries = _diagnose_queries()
+
+    ctx = catalog.prepare()
+    if flow.setup:
+        flow.setup(ctx, size)
+
+    with diagnose_queries() as report:
+        artifacts = flow.run(ctx, size)
+
+    observed = flow.verify(ctx, size, artifacts)
+
+    # The same rule the harness applies: a diagnosis of a scenario that did not
+    # build is an explanation of something else.
+    if point is not None and observed != point.expected_workload:
+        raise SystemExit(
+            f"{name} [{size}] produced {observed} {flow.workload_unit}, but "
+            f"the scale point declares {point.expected_workload}. The fixture "
+            f"is not building the scenario this size is supposed to diagnose."
+        )
+
+    print_report(name, size, flow, observed, report)
+
+
+# ---------------------------------------------------------------------------
+# Parent: temporary database, child processes
+# ---------------------------------------------------------------------------
+
+
+def _child(arguments, database, token):
+    """Run this file again as a child, pointed at `database`.
+
+    Output is inherited rather than captured: the report is for a person
+    reading the terminal, and there is no machine-readable channel to keep
+    clean.
+    """
+    environment = dict(
+        os.environ, **{run.DB_ENV_VAR: database, run.TOKEN_ENV_VAR: token}
+    )
+    # This interpreter running this file: no shell, and nothing in the command
+    # comes from anywhere but the runner itself.
+    return subprocess.run(  # noqa: S603
+        [sys.executable, os.path.abspath(__file__), *arguments],
+        env=environment,
+        check=False,
+    )
+
+
+def diagnose(name, size, template, directory, index, token):
+    """Copy the template and diagnose one execution in a fresh child."""
+    database = os.path.join(directory, f"diagnose-{index:02d}.sqlite3")
+    shutil.copy(template, database)
+
+    arguments = [CHILD_FLAG, name]
+    if size is not None:
+        arguments += ["--size", size]
+    result = _child(arguments, database, token)
+
+    if result.returncode != 0:
+        # The child was not captured, so whatever it said is already on this
+        # terminal. This only marks which execution it belonged to.
+        print(f"{name} [{size or '-'}]  FAILED", file=sys.stderr)
+        return False
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Explain a wagtail-localize benchmark flow with Django Query "
+            "Doctor. Diagnostic output only: use benchmarks/run.py for numbers."
+        ),
+    )
+    parser.add_argument(
+        "flow", nargs="?", help=f"flow name or {run.ALL}; omit with --list"
+    )
+    parser.add_argument("--size", help="diagnose only this scale point")
+    parser.add_argument("--list", action="store_true", help="print the catalog")
+    parser.add_argument(CHILD_FLAG, action="store_true", help=argparse.SUPPRESS)
+    arguments = parser.parse_args()
+
+    if arguments.diagnose_in_child:
+        diagnose_in_child(arguments.flow, arguments.size)
+        return 0
+
+    if arguments.list:
+        # The catalog is run.py's to describe, and printing it needs neither
+        # Django nor Query Doctor.
+        run.print_catalog()
+        return 0
+
+    if not arguments.flow:
+        parser.error(f"give a flow name or {run.ALL}, or use --list")
+
+    # Resolved before anything is created, so an impossible selection costs no
+    # temporary directory and no migration.
+    try:
+        plan = run._executions_for(arguments.flow, arguments.size)
+    except ValueError as error:
+        parser.error(str(error))
+
+    # Checked here rather than in the child: a missing tool should cost a
+    # message, not a migrated database and one failing process per execution.
+    if not _query_doctor_installed():
+        raise SystemExit(MISSING_QUERY_DOCTOR)
+
+    print(
+        "Query Doctor instruments every cursor, so these timings are not "
+        "comparable with benchmarks/run.py.",
+        file=sys.stderr,
+    )
+
+    directory = tempfile.mkdtemp(prefix="wl-query-doctor-")
+    ok = True
+    try:
+        token = run._own_directory(directory)
+        template = run._build_template(directory, token)
+        for index, (flow, size) in enumerate(plan):
+            ok &= diagnose(flow.name, size, template, directory, index, token)
+    finally:
+        shutil.rmtree(directory)
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/seed.py
+++ b/benchmarks/seed.py
@@ -1,0 +1,73 @@
+"""Build benchmark content without requiring Django at import time.
+
+Each execution uses a fresh database, so these helpers create but never clear
+data.
+"""
+
+TARGET_LANGUAGES = ["en", "fr", "es"]
+HOME_SLUG = "bench-home"
+# Spread leaf pages across a small, non-flat tree.
+CATEGORY_COUNT = 4
+
+
+def ensure_locales():
+    """Every locale the fixture needs. Idempotent."""
+    from wagtail.models import Locale
+
+    return {
+        code: Locale.objects.get_or_create(language_code=code)[0]
+        for code in TARGET_LANGUAGES
+    }
+
+
+def build_snippet_pool(count, locale):
+    """Create reusable translatable snippets referenced by benchmark pages."""
+    from tests.testapp.models import TestSnippet
+
+    return [
+        TestSnippet.objects.create(
+            field=f"Snippet {i} body — translatable text.",
+            small_charfield=f"tag-{i}"[:10],
+            locale=locale,
+        )
+        for i in range(count)
+    ]
+
+
+def build_tree(pages, locale, snippets):
+    """Build a categorized tree and return its home and flat leaf-page list."""
+    from wagtail.models import Page
+
+    from tests.testapp.models import TestHomePage, TestPage
+
+    root = Page.objects.get(depth=1)
+    home = root.add_child(
+        instance=TestHomePage(title="Bench Home", slug=HOME_SLUG, locale=locale)
+    )
+    categories = [
+        home.add_child(
+            instance=TestPage(
+                title=f"Category {c}", slug=f"bench-category-{c}", locale=locale
+            )
+        )
+        for c in range(CATEGORY_COUNT)
+    ]
+
+    pages_list = []
+    for i in range(pages):
+        category = categories[i % CATEGORY_COUNT]
+        page = category.add_child(
+            instance=TestPage(
+                title=f"Page {i}",
+                slug=f"bench-page-{i}",
+                locale=locale,
+                test_snippet=snippets[i % len(snippets)],
+                test_richtextfield=(
+                    f"<p>Body text for page {i}. This paragraph is "
+                    f"translatable prose that produces a segment.</p>"
+                ),
+            )
+        )
+        pages_list.append(page)
+
+    return home, pages_list

--- a/benchmarks/settings.py
+++ b/benchmarks/settings.py
@@ -1,0 +1,6 @@
+"""Settings for benchmark child processes."""
+
+from tests.testapp.settings import *  # noqa: F403
+
+
+DEBUG = False

--- a/tests/test_benchmarks_attribution.py
+++ b/tests/test_benchmarks_attribution.py
@@ -1,0 +1,630 @@
+"""Structural tests for the attribution runner.
+
+The runner is a manual diagnostic tool, so these tests attribute nothing real.
+They cover the parts that decide whether a report can be believed: that a shape
+collapses only what is volatile, that a group keeps the widths its shape hides,
+that the totals reconcile against the harness's own counter, and that a
+selection this command cannot attribute is refused before anything is built.
+
+Normalisation is exercised with synthetic statements rather than captured SQL.
+Real SQL changes when Django or Wagtail change how they build a query, and a
+test pinned to today's output would fail on an upgrade that broke nothing.
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from benchmarks import catalog, run, run_attribution
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _point(label, expected_workload, **overrides):
+    fields = {"label": label, "why": "w", "expected_workload": expected_workload}
+    fields.update(overrides)
+    return catalog.ScalePoint(**fields)
+
+
+def _flow(**overrides):
+    """A catalog Flow whose callables are whatever a test needs."""
+    fields = {
+        "name": "fake_flow",
+        "group": "fake",
+        "why": "w",
+        "entrypoint": "e",
+        "covers": (),
+        "run": lambda ctx, size: None,
+        "verify": lambda ctx, size, artifacts: None,
+        "workload_unit": "widgets",
+        "scale_points": (_point("small", 2), _point("large", 40)),
+    }
+    fields.update(overrides)
+    return catalog.Flow(**fields)
+
+
+def _event(shape="SELECT 1", frame="models.py:1 in f", stack=None, **overrides):
+    fields = {
+        "shape": shape,
+        "kind": "query",
+        "stack": [frame] if stack is None else stack,
+        "in_arity": None,
+        "batch": None,
+    }
+    fields.update(overrides)
+    return fields
+
+
+def _execution(events, observed_workload, total=None):
+    return {
+        "size": "small",
+        "observed_workload": observed_workload,
+        "total": len(events) if total is None else total,
+        "events": events,
+    }
+
+
+@contextlib.contextmanager
+def _captured_stdout():
+    stream = io.StringIO()
+    with mock.patch.object(sys, "stdout", stream):
+        yield stream
+
+
+# ---------------------------------------------------------------------------
+# Shapes
+# ---------------------------------------------------------------------------
+
+
+class TestShapeCollapsesOnlyWhatIsVolatile(SimpleTestCase):
+    def test_an_in_list_collapses_whatever_its_width(self):
+        two = run_attribution.shape('SELECT * FROM t WHERE "id" IN (%s, %s)')
+        placeholders = ", ".join(["%s"] * 40)
+        forty = run_attribution.shape(
+            f'SELECT * FROM t WHERE "id" IN ({placeholders})'  # noqa: S608
+        )
+        self.assertEqual(two, forty)
+
+    def test_not_in_collapses_too_and_stays_distinct_from_in(self):
+        inside = run_attribution.shape("SELECT * FROM t WHERE a IN (%s, %s)")
+        outside = run_attribution.shape("SELECT * FROM t WHERE a NOT IN (%s, %s)")
+        self.assertNotEqual(inside, outside)
+        self.assertIn("NOT IN", outside)
+
+    def test_a_values_list_keeps_every_placeholder(self):
+        """An insert of three columns and one of five are different statements.
+        Collapsing their placeholder lists the way an IN list is collapsed would
+        merge them into one shape."""
+        self.assertEqual(
+            run_attribution.shape("INSERT INTO t (a, b, c) VALUES (%s, %s, %s)"),
+            "INSERT INTO t (a, b, c) VALUES (%s, %s, %s)",
+        )
+
+    def test_a_function_argument_list_keeps_every_placeholder(self):
+        self.assertEqual(
+            run_attribution.shape("SELECT coalesce(%s, %s, %s) FROM t"),
+            "SELECT coalesce(%s, %s, %s) FROM t",
+        )
+
+    def test_savepoint_identifiers_collapse(self):
+        first = run_attribution.shape('SAVEPOINT "s140234_x1"')
+        second = run_attribution.shape('SAVEPOINT "s140987_x9"')
+        self.assertEqual(first, second)
+        self.assertEqual(first, "SAVEPOINT")
+
+    def test_release_and_rollback_to_keep_their_own_shapes(self):
+        release = run_attribution.shape('RELEASE SAVEPOINT "s1"')
+        rollback = run_attribution.shape('ROLLBACK TO SAVEPOINT "s1"')
+        self.assertNotEqual(release, rollback)
+
+    def test_whitespace_is_collapsed(self):
+        self.assertEqual(
+            run_attribution.shape("SELECT\n  a,\n  b\nFROM   t"),
+            "SELECT a, b FROM t",
+        )
+
+    def test_numeric_literals_are_left_alone(self):
+        """Django inlines structural numbers, and LIMIT 1 versus LIMIT 21 is the
+        difference between .get() and a sliced queryset."""
+        one = run_attribution.shape("SELECT a FROM t LIMIT 1")
+        many = run_attribution.shape("SELECT a FROM t LIMIT 21")
+        self.assertNotEqual(one, many)
+
+
+class TestArityIsMeasuredNotCollapsed(SimpleTestCase):
+    def test_an_in_list_reports_its_width(self):
+        self.assertEqual(
+            run_attribution.in_arity("SELECT * FROM t WHERE a IN (%s, %s, %s)"), 3
+        )
+
+    def test_a_statement_without_an_in_list_reports_nothing(self):
+        self.assertIsNone(run_attribution.in_arity("SELECT * FROM t WHERE a = %s"))
+
+    def test_several_in_lists_are_summed(self):
+        self.assertEqual(
+            run_attribution.in_arity(
+                "SELECT * FROM t WHERE a IN (%s, %s) AND b IN (%s, %s, %s)"
+            ),
+            5,
+        )
+
+
+class TestKindSeparatesTransactionControl(SimpleTestCase):
+    def test_a_plain_statement_is_a_query(self):
+        self.assertEqual(run_attribution.kind("SELECT 1"), "query")
+
+    def test_commit_and_begin_are_transaction_control(self):
+        self.assertEqual(run_attribution.kind("COMMIT"), "transaction")
+        self.assertEqual(run_attribution.kind("BEGIN"), "transaction")
+
+    def test_savepoints_are_their_own_kind(self):
+        self.assertEqual(run_attribution.kind('SAVEPOINT "s1"'), "savepoint")
+        self.assertEqual(run_attribution.kind('RELEASE SAVEPOINT "s1"'), "savepoint")
+
+    def test_rollback_to_savepoint_is_not_a_rollback(self):
+        """One undoes part of a transaction and the other undoes all of it."""
+        self.assertEqual(
+            run_attribution.kind('ROLLBACK TO SAVEPOINT "s1"'), "savepoint"
+        )
+        self.assertEqual(run_attribution.kind("ROLLBACK"), "transaction")
+
+
+class TestBatchSizeIsNeverPaidFor(SimpleTestCase):
+    def test_a_single_execution_has_no_batch(self):
+        self.assertIsNone(run_attribution.batch_size([1, 2, 3], many=False))
+
+    def test_no_parameters_have_no_batch(self):
+        self.assertIsNone(run_attribution.batch_size(None, many=True))
+
+    def test_a_sized_sequence_reports_its_length(self):
+        self.assertEqual(run_attribution.batch_size([(1,), (2,)], many=True), 2)
+
+    def test_an_iterator_is_reported_as_unknown_and_not_consumed(self):
+        """DB-API allows executemany() an iterable without __len__. Counting it
+        here would empty it before the driver saw it."""
+        params = iter([(1,), (2,), (3,)])
+        self.assertIsNone(run_attribution.batch_size(params, many=True))
+        self.assertEqual(list(params), [(1,), (2,), (3,)])
+
+
+# ---------------------------------------------------------------------------
+# Stacks
+# ---------------------------------------------------------------------------
+
+
+class TestTheProductStack(SimpleTestCase):
+    def test_a_call_from_outside_the_product_finds_no_frame(self):
+        self.assertEqual(run_attribution.product_stack(), [])
+
+    def test_frames_are_nearest_first_and_named_by_module_line_and_function(self):
+        # This file stands in for the product, so its own frames qualify.
+        with mock.patch.object(run_attribution, "_PRODUCT", f"{os.sep}tests{os.sep}"):
+
+            def inner():
+                return run_attribution.product_stack()
+
+            def outer():
+                return inner()
+
+            frames = outer()
+
+        self.assertTrue(frames[0].startswith("test_benchmarks_attribution.py:"))
+        self.assertIn(" in inner", frames[0])
+        self.assertIn(" in outer", frames[1])
+
+    def test_no_more_frames_are_kept_than_the_depth_allows(self):
+        with (
+            mock.patch.object(run_attribution, "_PRODUCT", f"{os.sep}tests{os.sep}"),
+            mock.patch.object(run_attribution, "STACK_DEPTH", 2),
+        ):
+
+            def a():
+                return run_attribution.product_stack()
+
+            def b():
+                return a()
+
+            def c():
+                return b()
+
+            frames = c()
+
+        self.assertEqual(len(frames), 2)
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+class TestGroupingKeepsShapeAndFrameApart(SimpleTestCase):
+    def test_the_same_shape_from_two_frames_is_two_groups(self):
+        grouped = run_attribution.group(
+            _execution(
+                [
+                    _event(shape="SELECT 1", frame="a.py:1 in f"),
+                    _event(shape="SELECT 1", frame="b.py:2 in g"),
+                ],
+                observed_workload=1,
+            )
+        )
+        self.assertEqual(len(grouped), 2)
+
+    def test_two_shapes_from_one_frame_are_two_groups(self):
+        grouped = run_attribution.group(
+            _execution(
+                [
+                    _event(shape="SELECT 1", frame="a.py:1 in f"),
+                    _event(shape="SELECT 2", frame="a.py:1 in f"),
+                ],
+                observed_workload=1,
+            )
+        )
+        self.assertEqual(len(grouped), 2)
+
+    def test_repetitions_of_one_group_are_counted(self):
+        grouped = run_attribution.group(
+            _execution([_event(), _event(), _event()], observed_workload=1)
+        )
+        self.assertEqual(next(iter(grouped.values()))["count"], 3)
+
+    def test_an_event_with_no_product_frame_is_named_rather_than_dropped(self):
+        grouped = run_attribution.group(
+            _execution([_event(stack=[])], observed_workload=1)
+        )
+        key = next(iter(grouped))
+        self.assertEqual(key[1], run_attribution.OUTSIDE)
+
+
+class TestAGroupKeepsTheWidthsItsShapeHides(SimpleTestCase):
+    def test_arity_is_reported_as_the_range_the_group_covered(self):
+        grouped = run_attribution.group(
+            _execution(
+                [_event(in_arity=2), _event(in_arity=40), _event(in_arity=7)],
+                observed_workload=1,
+            )
+        )
+        self.assertEqual(next(iter(grouped.values()))["in_arity"], [2, 40])
+
+    def test_a_group_whose_events_carry_no_width_reports_none(self):
+        grouped = run_attribution.group(_execution([_event()], observed_workload=1))
+        entry = next(iter(grouped.values()))
+        self.assertIsNone(entry["in_arity"])
+        self.assertIsNone(entry["batch"])
+
+    def test_an_unknown_batch_does_not_hide_a_known_one(self):
+        grouped = run_attribution.group(
+            _execution([_event(batch=None), _event(batch=5)], observed_workload=1)
+        )
+        self.assertEqual(next(iter(grouped.values()))["batch"], [5, 5])
+
+    def test_the_kind_of_a_group_is_kept(self):
+        grouped = run_attribution.group(
+            _execution(
+                [_event(shape="COMMIT", kind="transaction")], observed_workload=1
+            )
+        )
+        self.assertEqual(next(iter(grouped.values()))["kind"], "transaction")
+
+
+class TestCallersAreKept(SimpleTestCase):
+    def test_the_frames_above_the_nearest_one_are_reported_per_caller(self):
+        grouped = run_attribution.group(
+            _execution(
+                [
+                    _event(stack=["a.py:1 in f", "b.py:2 in g"]),
+                    _event(stack=["a.py:1 in f", "b.py:2 in g"]),
+                    _event(stack=["a.py:1 in f", "c.py:3 in h"]),
+                ],
+                observed_workload=1,
+            )
+        )
+        callers = next(iter(grouped.values()))["callers"]
+        self.assertEqual(callers["b.py:2 in g"], 2)
+        self.assertEqual(callers["c.py:3 in h"], 1)
+
+    def test_no_more_callers_are_kept_than_the_cap_allows(self):
+        events = [
+            _event(stack=["a.py:1 in f", f"caller{index}.py:1 in g"])
+            for index in range(run_attribution.CALLERS + 3)
+        ]
+        grouped = run_attribution.group(_execution(events, observed_workload=1))
+        callers = next(iter(grouped.values()))["callers"]
+        self.assertEqual(len(callers), run_attribution.CALLERS)
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestReconciliationAgainstTheHarnessCounter(SimpleTestCase):
+    def test_a_flow_without_transactions_leaves_nothing_unattributed(self):
+        execution = _execution([_event(), _event()], observed_workload=1, total=2)
+        self.assertEqual(run_attribution.unattributed(execution), 0)
+
+    def test_statements_the_wrapper_cannot_see_are_counted_not_dropped(self):
+        """Django's _commit() calls the connection directly and appends a
+        synthetic record to the query log, so the harness counts what no
+        wrapper runs for."""
+        execution = _execution([_event(), _event()], observed_workload=1, total=6)
+        self.assertEqual(run_attribution.unattributed(execution), 4)
+
+    def test_the_report_states_the_split(self):
+        flow = _flow()
+        small = _execution([_event()], observed_workload=2, total=5)
+        large = _execution([_event(), _event()], observed_workload=40, total=6)
+        rows = run_attribution.build(small, large)
+
+        with _captured_stdout() as stream:
+            run_attribution.print_report(flow.name, flow, small, large, rows)
+
+        printed = stream.getvalue()
+        self.assertIn("5 queries  = 1 attributed + 4 outside", printed)
+        self.assertIn("6 queries  = 2 attributed + 4 outside", printed)
+
+
+# ---------------------------------------------------------------------------
+# Rates
+# ---------------------------------------------------------------------------
+
+
+class TestRatesComeFromTheDeclaredWorkload(SimpleTestCase):
+    def _rows(self, small_events, large_events, small_workload=2, large_workload=40):
+        return run_attribution.build(
+            _execution(small_events, observed_workload=small_workload),
+            _execution(large_events, observed_workload=large_workload),
+        )
+
+    def test_a_group_growing_one_per_unit_has_a_rate_of_one(self):
+        rows = self._rows([_event()] * 2, [_event()] * 40)
+        self.assertAlmostEqual(rows[0]["rate"], 1.0)
+
+    def test_a_group_that_does_not_grow_has_a_rate_of_zero(self):
+        rows = self._rows([_event()], [_event()])
+        self.assertAlmostEqual(rows[0]["rate"], 0.0)
+
+    def test_a_group_present_at_only_one_size_still_appears(self):
+        rows = self._rows([_event(shape="SELECT 1")], [_event(shape="SELECT 2")])
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({row["delta"] for row in rows}, {1, -1})
+
+    def test_the_fixed_estimate_is_what_the_two_counts_imply_at_zero(self):
+        # 2 -> 40 over a workload of 2 -> 40 is one per unit through the origin.
+        rows = self._rows([_event()] * 2, [_event()] * 40)
+        self.assertAlmostEqual(rows[0]["fixed"], 0.0)
+
+    def test_a_group_that_skips_part_of_the_workload_shows_it(self):
+        # One event fewer at each size than the workload: a group that runs for
+        # all but one unit.
+        rows = self._rows([_event()] * 1, [_event()] * 39)
+        self.assertAlmostEqual(rows[0]["rate"], 1.0)
+        self.assertAlmostEqual(rows[0]["fixed"], -1.0)
+
+    def test_rows_are_ranked_by_how_much_they_grew(self):
+        rows = self._rows(
+            [_event(shape="SLOW"), _event(shape="FLAT")],
+            [_event(shape="SLOW")] * 40 + [_event(shape="FLAT")],
+        )
+        self.assertEqual(rows[0]["shape"], "SLOW")
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+class TestTheReportDisclosesWhatItHides(SimpleTestCase):
+    def _print(self, small_events, large_events):
+        flow = _flow()
+        small = _execution(small_events, observed_workload=2)
+        large = _execution(large_events, observed_workload=40)
+        rows = run_attribution.build(small, large)
+        with _captured_stdout() as stream:
+            run_attribution.print_report(flow.name, flow, small, large, rows)
+        return stream.getvalue()
+
+    def test_the_header_names_the_flow_and_both_workloads(self):
+        printed = self._print([_event()], [_event()])
+        self.assertIn("fake_flow: 2 -> 40 widgets", printed)
+
+    def test_groups_that_shrank_are_listed_separately(self):
+        printed = self._print([_event(shape="GONE")] * 3, [_event(shape="GONE")])
+        self.assertIn("Groups that shrank", printed)
+
+    def test_a_tail_it_does_not_print_is_summarised(self):
+        # One driver covers the coverage cut, so the smaller growing groups
+        # behind it are summarised rather than listed.
+        small = [_event(shape="BIG")] * 2 + [
+            _event(shape=f"UP{index}") for index in range(3)
+        ]
+        large = [_event(shape="BIG")] * 300 + [
+            _event(shape=f"UP{index}") for index in range(3) for _ in range(4)
+        ]
+        printed = self._print(small, large)
+        self.assertIn("3 further changed group(s) not shown", printed)
+        self.assertIn("net +9", printed)
+        self.assertIn("gross movement 9", printed)
+
+    def test_a_group_that_shrank_is_not_also_counted_as_hidden(self):
+        """It is printed in its own section, so calling it unseen would tell a
+        reader something is hidden that they have just read."""
+        small = [_event(shape="BIG")] * 2 + [_event(shape="DOWN")] * 6
+        large = [_event(shape="BIG")] * 300 + [_event(shape="DOWN")]
+        printed = self._print(small, large)
+        self.assertIn("Groups that shrank", printed)
+        self.assertNotIn("further changed group(s) not shown", printed)
+
+    def test_a_width_the_shape_hides_is_shown_beside_it(self):
+        printed = self._print(
+            [_event(in_arity=2)],
+            [_event(in_arity=40)] * 2,
+        )
+        self.assertIn("[IN arity 2 -> 40]", printed)
+
+    def test_a_group_with_no_width_carries_no_note(self):
+        printed = self._print([_event()], [_event()] * 2)
+        self.assertNotIn("[IN arity", printed)
+        self.assertNotIn("[batch", printed)
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+class TestSelectionIsRefusedEarly(SimpleTestCase):
+    def _main(self, *argv):
+        with mock.patch.object(sys, "argv", ["run_attribution.py", *argv]):
+            return run_attribution.main()
+
+    def test_an_unknown_flow_names_the_known_ones(self):
+        with (
+            _captured_stdout(),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit),
+        ):
+            self._main("no_such_flow")
+        self.assertIn("core_page_index", stderr.getvalue())
+
+    def test_a_flow_without_two_scale_points_is_refused_before_anything_is_built(self):
+        flow = _flow(scale_points=())
+        with (
+            mock.patch.dict(catalog.BY_NAME, {flow.name: flow}),
+            mock.patch.object(run, "_build_template") as template,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            self._main(flow.name)
+
+        self.assertIn("0 scale point", str(raised.exception))
+        template.assert_not_called()
+
+    def test_a_flow_with_one_scale_point_is_refused_too(self):
+        flow = _flow(scale_points=(_point("only", 3),))
+        with (
+            mock.patch.dict(catalog.BY_NAME, {flow.name: flow}),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            self._main(flow.name)
+
+        self.assertIn("1 scale point", str(raised.exception))
+
+    def test_no_flow_and_no_list_is_refused(self):
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(io.StringIO()):
+            self._main()
+
+    def test_listing_prints_the_catalog_without_building_anything(self):
+        with (
+            mock.patch.object(run, "_build_template") as template,
+            _captured_stdout() as stream,
+        ):
+            self.assertEqual(self._main("--list"), 0)
+
+        self.assertIn("core_page_index", stream.getvalue())
+        template.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# The instrumented region
+# ---------------------------------------------------------------------------
+
+
+class TestTheAttributedRegion(SimpleTestCase):
+    """What the child instruments, and what it refuses to report."""
+
+    @contextlib.contextmanager
+    def _child(self, flow, events):
+        captured = []
+
+        class FakeCapture:
+            def __init__(self, connection):
+                pass
+
+            def __enter__(self):
+                events.append("capture:enter")
+                return captured
+
+            def __exit__(self, *exc):
+                events.append("capture:exit")
+                return False
+
+        def fake_prepare():
+            events.append("prepare")
+            return "ctx"
+
+        with (
+            mock.patch.object(run, "guard_database", return_value="db"),
+            mock.patch.dict(catalog.BY_NAME, {flow.name: flow}),
+            mock.patch.object(catalog, "prepare", side_effect=fake_prepare),
+            mock.patch("benchmarks.env.bootstrap"),
+            mock.patch("django.test.utils.CaptureQueriesContext", FakeCapture),
+        ):
+            yield
+
+    def _run_child(self, flow, events, size="small"):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "events.json")
+            with (
+                self._child(flow, events),
+                mock.patch.dict(os.environ, {run_attribution.EVENTS_ENV_VAR: path}),
+            ):
+                run_attribution.attribute_in_child(flow.name, size)
+            with open(path) as handle:
+                return json.load(handle)
+
+    def test_prepare_setup_run_and_verify_happen_around_the_capture(self):
+        events = []
+        flow = _flow(
+            setup=lambda ctx, size: events.append("setup"),
+            run=lambda ctx, size: events.append("run") or "artifacts",
+            verify=lambda ctx, size, artifacts: events.append("verify") or 2,
+        )
+        self._run_child(flow, events)
+
+        self.assertEqual(
+            events,
+            ["prepare", "setup", "capture:enter", "run", "capture:exit", "verify"],
+        )
+
+    def test_a_workload_that_does_not_match_the_scale_point_fails(self):
+        events = []
+        flow = _flow(verify=lambda ctx, size, artifacts: 99)
+        with self.assertRaises(SystemExit) as raised:
+            self._run_child(flow, events)
+
+        self.assertIn("99", str(raised.exception))
+        self.assertIn("2", str(raised.exception))
+
+    def test_the_observed_workload_is_written_out(self):
+        events = []
+        flow = _flow(verify=lambda ctx, size, artifacts: 2)
+        written = self._run_child(flow, events)
+        self.assertEqual(written["observed_workload"], 2)
+        self.assertEqual(written["size"], "small")
+
+
+# ---------------------------------------------------------------------------
+# Separation from the harness
+# ---------------------------------------------------------------------------
+
+
+class TestTheBenchmarkRunnerIsUnaffected(SimpleTestCase):
+    def test_run_py_never_mentions_the_attribution_runner(self):
+        with open(run.__file__) as handle:
+            self.assertNotIn("run_attribution", handle.read())
+
+    def test_the_attribution_runner_reuses_the_harness_rather_than_copying_it(self):
+        with open(run_attribution.__file__) as handle:
+            source = handle.read()
+        for helper in ("_own_directory", "_build_template", "guard_database"):
+            self.assertIn(f"run.{helper}", source)

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -139,8 +139,8 @@ class TestCatalogIntegrity(SimpleTestCase):
 
     def test_the_catalog_expands_to_the_executions_it_claims(self):
         expanded = catalog.executions()
-        self.assertEqual(len(catalog.CATALOG), 8)
-        self.assertEqual(len(expanded), 13)
+        self.assertEqual(len(catalog.CATALOG), 9)
+        self.assertEqual(len(expanded), 15)
         self.assertEqual(
             len(expanded), sum(len(flow.sizes()) for flow in catalog.CATALOG)
         )

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -2,7 +2,10 @@
 
 import ast
 import contextlib
+import importlib.metadata
+import json
 import os
+import subprocess
 import sys
 import tempfile
 
@@ -496,3 +499,271 @@ class TestCatalogOrder(SimpleTestCase):
                 self.assertEqual(flow.scale_points, ())
                 self.assertIsNone(flow.workload_unit)
                 self.assertEqual(run._executions_for(name, None), [(flow, None)])
+
+
+class TestPublicResult(SimpleTestCase):
+    """The JSON is shared and archived, so it carries what a reader needs and
+    nothing that belongs to one run on one machine."""
+
+    def _result(self, **overrides):
+        result = {
+            "process": "a_flow",
+            "size": "large",
+            "queries": 42,
+            "seconds": 0.5,
+            "workload_unit": "things",
+            "expected_workload": 7,
+            "observed_workload": 7,
+            "pid": 1234,
+            "database": "/tmp/whatever/run-00.sqlite3",  # noqa: S108
+        }
+        result.update(overrides)
+        return result
+
+    def test_private_fields_are_dropped(self):
+        public = run._public_result(self._result())
+        for field in ("pid", "database", "seconds"):
+            with self.subTest(field=field):
+                self.assertNotIn(field, public)
+
+    def test_the_measurement_is_kept(self):
+        public = run._public_result(self._result())
+        self.assertEqual(public["queries"], 42)
+        self.assertEqual(public["workload_unit"], "things")
+        self.assertEqual(public["expected_workload"], 7)
+        self.assertEqual(public["observed_workload"], 7)
+        self.assertEqual(public["status"], "ok")
+
+    def test_a_failed_execution_reports_no_numbers(self):
+        public = run._public_result(
+            {"process": "a_flow", "size": None, "error": "it broke"}
+        )
+        self.assertEqual(public["status"], "failed")
+        self.assertIsNone(public["queries"])
+        self.assertIsNone(public["observed_workload"])
+
+
+class TestJsonDocument(SimpleTestCase):
+    def _write(self, results):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "run.json")
+            run._write_json(path, {"schema_version": run.SCHEMA_VERSION}, results)
+            with open(path) as handle:
+                return json.load(handle)
+
+    def test_a_run_where_everything_passed_is_complete(self):
+        document = self._write(
+            [
+                {
+                    "process": "a",
+                    "size": None,
+                    "queries": 1,
+                    "seconds": 0.0,
+                    "workload_unit": None,
+                    "expected_workload": None,
+                    "observed_workload": None,
+                    "pid": 1,
+                    "database": "d",
+                }
+            ]
+        )
+        self.assertEqual(document["status"], "complete")
+        self.assertEqual(document["schema_version"], run.SCHEMA_VERSION)
+
+    def test_one_failure_makes_the_whole_run_incomplete(self):
+        """A run with a hole in it is a record of what happened, never a
+        baseline something else can be compared against."""
+        document = self._write(
+            [
+                {
+                    "process": "a",
+                    "size": None,
+                    "queries": 1,
+                    "seconds": 0.0,
+                    "workload_unit": None,
+                    "expected_workload": None,
+                    "observed_workload": None,
+                    "pid": 1,
+                    "database": "d",
+                },
+                {"process": "b", "size": None, "error": "boom"},
+            ]
+        )
+        self.assertEqual(document["status"], "incomplete")
+        self.assertEqual(document["executions"][1]["status"], "failed")
+
+
+class TestJsonRun(SimpleTestCase):
+    """main() end to end with --json, with the executions faked so no database
+    is built."""
+
+    def _run(self, argv, failing=()):
+        def fake_execute(name, size, template, directory, index, token):
+            if (name, size) in failing:
+                return {"process": name, "size": size, "error": "deliberate"}
+            return {
+                "process": name,
+                "size": size,
+                "queries": 10 + index,
+                "seconds": 0.1,
+                "workload_unit": None,
+                "expected_workload": None,
+                "observed_workload": None,
+                "pid": 100 + index,
+                "database": f"/tmp/x/run-{index}.sqlite3",  # noqa: S108
+            }
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "run.json")
+            with (
+                mock.patch.object(run, "_build_template", return_value="template"),
+                mock.patch.object(run, "execute", side_effect=fake_execute),
+                mock.patch.object(
+                    run, "_provenance", return_value={"schema_version": 1}
+                ),
+                mock.patch.object(sys, "argv", ["run.py", *argv, "--json", path]),
+                mock.patch("sys.stdout"),
+                mock.patch("sys.stderr"),
+            ):
+                code = run.main()
+            with open(path) as handle:
+                return code, json.load(handle)
+
+    def test_all_writes_one_entry_per_execution_in_catalog_order(self):
+        code, document = self._run([run.ALL])
+        self.assertEqual(code, 0)
+        self.assertEqual(document["status"], "complete")
+        self.assertEqual(
+            [(e["flow"], e["size"]) for e in document["executions"]],
+            [(flow.name, size) for flow, size in catalog.executions()],
+        )
+
+    def test_a_flow_without_scale_points_records_a_null_size(self):
+        _code, document = self._run(["submit_page_post"])
+        self.assertEqual(document["executions"], [document["executions"][0]])
+        self.assertIsNone(document["executions"][0]["size"])
+
+    def test_a_failed_execution_is_written_and_marks_the_run_incomplete(self):
+        code, document = self._run([run.ALL], failing={("submit_page_post", None)})
+        self.assertEqual(code, 1)
+        self.assertEqual(document["status"], "incomplete")
+        failed = [e for e in document["executions"] if e["status"] == "failed"]
+        self.assertEqual([e["flow"] for e in failed], ["submit_page_post"])
+        # The rest still ran and were recorded.
+        self.assertEqual(len(document["executions"]), len(catalog.executions()))
+
+
+class TestJsonPathIsCheckedFirst(SimpleTestCase):
+    """A path that cannot be written is worth a message, not a run whose
+    results are then discarded."""
+
+    def test_a_directory_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(ValueError) as raised:
+                run._check_json_path(directory)
+            self.assertIn("is a directory", str(raised.exception))
+
+    def test_a_missing_parent_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(ValueError) as raised:
+                run._check_json_path(os.path.join(directory, "nope", "run.json"))
+            self.assertIn("no directory", str(raised.exception))
+
+    def test_an_unwritable_parent_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            parent = os.path.join(directory, "locked")
+            os.mkdir(parent, mode=0o500)
+            try:
+                with self.assertRaises(ValueError) as raised:
+                    run._check_json_path(os.path.join(parent, "run.json"))
+                self.assertIn("not writable", str(raised.exception))
+            finally:
+                os.chmod(parent, 0o700)
+
+    def test_an_unwritable_existing_file_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "run.json")
+            with open(path, "w") as handle:
+                handle.write("{}")
+            os.chmod(path, 0o400)
+            try:
+                with self.assertRaises(ValueError) as raised:
+                    run._check_json_path(path)
+                self.assertIn("not writable", str(raised.exception))
+            finally:
+                os.chmod(path, 0o600)
+
+    def test_a_writable_new_path_is_accepted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run._check_json_path(os.path.join(directory, "run.json"))
+
+
+class TestVersionsComeFromMetadata(SimpleTestCase):
+    """Read from the environment's metadata, so the parent still never imports
+    Django and no extra process is spawned."""
+
+    def test_every_measured_package_is_reported(self):
+        versions = run._versions()
+        for name in (*run.MEASURED_PACKAGES, "python"):
+            with self.subTest(package=name):
+                self.assertTrue(versions[name])
+
+    def test_the_public_keys_do_not_follow_distribution_names(self):
+        # A reader indexes this document; it should not have to know that the
+        # environment spells the distributions Django and wagtail-localize.
+        self.assertEqual(
+            list(run._versions()),
+            ["python", "django", "wagtail", "wagtail_localize"],
+        )
+
+    def test_missing_metadata_stops_the_run_and_names_the_package(self):
+        real = importlib.metadata.version
+
+        def fake(name):
+            if name == "wagtail-localize":
+                raise importlib.metadata.PackageNotFoundError(name)
+            return real(name)
+
+        with (
+            mock.patch.object(importlib.metadata, "version", side_effect=fake),
+            self.assertRaises(LookupError) as raised,
+        ):
+            run._versions()
+        self.assertIn("wagtail-localize", str(raised.exception))
+
+
+class TestProvenanceNeedsGit(SimpleTestCase):
+    """A complete document names the commit it measured. When git cannot say
+    which one, the run stops rather than writing a null."""
+
+    def test_a_failed_command_is_an_error_carrying_what_git_said(self):
+        failure = subprocess.CompletedProcess(
+            args=[], returncode=128, stdout="", stderr="fatal: not a git repository\n"
+        )
+        with (
+            mock.patch.object(subprocess, "run", return_value=failure),
+            self.assertRaises(RuntimeError) as raised,
+        ):
+            run._git("rev-parse", "HEAD")
+        self.assertIn("not a git repository", str(raised.exception))
+
+    def test_a_missing_executable_is_an_error(self):
+        with (
+            mock.patch.object(subprocess, "run", side_effect=FileNotFoundError("git")),
+            self.assertRaises(RuntimeError) as raised,
+        ):
+            run._git("rev-parse", "HEAD")
+        self.assertIn("cannot run git", str(raised.exception))
+
+    def test_provenance_does_not_survive_a_git_failure(self):
+        with (
+            mock.patch.object(run, "_git", side_effect=RuntimeError("no git")),
+            self.assertRaises(RuntimeError),
+        ):
+            run._provenance({"flow": "all", "size": None})
+
+    def test_a_working_run_records_git_facts_rather_than_nulls(self):
+        provenance = run._provenance({"flow": "all", "size": None})
+        for key in ("commit", "branch", "working_tree_clean"):
+            with self.subTest(key=key):
+                self.assertIsNotNone(provenance[key])

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -1,5 +1,6 @@
 """Structural tests for the benchmark harness."""
 
+import argparse
 import ast
 import contextlib
 import importlib.metadata
@@ -509,13 +510,14 @@ class TestPublicResult(SimpleTestCase):
         result = {
             "process": "a_flow",
             "size": "large",
+            "repeats": 1,
             "queries": 42,
-            "seconds": 0.5,
             "workload_unit": "things",
             "expected_workload": 7,
             "observed_workload": 7,
-            "pid": 1234,
-            "database": "/tmp/whatever/run-00.sqlite3",  # noqa: S108
+            "seconds_median": 0.5,
+            "seconds_min": 0.5,
+            "seconds_max": 0.5,
         }
         result.update(overrides)
         return result
@@ -533,14 +535,25 @@ class TestPublicResult(SimpleTestCase):
         self.assertEqual(public["expected_workload"], 7)
         self.assertEqual(public["observed_workload"], 7)
         self.assertEqual(public["status"], "ok")
+        self.assertEqual(public["repeats"], 1)
+        self.assertEqual(public["seconds_median"], 0.5)
+        self.assertEqual(public["seconds_min"], 0.5)
+        self.assertEqual(public["seconds_max"], 0.5)
 
     def test_a_failed_execution_reports_no_numbers(self):
         public = run._public_result(
             {"process": "a_flow", "size": None, "error": "it broke"}
         )
         self.assertEqual(public["status"], "failed")
-        self.assertIsNone(public["queries"])
-        self.assertIsNone(public["observed_workload"])
+        for field in (
+            "queries",
+            "observed_workload",
+            "seconds_median",
+            "seconds_min",
+            "seconds_max",
+        ):
+            with self.subTest(field=field):
+                self.assertIsNone(public[field])
 
 
 class TestJsonDocument(SimpleTestCase):
@@ -557,13 +570,14 @@ class TestJsonDocument(SimpleTestCase):
                 {
                     "process": "a",
                     "size": None,
+                    "repeats": 1,
                     "queries": 1,
-                    "seconds": 0.0,
                     "workload_unit": None,
                     "expected_workload": None,
                     "observed_workload": None,
-                    "pid": 1,
-                    "database": "d",
+                    "seconds_median": 0.0,
+                    "seconds_min": 0.0,
+                    "seconds_max": 0.0,
                 }
             ]
         )
@@ -578,13 +592,14 @@ class TestJsonDocument(SimpleTestCase):
                 {
                     "process": "a",
                     "size": None,
+                    "repeats": 1,
                     "queries": 1,
-                    "seconds": 0.0,
                     "workload_unit": None,
                     "expected_workload": None,
                     "observed_workload": None,
-                    "pid": 1,
-                    "database": "d",
+                    "seconds_median": 0.0,
+                    "seconds_min": 0.0,
+                    "seconds_max": 0.0,
                 },
                 {"process": "b", "size": None, "error": "boom"},
             ]
@@ -597,14 +612,16 @@ class TestJsonRun(SimpleTestCase):
     """main() end to end with --json, with the executions faked so no database
     is built."""
 
-    def _run(self, argv, failing=()):
+    def _run(self, argv, failing=(), stable=False):
         def fake_execute(name, size, template, directory, index, token):
             if (name, size) in failing:
                 return {"process": name, "size": size, "error": "deliberate"}
             return {
                 "process": name,
                 "size": size,
-                "queries": 10 + index,
+                # Unstable on purpose unless asked: the index differs per
+                # repetition, so a repeated run has to notice.
+                "queries": 10 if stable else 10 + index,
                 "seconds": 0.1,
                 "workload_unit": None,
                 "expected_workload": None,
@@ -619,7 +636,9 @@ class TestJsonRun(SimpleTestCase):
                 mock.patch.object(run, "_build_template", return_value="template"),
                 mock.patch.object(run, "execute", side_effect=fake_execute),
                 mock.patch.object(
-                    run, "_provenance", return_value={"schema_version": 1}
+                    run,
+                    "_provenance",
+                    return_value={"schema_version": run.SCHEMA_VERSION},
                 ),
                 mock.patch.object(sys, "argv", ["run.py", *argv, "--json", path]),
                 mock.patch("sys.stdout"),
@@ -651,6 +670,28 @@ class TestJsonRun(SimpleTestCase):
         self.assertEqual([e["flow"] for e in failed], ["submit_page_post"])
         # The rest still ran and were recorded.
         self.assertEqual(len(document["executions"]), len(catalog.executions()))
+
+    def test_repeated_executions_publish_their_summary(self):
+        code, document = self._run([run.ALL, "--repeat", "3"], stable=True)
+        self.assertEqual(code, 0)
+        self.assertEqual(document["status"], "complete")
+        self.assertEqual(document["schema_version"], 2)
+        for execution in document["executions"]:
+            with self.subTest(flow=execution["flow"], size=execution["size"]):
+                self.assertEqual(execution["repeats"], 3)
+                self.assertEqual(execution["seconds_median"], 0.1)
+                self.assertEqual(execution["seconds_min"], 0.1)
+                self.assertEqual(execution["seconds_max"], 0.1)
+                for field in ("pid", "database", "seconds"):
+                    self.assertNotIn(field, execution)
+
+    def test_a_measurement_that_moves_makes_the_whole_run_incomplete(self):
+        code, document = self._run([run.ALL, "--repeat", "3"])
+        self.assertEqual(code, 1)
+        self.assertEqual(document["status"], "incomplete")
+        self.assertEqual(
+            {execution["status"] for execution in document["executions"]}, {"failed"}
+        )
 
 
 class TestJsonPathIsCheckedFirst(SimpleTestCase):
@@ -767,3 +808,136 @@ class TestProvenanceNeedsGit(SimpleTestCase):
         for key in ("commit", "branch", "working_tree_clean"):
             with self.subTest(key=key):
                 self.assertIsNotNone(provenance[key])
+
+
+class TestRepeatedExecutions(SimpleTestCase):
+    """A repetition is a whole execution: fresh database, fresh child. The
+    parent summarises the time and refuses to summarise anything else."""
+
+    def _result(self, seconds, **overrides):
+        result = {
+            "process": "a_flow",
+            "size": "large",
+            "queries": 42,
+            "seconds": seconds,
+            "workload_unit": "things",
+            "expected_workload": 7,
+            "observed_workload": 7,
+        }
+        result.update(overrides)
+        return result
+
+    def test_a_repeat_below_one_or_not_a_number_is_refused(self):
+        for value in ("0", "-3", "two", "1.5"):
+            with (
+                self.subTest(value=value),
+                self.assertRaises(argparse.ArgumentTypeError),
+            ):
+                run._positive(value)
+
+    def test_an_invalid_repeat_costs_no_database_and_no_child(self):
+        with (
+            mock.patch.object(run, "_build_template") as build,
+            mock.patch.object(run, "execute") as execute,
+            mock.patch.object(sys, "argv", ["run.py", run.ALL, "--repeat", "0"]),
+            mock.patch("sys.stderr"),
+            self.assertRaises(SystemExit),
+        ):
+            run.main()
+        build.assert_not_called()
+        execute.assert_not_called()
+
+    def test_each_repetition_gets_its_own_database_index(self):
+        indices = []
+
+        def fake_execute(name, size, template, directory, index, token):
+            indices.append(index)
+            return self._result(0.1)
+
+        with mock.patch.object(run, "execute", side_effect=fake_execute):
+            result = run.repeat("a_flow", "large", "t", "d", 5, "token", 3)
+
+        self.assertEqual(indices, [5, 6, 7])
+        self.assertEqual(result["repeats"], 3)
+
+    def test_the_default_runs_each_execution_once(self):
+        calls = []
+
+        def fake_execute(name, size, template, directory, index, token):
+            calls.append(index)
+            return self._result(0.1)
+
+        with (
+            mock.patch.object(run, "_build_template", return_value="template"),
+            mock.patch.object(run, "execute", side_effect=fake_execute),
+            mock.patch.object(sys, "argv", ["run.py", "submit_page_post"]),
+            mock.patch("sys.stdout"),
+            mock.patch("sys.stderr"),
+        ):
+            code = run.main()
+
+        self.assertEqual(code, 0)
+        self.assertEqual(calls, [0])
+
+    def test_the_time_is_summarised_over_every_repetition(self):
+        aggregate = run._aggregate(
+            "a_flow",
+            "large",
+            [self._result(0.3), self._result(0.1), self._result(0.2)],
+        )
+        self.assertEqual(aggregate["repeats"], 3)
+        self.assertEqual(aggregate["seconds_median"], 0.2)
+        self.assertEqual(aggregate["seconds_min"], 0.1)
+        self.assertEqual(aggregate["seconds_max"], 0.3)
+        self.assertEqual(aggregate["queries"], 42)
+        self.assertNotIn("error", aggregate)
+
+    def test_a_measurement_that_moves_between_repetitions_fails(self):
+        for field, moved in (
+            ("queries", 43),
+            ("workload_unit", "others"),
+            ("expected_workload", 8),
+            ("observed_workload", 8),
+        ):
+            with self.subTest(field=field):
+                aggregate = run._aggregate(
+                    "a_flow",
+                    "large",
+                    [self._result(0.1), self._result(0.1, **{field: moved})],
+                )
+                self.assertIn("error", aggregate)
+                self.assertIn(field, aggregate["error"])
+                self.assertNotIn("queries", aggregate)
+
+    def test_one_failed_repetition_fails_the_whole_aggregate(self):
+        aggregate = run._aggregate(
+            "a_flow",
+            "large",
+            [
+                self._result(0.1),
+                {"process": "a_flow", "size": "large", "error": "deliberate"},
+            ],
+        )
+        self.assertIn("deliberate", aggregate["error"])
+        self.assertEqual(run._public_result(aggregate)["status"], "failed")
+
+    def test_the_document_records_the_repeat_the_command_asked_for(self):
+        provenance = mock.Mock(return_value={"schema_version": run.SCHEMA_VERSION})
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "run.json")
+            with (
+                mock.patch.object(run, "_build_template", return_value="t"),
+                mock.patch.object(
+                    run, "execute", side_effect=lambda *args: self._result(0.1)
+                ),
+                mock.patch.object(run, "_provenance", provenance),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["run.py", "submit_page_post", "--repeat", "4", "--json", path],
+                ),
+                mock.patch("sys.stdout"),
+                mock.patch("sys.stderr"),
+            ):
+                run.main()
+        self.assertEqual(provenance.call_args.args[0]["repeat"], 4)

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -351,6 +351,34 @@ class TestExecutionSelection(SimpleTestCase):
         self.assertIn(run.ALL, message)
 
 
+class TestListTakesNoSelection(SimpleTestCase):
+    """`--list` prints the catalog and nothing else, so an argument that asks
+    for something it cannot do is an error rather than a silent omission."""
+
+    def _main_with(self, argv):
+        with (
+            mock.patch.object(sys, "argv", ["run.py", *argv]),
+            mock.patch("sys.stdout"),
+            mock.patch("sys.stderr"),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            run.main()
+        return raised.exception
+
+    def test_a_flow_name_is_refused(self):
+        self.assertEqual(self._main_with(["submit_page_post", "--list"]).code, 2)
+
+    def test_a_json_path_is_refused(self):
+        self.assertEqual(self._main_with(["--list", "--json", "run.json"]).code, 2)
+
+    def test_the_bare_flag_still_prints(self):
+        with (
+            mock.patch.object(sys, "argv", ["run.py", "--list"]),
+            mock.patch("sys.stdout"),
+        ):
+            self.assertEqual(run.main(), 0)
+
+
 class TestOrchestration(SimpleTestCase):
     """A failing execution must not stop the ones after it."""
 

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -136,8 +136,8 @@ class TestCatalogIntegrity(SimpleTestCase):
 
     def test_the_catalog_expands_to_the_executions_it_claims(self):
         expanded = catalog.executions()
-        self.assertEqual(len(catalog.CATALOG), 2)
-        self.assertEqual(len(expanded), 3)
+        self.assertEqual(len(catalog.CATALOG), 4)
+        self.assertEqual(len(expanded), 5)
         self.assertEqual(
             len(expanded), sum(len(flow.sizes()) for flow in catalog.CATALOG)
         )
@@ -465,3 +465,24 @@ class TestUnusableChildResult(SimpleTestCase):
 
         self.assertEqual(code, 1)
         self.assertEqual(len(attempted), len(catalog.executions()))
+
+
+class TestCatalogOrder(SimpleTestCase):
+    def test_creation_processes_come_before_the_editor(self):
+        """Relative order only. Asserting the whole shape of the list would
+        break as soon as flows from other groups are added."""
+        order = [flow.name for flow in catalog.CATALOG]
+        editor = order.index("edit_translation_get")
+
+        self.assertLess(order.index("submit_page_get"), order.index("submit_page_post"))
+        for name in ("submit_page_get", "submit_page_post", "submit_snippet_post"):
+            with self.subTest(flow=name):
+                self.assertLess(order.index(name), editor)
+
+    def test_the_sizeless_processes_each_expand_to_one_execution(self):
+        for name in ("submit_page_get", "submit_page_post", "submit_snippet_post"):
+            with self.subTest(flow=name):
+                flow = catalog.BY_NAME[name]
+                self.assertEqual(flow.scale_points, ())
+                self.assertIsNone(flow.workload_unit)
+                self.assertEqual(run._executions_for(name, None), [(flow, None)])

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -140,20 +140,25 @@ class TestCatalogIntegrity(SimpleTestCase):
 
     def test_the_catalog_expands_to_the_executions_it_claims(self):
         expanded = catalog.executions()
-        self.assertEqual(len(catalog.CATALOG), 9)
+        self.assertEqual(len(catalog.CATALOG), 8)
         self.assertEqual(len(expanded), 15)
         self.assertEqual(
             len(expanded), sum(len(flow.sizes()) for flow in catalog.CATALOG)
         )
         self.assertIn((catalog.BY_NAME["edit_translation_get"], "large"), expanded)
 
-    def test_a_flow_without_scale_points_expands_to_a_single_sizeless_execution(self):
+    def test_submit_page_post_expands_over_related_object_references(self):
         flow = catalog.BY_NAME["submit_page_post"]
-        self.assertEqual(flow.scale_points, ())
-        self.assertIsNone(flow.workload_unit)
+        self.assertEqual(
+            [point.label for point in flow.scale_points], ["small", "large"]
+        )
+        self.assertEqual(
+            [point.expected_workload for point in flow.scale_points], [2, 40]
+        )
+        self.assertEqual(flow.workload_unit, "related_object_segments")
         self.assertEqual(
             [pair for pair in catalog.executions() if pair[0] is flow],
-            [(flow, None)],
+            [(flow, "small"), (flow, "large")],
         )
 
 
@@ -277,19 +282,19 @@ class TestChildSelectionGuard(SimpleTestCase):
         self.assertIn("needs a size", str(raised.exception))
 
     def test_a_flow_without_scale_points_is_accepted_without_a_size(self):
-        _catalog, flow, point = run._select("submit_page_post", None)
-        self.assertEqual(flow.name, "submit_page_post")
+        _catalog, flow, point = run._select("submit_snippet_post", None)
+        self.assertEqual(flow.name, "submit_snippet_post")
         self.assertIsNone(point)
 
     def test_a_size_on_a_flow_without_scale_points_is_refused(self):
         with self.assertRaises(SystemExit) as raised:
-            run._select("submit_page_post", "small")
+            run._select("submit_snippet_post", "small")
         self.assertIn("takes no size", str(raised.exception))
 
     def test_a_declared_size_is_accepted(self):
-        _catalog, flow, point = run._select("edit_translation_get", "large")
-        self.assertEqual(flow.name, "edit_translation_get")
-        self.assertEqual(point.expected_workload, 42)
+        _catalog, flow, point = run._select("submit_page_post", "large")
+        self.assertEqual(flow.name, "submit_page_post")
+        self.assertEqual(point.expected_workload, 40)
 
 
 class TestHarnessSettings(SimpleTestCase):
@@ -327,12 +332,14 @@ class TestExecutionSelection(SimpleTestCase):
         )
 
     def test_a_flow_without_scale_points_selects_one_sizeless_execution(self):
-        flow = catalog.BY_NAME["submit_page_post"]
-        self.assertEqual(run._executions_for("submit_page_post", None), [(flow, None)])
+        flow = catalog.BY_NAME["submit_snippet_post"]
+        self.assertEqual(
+            run._executions_for("submit_snippet_post", None), [(flow, None)]
+        )
 
     def test_a_flow_without_scale_points_refuses_a_size(self):
         with self.assertRaises(ValueError) as raised:
-            run._executions_for("submit_page_post", "small")
+            run._executions_for("submit_snippet_post", "small")
         self.assertIn("takes no size", str(raised.exception))
 
     def test_an_unknown_name_lists_the_valid_ones(self):
@@ -478,9 +485,7 @@ class TestCatalogOrder(SimpleTestCase):
         order = [flow.name for flow in catalog.CATALOG]
         editor = order.index("edit_translation_get")
 
-        self.assertLess(order.index("submit_page_get"), order.index("submit_page_post"))
         for name in (
-            "submit_page_get",
             "submit_page_post",
             "submit_snippet_post",
             "translate_page_subtree",
@@ -494,7 +499,7 @@ class TestCatalogOrder(SimpleTestCase):
                 self.assertGreater(order.index(name), editor)
 
     def test_the_sizeless_processes_each_expand_to_one_execution(self):
-        for name in ("submit_page_get", "submit_page_post", "submit_snippet_post"):
+        for name in ("submit_snippet_post",):
             with self.subTest(flow=name):
                 flow = catalog.BY_NAME[name]
                 self.assertEqual(flow.scale_points, ())
@@ -658,12 +663,12 @@ class TestJsonRun(SimpleTestCase):
         )
 
     def test_a_flow_without_scale_points_records_a_null_size(self):
-        _code, document = self._run(["submit_page_post"])
+        _code, document = self._run(["submit_snippet_post"])
         self.assertEqual(document["executions"], [document["executions"][0]])
         self.assertIsNone(document["executions"][0]["size"])
 
     def test_a_failed_execution_is_written_and_marks_the_run_incomplete(self):
-        code, document = self._run([run.ALL], failing={("submit_page_post", None)})
+        code, document = self._run([run.ALL], failing={("submit_page_post", "small")})
         self.assertEqual(code, 1)
         self.assertEqual(document["status"], "incomplete")
         failed = [e for e in document["executions"] if e["status"] == "failed"]
@@ -877,7 +882,7 @@ class TestRepeatedExecutions(SimpleTestCase):
             code = run.main()
 
         self.assertEqual(code, 0)
-        self.assertEqual(calls, [0])
+        self.assertEqual(calls, [0, 1])
 
     def test_the_time_is_summarised_over_every_repetition(self):
         aggregate = run._aggregate(

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -10,17 +10,10 @@ from unittest import mock
 
 from django.test import SimpleTestCase
 
+from benchmarks import catalog, run
 
-BENCHMARKS = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "benchmarks"
-)
 
-# Import the harness the way `python benchmarks/run.py` does.
-if BENCHMARKS not in sys.path:
-    sys.path.insert(0, BENCHMARKS)
-
-import catalog  # noqa: E402
-import run  # noqa: E402
+BENCHMARKS = os.path.dirname(os.path.abspath(run.__file__))
 
 
 @contextlib.contextmanager
@@ -42,9 +35,32 @@ def environment(**values):
                 os.environ[key] = value
 
 
+DJANGO = ("django", "wagtail")
+# Any harness sibling. Forbidden at module level in run.py, where importing one
+# would run its imports too; allowed inside parent functions when the sibling is
+# Django-free, which benchmarks.catalog is and benchmarks.env is not.
+HARNESS = ("benchmarks",)
+BOOTSTRAP = (*DJANGO, "benchmarks.env", "benchmarks.settings")
+
+
 def _source_of(filename):
     with open(os.path.join(BENCHMARKS, filename)) as handle:
         return handle.read()
+
+
+def _imported_names(node):
+    """Every module path an import node names, or () if it is not an import.
+
+    `from benchmarks import env` and `from benchmarks.env import bootstrap`
+    both have to be read as naming benchmarks.env, and one statement can carry
+    several aliases.
+    """
+    if isinstance(node, ast.Import):
+        return tuple(alias.name for alias in node.names)
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        return (module, *(f"{module}.{alias.name}" for alias in node.names))
+    return ()
 
 
 class TestFlowModel(SimpleTestCase):
@@ -139,15 +155,11 @@ class TestCatalogIntegrity(SimpleTestCase):
 
 class TestCatalogNeedsNoDjango(SimpleTestCase):
     def test_the_catalog_module_imports_no_django_at_module_level(self):
-        source = ast.parse(_source_of("catalog.py"))
-        for node in source.body:
-            if isinstance(node, ast.Import | ast.ImportFrom):
-                module = getattr(node, "module", "") or ""
-                names = [alias.name for alias in node.names]
+        for node in ast.parse(_source_of("catalog.py")).body:
+            for name in _imported_names(node):
                 self.assertFalse(
-                    module.startswith(("django", "wagtail"))
-                    or any(n.startswith(("django", "wagtail")) for n in names),
-                    f"catalog.py imports {module or names} at module level",
+                    name.startswith(DJANGO),
+                    f"catalog.py imports {name} at module level",
                 )
 
 
@@ -155,18 +167,11 @@ class TestRunnerParentNeverImportsDjango(SimpleTestCase):
     """The parent must not open a Django connection before copying SQLite."""
 
     def test_run_py_imports_no_django_at_module_level(self):
-        source = ast.parse(_source_of("run.py"))
-        for node in source.body:
-            if isinstance(node, ast.Import | ast.ImportFrom):
-                module = getattr(node, "module", "") or ""
-                names = [alias.name for alias in node.names]
+        for node in ast.parse(_source_of("run.py")).body:
+            for name in _imported_names(node):
                 self.assertFalse(
-                    module.startswith(("django", "wagtail", "env", "catalog"))
-                    or any(
-                        n.startswith(("django", "wagtail", "env", "catalog"))
-                        for n in names
-                    ),
-                    f"run.py imports {module or names} at module level",
+                    name.startswith(DJANGO + HARNESS),
+                    f"run.py imports {name} at module level",
                 )
 
     def test_the_parent_code_path_defers_every_django_import(self):
@@ -177,15 +182,10 @@ class TestRunnerParentNeverImportsDjango(SimpleTestCase):
             if not isinstance(node, ast.FunctionDef) or node.name in child_side:
                 continue
             for inner in ast.walk(node):
-                if isinstance(inner, ast.Import | ast.ImportFrom):
-                    module = getattr(inner, "module", "") or ""
-                    names = [alias.name for alias in inner.names]
+                for name in _imported_names(inner):
                     self.assertFalse(
-                        module.startswith(("django", "wagtail", "env"))
-                        or any(
-                            n.startswith(("django", "wagtail", "env")) for n in names
-                        ),
-                        f"parent function {node.name}() imports {module or names}",
+                        name.startswith(BOOTSTRAP),
+                        f"parent function {node.name}() imports {name}",
                     )
 
 
@@ -376,4 +376,92 @@ class TestOrchestration(SimpleTestCase):
     def test_a_run_with_no_failures_reports_success(self):
         code, attempted = self._run_all(failing_index=None)
         self.assertEqual(code, 0)
+        self.assertEqual(len(attempted), len(catalog.executions()))
+
+
+class TestSingleModuleIdentity(SimpleTestCase):
+    """Loaded flat and as a package, a harness module becomes two objects with
+    separate state. Everything imports it one way."""
+
+    def test_the_harness_modules_are_package_qualified(self):
+        for module in (catalog, run):
+            with self.subTest(module=module.__name__):
+                self.assertTrue(module.__name__.startswith("benchmarks."))
+
+    def test_no_harness_module_imports_a_sibling_by_bare_name(self):
+        siblings = {"catalog", "env", "run", "seed", "settings"}
+        for filename in ("run.py", "catalog.py", "env.py", "seed.py"):
+            for node in ast.walk(ast.parse(_source_of(filename))):
+                for name in _imported_names(node):
+                    with self.subTest(file=filename, imported=name):
+                        self.assertNotIn(name.split(".")[0], siblings)
+
+
+class TestCatalogInvariants(SimpleTestCase):
+    def test_a_flow_declaring_a_workload_unit_declares_scale_points(self):
+        """Without scale points there is no expected_workload to compare an
+        observed one against, so the unit would measure nothing."""
+        for flow in catalog.CATALOG:
+            with self.subTest(flow=flow.name):
+                if flow.workload_unit:
+                    self.assertTrue(flow.scale_points)
+
+
+class TestUnusableChildResult(SimpleTestCase):
+    """A child that prints something the parent cannot read is that execution's
+    failure. The run continues and ends non-zero."""
+
+    def _execute_with_stdout(self, stdout):
+        completed = mock.Mock(returncode=0, stdout=stdout, stderr="")
+        with (
+            mock.patch.object(run, "_child", return_value=completed),
+            mock.patch("shutil.copy"),
+        ):
+            return run.execute(
+                "a_flow", None, "template", "unused-directory", 0, "token"
+            )
+
+    def test_malformed_json_becomes_a_failed_result(self):
+        result = self._execute_with_stdout(f"{run.RESULT_PREFIX}{{not json")
+        self.assertIn("error", result)
+        self.assertNotIn("queries", result)
+
+    def test_a_result_missing_a_field_becomes_a_failed_result(self):
+        result = self._execute_with_stdout(f'{run.RESULT_PREFIX}{{"pid": 1}}')
+        self.assertIn("error", result)
+
+    def test_a_json_value_that_is_not_an_object_becomes_a_failed_result(self):
+        result = self._execute_with_stdout(f"{run.RESULT_PREFIX}[1, 2, 3]")
+        self.assertIn("error", result)
+
+    def test_a_well_formed_result_is_returned(self):
+        payload = (
+            '{"pid": 1, "database": "d", "queries": 7, "seconds": 0.5, '
+            '"observed_workload": null, "expected_workload": null, '
+            '"workload_unit": null}'
+        )
+        result = self._execute_with_stdout(run.RESULT_PREFIX + payload)
+        self.assertNotIn("error", result)
+        self.assertEqual(result["queries"], 7)
+
+    def test_an_unusable_result_does_not_stop_the_rest_of_the_run(self):
+        attempted = []
+
+        def fake_child(args, database, token):
+            attempted.append(args)
+            return mock.Mock(
+                returncode=0, stdout=f"{run.RESULT_PREFIX}{{broken", stderr=""
+            )
+
+        with (
+            mock.patch.object(run, "_build_template", return_value="template"),
+            mock.patch.object(run, "_child", side_effect=fake_child),
+            mock.patch("shutil.copy"),
+            mock.patch.object(sys, "argv", ["run.py", run.ALL]),
+            mock.patch("sys.stdout"),
+            mock.patch("sys.stderr"),
+        ):
+            code = run.main()
+
+        self.assertEqual(code, 1)
         self.assertEqual(len(attempted), len(catalog.executions()))

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -6,6 +6,8 @@ import os
 import sys
 import tempfile
 
+from unittest import mock
+
 from django.test import SimpleTestCase
 
 
@@ -291,3 +293,87 @@ class TestHarnessSettings(SimpleTestCase):
         import benchmarks.settings
 
         self.assertFalse(benchmarks.settings.DEBUG)
+
+
+class TestReservedCatalogNames(SimpleTestCase):
+    def test_no_flow_is_called_all(self):
+        self.assertNotIn(run.ALL, catalog.BY_NAME)
+
+
+class TestExecutionSelection(SimpleTestCase):
+    def test_all_selects_the_whole_catalog_in_order(self):
+        self.assertEqual(run._executions_for(run.ALL, None), list(catalog.executions()))
+
+    def test_all_refuses_a_size(self):
+        with self.assertRaises(ValueError) as raised:
+            run._executions_for(run.ALL, "small")
+        self.assertIn("cannot be used with all", str(raised.exception))
+
+    def test_a_scaled_flow_without_a_size_selects_every_point(self):
+        flow = catalog.BY_NAME["edit_translation_get"]
+        self.assertEqual(
+            run._executions_for("edit_translation_get", None),
+            [(flow, "small"), (flow, "large")],
+        )
+
+    def test_a_scaled_flow_with_a_size_selects_only_that_point(self):
+        flow = catalog.BY_NAME["edit_translation_get"]
+        self.assertEqual(
+            run._executions_for("edit_translation_get", "large"), [(flow, "large")]
+        )
+
+    def test_a_flow_without_scale_points_selects_one_sizeless_execution(self):
+        flow = catalog.BY_NAME["submit_page_post"]
+        self.assertEqual(run._executions_for("submit_page_post", None), [(flow, None)])
+
+    def test_a_flow_without_scale_points_refuses_a_size(self):
+        with self.assertRaises(ValueError) as raised:
+            run._executions_for("submit_page_post", "small")
+        self.assertIn("takes no size", str(raised.exception))
+
+    def test_an_unknown_name_lists_the_valid_ones(self):
+        with self.assertRaises(ValueError) as raised:
+            run._executions_for("no_such_flow", None)
+        message = str(raised.exception)
+        self.assertIn("edit_translation_get", message)
+        self.assertIn(run.ALL, message)
+
+
+class TestOrchestration(SimpleTestCase):
+    """A failing execution must not stop the ones after it."""
+
+    def _run_all(self, failing_index):
+        attempted = []
+
+        def fake_execute(name, size, template, directory, index, token):
+            attempted.append((name, size))
+            if index == failing_index:
+                return {"process": name, "size": size, "error": "deliberate"}
+            return {
+                "process": name,
+                "size": size,
+                "queries": 1,
+                "seconds": 0.0,
+                "workload_unit": None,
+                "expected_workload": None,
+                "observed_workload": None,
+            }
+
+        with (
+            mock.patch.object(run, "_build_template", return_value="template"),
+            mock.patch.object(run, "execute", side_effect=fake_execute),
+            mock.patch.object(sys, "argv", ["run.py", run.ALL]),
+            mock.patch("sys.stdout"),
+            mock.patch("sys.stderr"),
+        ):
+            return run.main(), attempted
+
+    def test_every_execution_is_attempted_and_the_run_reports_failure(self):
+        code, attempted = self._run_all(failing_index=0)
+        self.assertEqual(code, 1)
+        self.assertEqual(len(attempted), len(catalog.executions()))
+
+    def test_a_run_with_no_failures_reports_success(self):
+        code, attempted = self._run_all(failing_index=None)
+        self.assertEqual(code, 0)
+        self.assertEqual(len(attempted), len(catalog.executions()))

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -12,7 +12,8 @@ import tempfile
 
 from unittest import mock
 
-from django.test import SimpleTestCase
+from django.core.management import call_command
+from django.test import SimpleTestCase, TransactionTestCase
 
 from benchmarks import catalog, run
 
@@ -946,3 +947,38 @@ class TestRepeatedExecutions(SimpleTestCase):
             ):
                 run.main()
         self.assertEqual(provenance.call_args.args[0]["repeat"], 4)
+
+
+class TestSmokeFixtureAndFlow(TransactionTestCase):
+    """The one test that builds the fixture and runs a flow for real.
+
+    Every other test here is structural: they read the catalog, the runner's
+    AST, or mocked results, so a change to `tests/testapp`'s models could break
+    `prepare()` or a flow's invariants while CI stays green, and the breakage
+    would only surface the next time somebody ran the harness by hand. This
+    test closes that gap with the cheapest flow in the catalog.
+
+    It is a `TransactionTestCase`, unlike the rest of the suite, because the
+    harness runs in autocommit: under `TestCase`'s wrapping transaction any
+    `on_commit` hooks would be deferred instead of firing where they do in a
+    real run, and the fixture would build under transactional conditions the
+    harness never runs in.
+    """
+
+    def setUp(self):
+        # The testapp settings use DatabaseCache, the test runner does not
+        # create its table, and a Locale receiver touches the cache when the
+        # first locale is created -- the same reason run.py's template build
+        # creates it.
+        call_command("createcachetable", verbosity=0)
+
+    def test_the_cheapest_flow_completes_its_declared_workload(self):
+        context = catalog.prepare()
+        flow = catalog.BY_NAME["core_page_index"]
+
+        if flow.setup:
+            flow.setup(context, "small")
+        artifacts = flow.run(context, "small")
+        observed = flow.verify(context, "small", artifacts)
+
+        self.assertEqual(observed, flow.scale_point("small").expected_workload)

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -139,8 +139,8 @@ class TestCatalogIntegrity(SimpleTestCase):
 
     def test_the_catalog_expands_to_the_executions_it_claims(self):
         expanded = catalog.executions()
-        self.assertEqual(len(catalog.CATALOG), 7)
-        self.assertEqual(len(expanded), 11)
+        self.assertEqual(len(catalog.CATALOG), 8)
+        self.assertEqual(len(expanded), 13)
         self.assertEqual(
             len(expanded), sum(len(flow.sizes()) for flow in catalog.CATALOG)
         )

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -118,10 +118,21 @@ class TestCatalogIntegrity(SimpleTestCase):
 
     def test_the_catalog_expands_to_the_executions_it_claims(self):
         expanded = catalog.executions()
+        self.assertEqual(len(catalog.CATALOG), 2)
+        self.assertEqual(len(expanded), 3)
         self.assertEqual(
             len(expanded), sum(len(flow.sizes()) for flow in catalog.CATALOG)
         )
         self.assertIn((catalog.BY_NAME["edit_translation_get"], "large"), expanded)
+
+    def test_a_flow_without_scale_points_expands_to_a_single_sizeless_execution(self):
+        flow = catalog.BY_NAME["submit_page_post"]
+        self.assertEqual(flow.scale_points, ())
+        self.assertIsNone(flow.workload_unit)
+        self.assertEqual(
+            [pair for pair in catalog.executions() if pair[0] is flow],
+            [(flow, None)],
+        )
 
 
 class TestCatalogNeedsNoDjango(SimpleTestCase):
@@ -258,6 +269,16 @@ class TestChildSelectionGuard(SimpleTestCase):
         with self.assertRaises(SystemExit) as raised:
             run._select("edit_translation_get", None)
         self.assertIn("needs a size", str(raised.exception))
+
+    def test_a_flow_without_scale_points_is_accepted_without_a_size(self):
+        _catalog, flow, point = run._select("submit_page_post", None)
+        self.assertEqual(flow.name, "submit_page_post")
+        self.assertIsNone(point)
+
+    def test_a_size_on_a_flow_without_scale_points_is_refused(self):
+        with self.assertRaises(SystemExit) as raised:
+            run._select("submit_page_post", "small")
+        self.assertIn("takes no size", str(raised.exception))
 
     def test_a_declared_size_is_accepted(self):
         _catalog, flow, point = run._select("edit_translation_get", "large")

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -136,8 +136,8 @@ class TestCatalogIntegrity(SimpleTestCase):
 
     def test_the_catalog_expands_to_the_executions_it_claims(self):
         expanded = catalog.executions()
-        self.assertEqual(len(catalog.CATALOG), 4)
-        self.assertEqual(len(expanded), 5)
+        self.assertEqual(len(catalog.CATALOG), 7)
+        self.assertEqual(len(expanded), 11)
         self.assertEqual(
             len(expanded), sum(len(flow.sizes()) for flow in catalog.CATALOG)
         )
@@ -475,9 +475,19 @@ class TestCatalogOrder(SimpleTestCase):
         editor = order.index("edit_translation_get")
 
         self.assertLess(order.index("submit_page_get"), order.index("submit_page_post"))
-        for name in ("submit_page_get", "submit_page_post", "submit_snippet_post"):
+        for name in (
+            "submit_page_get",
+            "submit_page_post",
+            "submit_snippet_post",
+            "translate_page_subtree",
+        ):
             with self.subTest(flow=name):
                 self.assertLess(order.index(name), editor)
+
+        # Updating an existing translation only makes sense once one exists.
+        for name in ("update_translations_get", "update_translations_post_publish"):
+            with self.subTest(flow=name):
+                self.assertGreater(order.index(name), editor)
 
     def test_the_sizeless_processes_each_expand_to_one_execution(self):
         for name in ("submit_page_get", "submit_page_post", "submit_snippet_post"):

--- a/tests/test_benchmarks_harness.py
+++ b/tests/test_benchmarks_harness.py
@@ -1,0 +1,272 @@
+"""Structural tests for the benchmark harness."""
+
+import ast
+import contextlib
+import os
+import sys
+import tempfile
+
+from django.test import SimpleTestCase
+
+
+BENCHMARKS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "benchmarks"
+)
+
+# Import the harness the way `python benchmarks/run.py` does.
+if BENCHMARKS not in sys.path:
+    sys.path.insert(0, BENCHMARKS)
+
+import catalog  # noqa: E402
+import run  # noqa: E402
+
+
+@contextlib.contextmanager
+def environment(**values):
+    """Set env vars for the duration of a block, restoring what was there."""
+    previous = {key: os.environ.get(key) for key in values}
+    for key, value in values.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _source_of(filename):
+    with open(os.path.join(BENCHMARKS, filename)) as handle:
+        return handle.read()
+
+
+class TestFlowModel(SimpleTestCase):
+    def test_a_flow_without_scale_points_runs_once_with_no_size(self):
+        flow = catalog.Flow(
+            name="x",
+            group="g",
+            why="w",
+            entrypoint="e",
+            covers=(),
+            run=lambda ctx, size: None,
+            verify=lambda ctx, size, a: None,
+        )
+        self.assertEqual(flow.sizes(), (None,))
+        self.assertIsNone(flow.scale_point(None))
+
+    def test_a_flow_with_scale_points_expands_to_one_execution_each(self):
+        flow = catalog.Flow(
+            name="x",
+            group="g",
+            why="w",
+            entrypoint="e",
+            covers=(),
+            run=lambda ctx, size: None,
+            verify=lambda ctx, size, a: None,
+            workload_unit="things",
+            scale_points=(
+                catalog.ScalePoint("small", why="w", expected_workload=1),
+                catalog.ScalePoint("large", why="w", expected_workload=9),
+            ),
+        )
+        self.assertEqual(flow.sizes(), ("small", "large"))
+        self.assertEqual(flow.scale_point("large").expected_workload, 9)
+        self.assertIsNone(flow.scale_point("enormous"))
+
+
+class TestCatalogIntegrity(SimpleTestCase):
+    def test_flow_names_are_unique(self):
+        names = [flow.name for flow in catalog.CATALOG]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_a_flow_declaring_scale_points_declares_two_or_more(self):
+        for flow in catalog.CATALOG:
+            with self.subTest(flow=flow.name):
+                self.assertNotEqual(len(flow.scale_points), 1)
+
+    def test_every_scale_point_declares_the_workload_it_expects(self):
+        for flow in catalog.CATALOG:
+            for point in flow.scale_points:
+                with self.subTest(flow=flow.name, size=point.label):
+                    self.assertIsInstance(point.expected_workload, int)
+                    self.assertGreater(point.expected_workload, 0)
+
+    def test_a_flow_with_scale_points_names_the_unit_they_count(self):
+        for flow in catalog.CATALOG:
+            with self.subTest(flow=flow.name):
+                if flow.scale_points:
+                    self.assertTrue(flow.workload_unit)
+
+    def test_every_flow_is_documented(self):
+        for flow in catalog.CATALOG:
+            with self.subTest(flow=flow.name):
+                self.assertTrue(flow.why)
+                self.assertTrue(flow.entrypoint)
+                self.assertTrue(flow.group)
+
+    def test_expected_workload_grows_with_the_scale_points(self):
+        for flow in catalog.CATALOG:
+            with self.subTest(flow=flow.name):
+                expected = [p.expected_workload for p in flow.scale_points]
+                self.assertEqual(expected, sorted(expected))
+                self.assertEqual(len(expected), len(set(expected)))
+
+    def test_the_catalog_expands_to_the_executions_it_claims(self):
+        expanded = catalog.executions()
+        self.assertEqual(
+            len(expanded), sum(len(flow.sizes()) for flow in catalog.CATALOG)
+        )
+        self.assertIn((catalog.BY_NAME["edit_translation_get"], "large"), expanded)
+
+
+class TestCatalogNeedsNoDjango(SimpleTestCase):
+    def test_the_catalog_module_imports_no_django_at_module_level(self):
+        source = ast.parse(_source_of("catalog.py"))
+        for node in source.body:
+            if isinstance(node, ast.Import | ast.ImportFrom):
+                module = getattr(node, "module", "") or ""
+                names = [alias.name for alias in node.names]
+                self.assertFalse(
+                    module.startswith(("django", "wagtail"))
+                    or any(n.startswith(("django", "wagtail")) for n in names),
+                    f"catalog.py imports {module or names} at module level",
+                )
+
+
+class TestRunnerParentNeverImportsDjango(SimpleTestCase):
+    """The parent must not open a Django connection before copying SQLite."""
+
+    def test_run_py_imports_no_django_at_module_level(self):
+        source = ast.parse(_source_of("run.py"))
+        for node in source.body:
+            if isinstance(node, ast.Import | ast.ImportFrom):
+                module = getattr(node, "module", "") or ""
+                names = [alias.name for alias in node.names]
+                self.assertFalse(
+                    module.startswith(("django", "wagtail", "env", "catalog"))
+                    or any(
+                        n.startswith(("django", "wagtail", "env", "catalog"))
+                        for n in names
+                    ),
+                    f"run.py imports {module or names} at module level",
+                )
+
+    def test_the_parent_code_path_defers_every_django_import(self):
+        source = ast.parse(_source_of("run.py"))
+        child_side = {"run_in_child", "build_template_in_child"}
+
+        for node in source.body:
+            if not isinstance(node, ast.FunctionDef) or node.name in child_side:
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Import | ast.ImportFrom):
+                    module = getattr(inner, "module", "") or ""
+                    names = [alias.name for alias in inner.names]
+                    self.assertFalse(
+                        module.startswith(("django", "wagtail", "env"))
+                        or any(
+                            n.startswith(("django", "wagtail", "env")) for n in names
+                        ),
+                        f"parent function {node.name}() imports {module or names}",
+                    )
+
+
+class TestScalePointLabelsAreUnique(SimpleTestCase):
+    def test_no_flow_declares_the_same_label_twice(self):
+        for flow in catalog.CATALOG:
+            with self.subTest(flow=flow.name):
+                labels = [point.label for point in flow.scale_points]
+                self.assertEqual(len(labels), len(set(labels)))
+
+
+class TestDatabaseGuard(SimpleTestCase):
+    """Internal child commands must refuse databases the harness does not own."""
+
+    def test_a_database_outside_a_harness_directory_is_refused(self):
+        with tempfile.TemporaryDirectory() as outsider:
+            database = os.path.join(outsider, "somebodys-real.sqlite3")
+            contents = b"not a real database, and must stay that way"
+            with open(database, "wb") as handle:
+                handle.write(contents)
+
+            with (
+                environment(
+                    **{run.DB_ENV_VAR: database, run.TOKEN_ENV_VAR: "any-token"}
+                ),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                run.guard_database()
+
+            self.assertIn("refusing to use", str(raised.exception))
+            with open(database, "rb") as handle:
+                self.assertEqual(handle.read(), contents)
+
+    def test_a_missing_token_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run._own_directory(directory)
+            database = os.path.join(directory, "run-00.sqlite3")
+
+            with (
+                environment(**{run.DB_ENV_VAR: database, run.TOKEN_ENV_VAR: None}),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                run.guard_database()
+
+            self.assertIn(run.TOKEN_ENV_VAR, str(raised.exception))
+
+    def test_a_wrong_token_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run._own_directory(directory)
+            database = os.path.join(directory, "run-00.sqlite3")
+
+            with (
+                environment(
+                    **{run.DB_ENV_VAR: database, run.TOKEN_ENV_VAR: "not-the-token"}
+                ),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                run.guard_database()
+
+            self.assertIn("token does not match", str(raised.exception))
+
+    def test_the_harness_own_directory_is_accepted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            token = run._own_directory(directory)
+            database = os.path.join(directory, "run-00.sqlite3")
+
+            with environment(**{run.DB_ENV_VAR: database, run.TOKEN_ENV_VAR: token}):
+                self.assertEqual(run.guard_database(), os.path.realpath(database))
+
+
+class TestChildSelectionGuard(SimpleTestCase):
+    def test_an_unknown_flow_is_refused(self):
+        with self.assertRaises(SystemExit) as raised:
+            run._select("no_such_flow", "small")
+        self.assertIn("unknown flow", str(raised.exception))
+
+    def test_an_undeclared_size_is_refused(self):
+        with self.assertRaises(SystemExit) as raised:
+            run._select("edit_translation_get", "enormous")
+        self.assertIn("no size", str(raised.exception))
+
+    def test_a_flow_with_scale_points_requires_one(self):
+        with self.assertRaises(SystemExit) as raised:
+            run._select("edit_translation_get", None)
+        self.assertIn("needs a size", str(raised.exception))
+
+    def test_a_declared_size_is_accepted(self):
+        _catalog, flow, point = run._select("edit_translation_get", "large")
+        self.assertEqual(flow.name, "edit_translation_get")
+        self.assertEqual(point.expected_workload, 42)
+
+
+class TestHarnessSettings(SimpleTestCase):
+    def test_the_harness_settings_turn_debug_off(self):
+        import benchmarks.settings
+
+        self.assertFalse(benchmarks.settings.DEBUG)

--- a/tests/test_benchmarks_query_doctor.py
+++ b/tests/test_benchmarks_query_doctor.py
@@ -1,0 +1,513 @@
+"""Structural tests for the Query Doctor runner.
+
+The runner is a manual diagnostic tool, so these tests do not diagnose
+anything: they check the properties that keep it separate from the benchmark
+harness — that it needs no Query Doctor to list or to refuse a selection, that
+it diagnoses the flow's own call and nothing around it, and that run.py is not
+dragged along with it.
+
+They run in an environment that may or may not have django-query-doctor
+installed, so nothing here may depend on either.
+"""
+
+import ast
+import builtins
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+
+from types import SimpleNamespace
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from benchmarks import catalog, run, run_query_doctor
+
+
+BENCHMARKS = os.path.dirname(os.path.abspath(run.__file__))
+
+DJANGO = ("django", "wagtail")
+QUERY_DOCTOR = ("query_doctor",)
+BOOTSTRAP = (*DJANGO, "benchmarks.env", "benchmarks.settings")
+
+
+def _source_of(filename):
+    with open(os.path.join(BENCHMARKS, filename)) as handle:
+        return handle.read()
+
+
+def _imported_names(node):
+    """Every module path an import node names, or () if it is not an import."""
+    if isinstance(node, ast.Import):
+        return tuple(alias.name for alias in node.names)
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        return (module, *(f"{module}.{alias.name}" for alias in node.names))
+    return ()
+
+
+@contextlib.contextmanager
+def query_doctor_missing():
+    """Make importing Query Doctor fail, whatever this environment has.
+
+    The runner has to behave the same for someone who never installed the tool,
+    and the test suite must not need it either.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "query_doctor" or name.startswith("query_doctor."):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "query_doctor":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    with (
+        mock.patch.object(builtins, "__import__", side_effect=fake_import),
+        mock.patch.object(importlib.util, "find_spec", side_effect=fake_find_spec),
+    ):
+        yield
+
+
+def _flow(**overrides):
+    """A catalog Flow whose callables are whatever a test needs."""
+    fields = {
+        "name": "fake_flow",
+        "group": "fake",
+        "why": "w",
+        "entrypoint": "e",
+        "covers": (),
+        "run": lambda ctx, size: None,
+        "verify": lambda ctx, size, artifacts: None,
+    }
+    fields.update(overrides)
+    return catalog.Flow(**fields)
+
+
+def _report(**overrides):
+    """Enough of a DiagnosisReport for the runner to print."""
+    fields = {"total_queries": 3, "total_time_ms": 1.5, "prescriptions": []}
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+@contextlib.contextmanager
+def _child_environment(flow, events, report=None, prepared="ctx"):
+    """Everything the child touches, replaced by something that records.
+
+    No database, no Django bootstrap and no Query Doctor: what is under test is
+    the order of the calls and where the diagnosis begins and ends.
+    """
+
+    @contextlib.contextmanager
+    def fake_diagnose_queries():
+        events.append("diagnose:enter")
+        yield report if report is not None else _report()
+        events.append("diagnose:exit")
+
+    def fake_prepare():
+        events.append("prepare")
+        return prepared
+
+    with (
+        mock.patch.object(run, "guard_database", return_value="db"),
+        mock.patch.dict(catalog.BY_NAME, {flow.name: flow}),
+        mock.patch.object(catalog, "prepare", side_effect=fake_prepare),
+        mock.patch("benchmarks.env.bootstrap"),
+        mock.patch.object(
+            run_query_doctor, "_diagnose_queries", return_value=fake_diagnose_queries
+        ),
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def _captured_stdout():
+    stream = io.StringIO()
+    with mock.patch.object(sys, "stdout", stream):
+        yield stream
+
+
+class TestListingNeedsNothing(SimpleTestCase):
+    """--list is a catalog listing. It has to work in an environment with no
+    Query Doctor and no database, exactly like run.py --list."""
+
+    def test_the_module_imports_no_query_doctor_and_no_django_at_module_level(self):
+        for node in ast.parse(_source_of("run_query_doctor.py")).body:
+            for name in _imported_names(node):
+                self.assertFalse(
+                    name.startswith(DJANGO + QUERY_DOCTOR),
+                    f"run_query_doctor.py imports {name} at module level",
+                )
+
+    def test_the_parent_code_path_defers_every_django_import(self):
+        source = ast.parse(_source_of("run_query_doctor.py"))
+        child_side = {"diagnose_in_child"}
+
+        for node in source.body:
+            if not isinstance(node, ast.FunctionDef) or node.name in child_side:
+                continue
+            for inner in ast.walk(node):
+                for name in _imported_names(inner):
+                    self.assertFalse(
+                        name.startswith(BOOTSTRAP),
+                        f"parent function {node.name}() imports {name}",
+                    )
+
+    def test_listing_works_without_query_doctor(self):
+        with (
+            query_doctor_missing(),
+            mock.patch.object(sys, "argv", ["run_query_doctor.py", "--list"]),
+            _captured_stdout() as stdout,
+        ):
+            code = run_query_doctor.main()
+
+        self.assertEqual(code, 0)
+        self.assertIn("edit_translation_get", stdout.getvalue())
+
+    def test_listing_does_not_look_for_query_doctor_at_all(self):
+        with (
+            mock.patch.object(run_query_doctor, "_query_doctor_installed") as installed,
+            mock.patch.object(run_query_doctor, "_diagnose_queries") as diagnose,
+            mock.patch.object(sys, "argv", ["run_query_doctor.py", "--list"]),
+            _captured_stdout(),
+        ):
+            run_query_doctor.main()
+
+        installed.assert_not_called()
+        diagnose.assert_not_called()
+
+
+class TestSelectionIsRefusedEarly(SimpleTestCase):
+    """An impossible selection is worth a message, not a migrated database."""
+
+    def _main(self, argv):
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(run, "_build_template") as build_template,
+            mock.patch.object(run_query_doctor, "diagnose") as diagnose,
+            mock.patch.object(sys, "argv", ["run_query_doctor.py", *argv]),
+            mock.patch.object(sys, "stderr", stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            run_query_doctor.main()
+        return str(raised.exception), stderr.getvalue(), build_template, diagnose
+
+    def test_an_unknown_flow_names_the_known_ones(self):
+        _code, message, build_template, diagnose = self._main(["no_such_flow"])
+        self.assertIn("unknown flow", message)
+        self.assertIn("edit_translation_get", message)
+        build_template.assert_not_called()
+        diagnose.assert_not_called()
+
+    def test_an_undeclared_size_is_refused(self):
+        _code, message, build_template, _ = self._main(
+            ["edit_translation_get", "--size", "enormous"]
+        )
+        self.assertIn("no size 'enormous'", message)
+        self.assertIn("small, large", message)
+        build_template.assert_not_called()
+
+    def test_a_size_on_a_flow_without_scale_points_is_refused(self):
+        _code, message, build_template, _ = self._main(
+            ["submit_snippet_post", "--size", "small"]
+        )
+        self.assertIn("takes no size", message)
+        build_template.assert_not_called()
+
+    def test_no_flow_and_no_list_is_refused(self):
+        _code, message, build_template, _ = self._main([])
+        self.assertIn("give a flow name", message)
+        build_template.assert_not_called()
+
+    def test_all_selects_the_whole_catalog(self):
+        """The plan for `all` is run.py's, so the two commands cover the same
+        executions in the same order."""
+        selected = []
+
+        def fake_diagnose(name, size, template, directory, index, token):
+            selected.append((name, size))
+            return True
+
+        with (
+            mock.patch.object(run, "_build_template", return_value="template"),
+            mock.patch.object(
+                run_query_doctor, "_query_doctor_installed", return_value=True
+            ),
+            mock.patch.object(run_query_doctor, "diagnose", side_effect=fake_diagnose),
+            mock.patch.object(sys, "argv", ["run_query_doctor.py", run.ALL]),
+            mock.patch.object(sys, "stderr", io.StringIO()),
+            _captured_stdout(),
+        ):
+            code = run_query_doctor.main()
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            selected, [(flow.name, size) for flow, size in catalog.executions()]
+        )
+
+
+class TestMissingQueryDoctorSaysSo(SimpleTestCase):
+    def test_the_parent_stops_before_building_anything(self):
+        with (
+            query_doctor_missing(),
+            mock.patch.object(run, "_build_template") as build_template,
+            mock.patch.object(sys, "argv", ["run_query_doctor.py", run.ALL]),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            run_query_doctor.main()
+
+        message = str(raised.exception)
+        self.assertIn("django-query-doctor is not installed", message)
+        self.assertIn("benchmarks/README.md", message)
+        build_template.assert_not_called()
+
+    def test_the_child_says_the_same_thing(self):
+        with query_doctor_missing(), self.assertRaises(SystemExit) as raised:
+            run_query_doctor._diagnose_queries()
+
+        self.assertIn("django-query-doctor is not installed", str(raised.exception))
+
+
+class TestTheDiagnosedRegion(SimpleTestCase):
+    """Fixture, setup and verification are scaffolding: their queries would be
+    attributed to the flow if they ran inside the diagnosis."""
+
+    @staticmethod
+    def _recorder(events, label):
+        """A flow callable that only says it was called."""
+
+        def call(*args):
+            events.append(label)
+
+        return call
+
+    def test_prepare_setup_run_and_verify_happen_in_that_order(self):
+        events = []
+        flow = _flow(
+            setup=self._recorder(events, "setup"),
+            run=self._recorder(events, "run"),
+            verify=self._recorder(events, "verify"),
+        )
+
+        with _child_environment(flow, events), _captured_stdout():
+            run_query_doctor.diagnose_in_child(flow.name, None)
+
+        self.assertEqual(
+            events,
+            ["prepare", "setup", "diagnose:enter", "run", "diagnose:exit", "verify"],
+        )
+
+    def test_a_flow_without_setup_is_diagnosed_the_same_way(self):
+        events = []
+        flow = _flow(
+            run=self._recorder(events, "run"), verify=self._recorder(events, "verify")
+        )
+
+        with _child_environment(flow, events), _captured_stdout():
+            run_query_doctor.diagnose_in_child(flow.name, None)
+
+        self.assertEqual(
+            events, ["prepare", "diagnose:enter", "run", "diagnose:exit", "verify"]
+        )
+
+    def test_the_flow_receives_the_prepared_fixture_and_the_size(self):
+        seen = {}
+
+        def setup(ctx, size):
+            seen["setup"] = (ctx, size)
+
+        def run_flow(ctx, size):
+            seen["run"] = (ctx, size)
+            return "artifacts"
+
+        def verify(ctx, size, artifacts):
+            seen["verify"] = (ctx, size, artifacts)
+            return 1
+
+        flow = _flow(
+            scale_points=(catalog.ScalePoint("small", why="w", expected_workload=1),),
+            workload_unit="things",
+            setup=setup,
+            run=run_flow,
+            verify=verify,
+        )
+
+        with _child_environment(flow, []), _captured_stdout():
+            run_query_doctor.diagnose_in_child(flow.name, "small")
+
+        self.assertEqual(seen["setup"], ("ctx", "small"))
+        self.assertEqual(seen["run"], ("ctx", "small"))
+        self.assertEqual(seen["verify"], ("ctx", "small", "artifacts"))
+
+
+class TestObservedWorkloadIsChecked(SimpleTestCase):
+    """The same rule the harness applies: a diagnosis of a scenario that did
+    not build explains something else."""
+
+    def _flow_observing(self, observed):
+        return _flow(
+            workload_unit="things",
+            scale_points=(catalog.ScalePoint("small", why="w", expected_workload=7),),
+            verify=lambda ctx, size, artifacts: observed,
+        )
+
+    def test_a_workload_that_does_not_match_fails(self):
+        flow = self._flow_observing(3)
+        with (
+            _child_environment(flow, []),
+            _captured_stdout(),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            run_query_doctor.diagnose_in_child(flow.name, "small")
+
+        message = str(raised.exception)
+        self.assertIn("produced 3 things", message)
+        self.assertIn("declares 7", message)
+
+    def test_a_matching_workload_is_reported(self):
+        flow = self._flow_observing(7)
+        with _child_environment(flow, []), _captured_stdout() as stdout:
+            run_query_doctor.diagnose_in_child(flow.name, "small")
+
+        self.assertIn("7 things", stdout.getvalue())
+
+    def test_a_flow_without_scale_points_has_no_workload_to_check(self):
+        flow = _flow(verify=lambda ctx, size, artifacts: None)
+        with _child_environment(flow, []), _captured_stdout() as stdout:
+            run_query_doctor.diagnose_in_child(flow.name, None)
+
+        self.assertIn("fake_flow [-]", stdout.getvalue())
+
+
+class TestReportPlacesItsFindings(SimpleTestCase):
+    """A page of prescriptions nobody can place is not a diagnosis: the same
+    flow reports differently at each scale point."""
+
+    def _print(self, report, size="small", observed=7):
+        flow = _flow(
+            workload_unit="things",
+            scale_points=(catalog.ScalePoint("small", why="w", expected_workload=7),),
+        )
+        with _captured_stdout() as stdout:
+            run_query_doctor.print_report(flow.name, size, flow, observed, report)
+        return stdout.getvalue()
+
+    def test_the_header_names_the_flow_size_and_observed_workload(self):
+        output = self._print(_report())
+        self.assertIn("fake_flow [small]", output)
+        self.assertIn("7 things", output)
+        self.assertIn("3 queries", output)
+
+    def test_a_clean_flow_says_so(self):
+        self.assertIn("no prescriptions", self._print(_report()))
+
+    def test_prescriptions_are_printed_worst_first(self):
+        def prescription(severity, issue, count, description):
+            return SimpleNamespace(
+                severity=SimpleNamespace(value=severity),
+                issue_type=SimpleNamespace(value=issue),
+                query_count=count,
+                description=description,
+                fix_suggestion=f"fix {description}",
+                callsite=SimpleNamespace(
+                    filepath="models.py", line_number=10, function_name="save"
+                ),
+            )
+
+        output = self._print(
+            _report(
+                prescriptions=[
+                    prescription("info", "fat_select", 1, "wide"),
+                    prescription("warning", "duplicate_query", 2, "repeated"),
+                    prescription("critical", "n_plus_one", 40, "fanned out"),
+                ]
+            )
+        )
+
+        self.assertLess(output.index("fanned out"), output.index("repeated"))
+        self.assertLess(output.index("repeated"), output.index("wide"))
+        self.assertIn("CRITICAL  n_plus_one  (40 queries)", output)
+        self.assertIn("fix: fix fanned out", output)
+        self.assertIn("at models.py:10 in save", output)
+
+
+class TestTheBenchmarkRunnerIsUnaffected(SimpleTestCase):
+    """Two independent commands. run.py must keep working, and keep measuring
+    the same thing, in an environment that has never heard of Query Doctor."""
+
+    def test_run_py_never_mentions_query_doctor(self):
+        for filename in ("run.py", "catalog.py", "env.py", "seed.py", "settings.py"):
+            with self.subTest(file=filename):
+                self.assertNotIn("query_doctor", _source_of(filename))
+
+    def test_no_harness_module_imports_the_diagnostic_runner(self):
+        for filename in ("run.py", "catalog.py", "env.py", "seed.py"):
+            for node in ast.walk(ast.parse(_source_of(filename))):
+                for name in _imported_names(node):
+                    with self.subTest(file=filename, imported=name):
+                        self.assertNotIn("run_query_doctor", name)
+
+    def test_the_benchmark_runner_runs_without_query_doctor(self):
+        """main() end to end with the executions faked, in an environment where
+        importing Query Doctor raises."""
+        attempted = []
+
+        def fake_execute(name, size, template, directory, index, token):
+            attempted.append((name, size))
+            return {
+                "process": name,
+                "size": size,
+                "queries": 1,
+                "seconds": 0.0,
+                "workload_unit": None,
+                "expected_workload": None,
+                "observed_workload": None,
+            }
+
+        with (
+            query_doctor_missing(),
+            mock.patch.object(run, "_build_template", return_value="template"),
+            mock.patch.object(run, "execute", side_effect=fake_execute),
+            mock.patch.object(sys, "argv", ["run.py", run.ALL]),
+            mock.patch("sys.stdout"),
+            mock.patch("sys.stderr"),
+        ):
+            code = run.main()
+
+        self.assertEqual(code, 0)
+        self.assertEqual(len(attempted), len(catalog.executions()))
+
+    def test_the_diagnostic_runner_reuses_the_harness_rather_than_copying_it(self):
+        """Selection, ownership and the template come from run.py. If they were
+        restated here they could drift, and the two commands would stop
+        describing the same executions."""
+        source = _source_of("run_query_doctor.py")
+        for attribute in (
+            "run._executions_for",
+            "run._select",
+            "run._own_directory",
+            "run._build_template",
+            "run.guard_database",
+        ):
+            with self.subTest(attribute=attribute):
+                self.assertIn(attribute, source)
+
+
+class TestSingleModuleIdentity(SimpleTestCase):
+    def test_the_runner_is_package_qualified(self):
+        self.assertTrue(run_query_doctor.__name__.startswith("benchmarks."))
+
+    def test_it_imports_no_sibling_by_bare_name(self):
+        siblings = {"catalog", "env", "run", "seed", "settings"}
+        for node in ast.walk(ast.parse(_source_of("run_query_doctor.py"))):
+            for name in _imported_names(node):
+                with self.subTest(imported=name):
+                    self.assertNotIn(name.split(".")[0], siblings)


### PR DESCRIPTION
## Summary

Adds a performance benchmark harness for reproducible measurement and diagnosis of translation flows, and for validating optimizations to them later. Refs wagtail/wagtail-localize#938.

## What it does

The harness runs real translation operations in an isolated process against a clean database, and records query count and time.

The harness defines a catalogue of eight named flows, each representing a real translation operation, such as submitting a page for translation, translating a snippet, syncing a page tree, or refreshing segments. A flow can declare two input sizes, so results show how its cost grows rather than only its total, and it can be repeated to summarise timing variance. `--list` prints the catalogue, including what each flow covers.

```console
$ python benchmarks/run.py core_page_index --repeat 5
core_page_index [small]  119 queries  25.5 ms median (min 23.8, max 29.2, 5 repeats)  24 indexed_pages (expected 24)
core_page_index [large]  319 queries  68.1 ms median (min 64.6, max 80.1, 5 repeats)  64 indexed_pages (expected 64)
```

Query counts are identical across repeats; time varies, so it is reported as median, minimum, and maximum. Fixture construction and verification stay outside the measured section. The run fails if its observed workload differs from the catalogue's expected workload, because measuring a scenario that did not build would describe something else. `--json PATH` additionally writes the run with its commit, branch, and dependency versions, so any number can be reproduced. The optimisation for this flow is deliberately out of scope for this PR and is tracked separately.

`benchmarks/run_query_doctor.py` is a separate, manual command that runs the same flow under Django Query Doctor to explain *why* a number is what it is, including a fix suggestion when Query Doctor has one. `run.py` does not import it, does not know it exists, and runs unchanged in an environment where the tool is not installed.

## Developer tooling, not a CI gate

The harness is run by hand when investigating or validating a change. Query-count regression protection stays where it already lives: `assertNumQueries` / `CaptureQueriesContext` in targeted product tests, added per fix.

Concretely, in CI:

- the harness's tests run in the existing matrix, with no new dependencies: structural tests for the runner and catalogue, plus one in-process smoke test that builds the fixture and runs the cheapest flow, so a change to the test app's models that breaks the fixture fails in CI rather than on the next manual run;
- the benchmarks themselves do not run;
- Query Doctor is not involved at all — its test suite passes without it installed.

## Scope

- Adds developer tooling under `benchmarks/`; kept in the repository but shipped in neither the wheel nor the sdist. Since #945 the sdist is built from an explicit `include` list in `[tool.flit.sdist]`, and `benchmarks/` is not on it.
- Adds tests for the harness and for the Query Doctor command.
- Does not modify `src/wagtail_localize`, runtime dependencies, or product behaviour.
- Benchmark and Query Doctor commands run only when explicitly invoked.

### AI usage

AI-assisted: an LLM helped design and implement the harness (catalogue, runner, and tests) iteratively across several sessions, and helped draft this description. All changes were reviewed, tested, and understood.
