### PR TITLE
Fix warning about inconsistent ordering

### DIFF
--- a/src/wagtail_localize/views/report.py
+++ b/src/wagtail_localize/views/report.py
@@ -176,4 +176,4 @@ class TranslationsReportView(ReportView):
                 )
                 .filter(is_translated=False)
             )
-        )
+        ).order_by("pk")


### PR DESCRIPTION
### Description

Fixes this warning in the testsuite output

	UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'wagtail_localize.models.Translation'> QuerySet.


### AI usage

None
