### PR TITLE
Optimize PageIndex.from_database() to use a constant query count

### DIFF
--- a/src/wagtail_localize/synctree.py
+++ b/src/wagtail_localize/synctree.py
@@ -63,31 +63,31 @@ class PageIndex:
         ]
 
         @classmethod
-        def from_page_instance(cls, page):
+        def from_page_instance(
+            cls, page, locales_by_key, aliased_locales_by_key, translation_key_by_path
+        ):
             """
             Initialises an Entry from the given page instance.
+
+            The three mappings cover the whole tree and are built once by
+            from_database(): which locales have a real page for a translation
+            key, which have an alias, and which translation key belongs to a
+            given path.
             """
             # Get parent, but only if the parent is not the root page. We consider the
             # homepage of each langauge tree to be the roots
-            parent_page = page.get_parent() if page.depth > 2 else None
+            parent_path = page.path[: -Page.steplen] if page.depth > 2 else None
+            parent_translation_key = (
+                translation_key_by_path.get(parent_path) if parent_path else None
+            )
 
             return cls(
                 page.content_type,
                 page.translation_key,
                 page.locale,
-                parent_page.translation_key if parent_page else None,
-                list(
-                    Page.objects.filter(
-                        translation_key=page.translation_key,
-                        alias_of__isnull=True,
-                    ).values_list("locale", flat=True)
-                ),
-                list(
-                    Page.objects.filter(
-                        translation_key=page.translation_key,
-                        alias_of__isnull=False,
-                    ).values_list("locale", flat=True)
-                ),
+                parent_translation_key,
+                locales_by_key.get(page.translation_key, []),
+                aliased_locales_by_key.get(page.translation_key, []),
             )
 
     def __init__(self, pages):
@@ -148,11 +148,35 @@ class PageIndex:
         Populates the index from the database.
         """
         pages = []
+        translation_key_by_path = {}
+        locales_by_key = defaultdict(list)
+        aliased_locales_by_key = defaultdict(list)
 
-        for page in Page.objects.filter(alias_of__isnull=True, depth__gt=1).only(
-            *PageIndex.Entry.REQUIRED_PAGE_FIELDS
+        # Every page in the tree, aliases included: the aliases are what
+        # aliased_locales is built from. Only the root is left out, because it
+        # is not indexed and no page looks it up as a parent.
+        for translation_key, locale_id, alias_of_id, path in Page.objects.filter(
+            depth__gt=1
+        ).values_list("translation_key", "locale_id", "alias_of_id", "path"):
+            translation_key_by_path[path] = translation_key
+            if alias_of_id is None:
+                locales_by_key[translation_key].append(locale_id)
+            else:
+                aliased_locales_by_key[translation_key].append(locale_id)
+
+        for page in (
+            Page.objects.filter(alias_of__isnull=True, depth__gt=1)
+            .select_related("content_type", "locale")
+            .only(*PageIndex.Entry.REQUIRED_PAGE_FIELDS)
         ):
-            pages.append(PageIndex.Entry.from_page_instance(page))
+            pages.append(
+                PageIndex.Entry.from_page_instance(
+                    page,
+                    locales_by_key,
+                    aliased_locales_by_key,
+                    translation_key_by_path,
+                )
+            )
 
         return PageIndex(pages)
 

--- a/tests/test_synctree.py
+++ b/tests/test_synctree.py
@@ -1,5 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from wagtail.models import Locale, Page
 from wagtail.test.utils import WagtailTestUtils
@@ -91,6 +93,45 @@ class TestPageIndex(TestCase):
         )
         self.assertEqual(canadaonlypage_entry.locales, [self.fr_ca_locale.id])
         self.assertEqual(canadaonlypage_entry.aliased_locales, [])
+
+    def _add_pages(self, count, start=0):
+        """Pages that each have a translation and an alias, so that every entry
+        the index builds has both `locales` and `aliased_locales` to fill."""
+        for index in range(start, start + count):
+            page = self.en_homepage.add_child(
+                instance=TestPage(title=f"Page {index}", slug=f"page-{index}")
+            )
+            translation = page.copy_for_translation(self.fr_locale)
+            translation.copy_for_translation(self.fr_ca_locale, alias=True)
+
+    def _count_index_queries(self):
+        with CaptureQueriesContext(connection) as captured:
+            PageIndex.from_database()
+        return len(captured)
+
+    def test_from_database_query_count_does_not_grow_with_the_tree(self):
+        """from_database() reads the whole tree in a fixed number of queries.
+
+        It used to issue five per page: the parent lookup, the content type, the
+        locale, and the two lookups behind `locales` and `aliased_locales`.
+        What this protects is the property rather than the number: the count
+        must not depend on how large the tree is.
+        """
+        fr_homepage = self.en_homepage.copy_for_translation(self.fr_locale)
+        fr_homepage.copy_for_translation(self.fr_ca_locale)
+
+        self._add_pages(2)
+        small = self._count_index_queries()
+
+        self._add_pages(20, start=2)
+        large = self._count_index_queries()
+
+        self.assertEqual(
+            small,
+            large,
+            "from_database() issued more queries for the larger tree, so its "
+            "cost grew with the number of pages again.",
+        )
 
 
 class TestSignalsAndHooks(TestCase, WagtailTestUtils):


### PR DESCRIPTION
Closes #927.

## Summary

`PageIndex.from_database()` builds an index that `synchronize_tree()` uses, and building it cost five queries for every indexed page: the parent lookup, the content type, the locale, and one query each for the locales the page already exists in and the locales it is aliased into. The total therefore grew linearly with the size of the page tree.

This PR takes a measurement-driven approach. It first uses the benchmark harness and its supporting analysis tools to establish a baseline and attribute the growing query count to its call sites. It then updates `PageIndex.from_database()` to build three mappings in a single pass — which locales have a real page for a translation key, which have an alias, and which translation key belongs to a given path — and to preload `content_type` and `locale` for the indexed pages. This reduces the method to two queries regardless of page tree size.

The bulk pass includes aliases, because `aliased_locales` is built from them, and excludes only the root page, which is not indexed and is never resolved as a parent — `from_page_instance()` looks for a parent only below depth 2, and the pages at depth 2 are the locale homepages.

`PageIndex.Entry.from_page_instance()` now receives those mappings as arguments. It is covered by the generated API reference, so its published signature changes with it.

Finally, it adds a regression test that expands the page tree and verifies that the query count does not grow, preserving the constant-query property in the regular test suite.

## Measurements

The benchmark harness runs a flow at two input sizes, each in its own process against its own fresh database, and reports the query count for each. A separate command runs the same flow and attributes that count to the code that produced it. Both were used here, in that order. Every output below is behind a toggle.

| | Before | After |
|---|---:|---:|
| Queries at 24 indexed pages | 119 | 2 |
| Queries at 64 indexed pages | 319 | 2 |
| Query growth | 5.00 per page | None |
| Median time at 64 indexed pages | 63.3 ms | 2.8 ms |

### 1. Establish the baseline

Two hundred more queries for forty more pages: five per indexed page. This says the cost grows with the tree and how fast, but not where the queries come from.

<details>
<summary>Output — <code>run.py core_page_index --repeat 5</code></summary>

```console
core_page_index [small]  119 queries  24.2 ms median (min 23.6, max 25.3, 5 repeats)  24 indexed_pages (expected 24)
core_page_index [large]  319 queries  63.3 ms median (min 62.0, max 66.4, 5 repeats)  64 indexed_pages (expected 64)
```

`(expected 24)` and `(expected 64)` confirm the fixture built the scenario the flow declares, so the numbers describe the intended workload. The run fails rather than reports if they disagree. Query counts were identical across all five repetitions.

</details>

### 2. Attribute the count to its call sites

Five call sites each add one query per indexed page: the parent lookup, the two unloaded foreign keys, and one query each for the locales the page already exists in and the locales it is aliased into. A sixth group is the queryset that fetches the pages, and it does not grow.

That list is what the change had to remove, and it decided the shape of the fix: three mappings built in one pass for the three that vary by translation key or path, and `select_related` for the two foreign keys.

<details>
<summary>Output — <code>run_attribution.py core_page_index</code></summary>

```console
core_page_index: 24 -> 64 indexed_pages
  small   119 queries  = 119 attributed + 0 outside execute_wrapper
  large   319 queries  = 319 attributed + 0 outside execute_wrapper

  Growth drivers (5 of 5 growing groups)
     +1.00/indexed_pages     22 -> 62     synctree.py:72 in from_page_instance  (fixed -2)
             SELECT "wagtailcore_page"."id", "wagtailcore_page"."path", ...
     +1.00/indexed_pages     24 -> 64     synctree.py:75 in from_page_instance
             SELECT "django_content_type"."id", "django_content_type"."app_label", ...
     +1.00/indexed_pages     24 -> 64     synctree.py:77 in from_page_instance
             SELECT "wagtailcore_locale"."id", "wagtailcore_locale"."language_code" ...
     +1.00/indexed_pages     24 -> 64     synctree.py:79 in from_page_instance
             SELECT "wagtailcore_page"."locale_id" AS "locale" ... WHERE alias_of_id IS NULL
     +1.00/indexed_pages     24 -> 64     synctree.py:85 in from_page_instance
             SELECT "wagtailcore_page"."locale_id" AS "locale" ... WHERE alias_of_id IS NOT NULL

  Largest fixed cost (1 of 1 constant groups)
         1 fixed       1 -> 1      synctree.py:152 in from_database
             SELECT "wagtailcore_page"."id", "wagtailcore_page"."path", ...
```

The first two lines reconcile the attribution against the harness's own counter: every query the harness counted has a call site here. Line 72 sits two below the workload at both sizes because the parent lookup is skipped for the locale homepages.

</details>

### 3. Cross-check with an outside tool

Django Query Doctor reports two critical N+1 findings, for the unloaded `content_type` and `locale` foreign keys. Those are two of the five sources. The other three carry a different translation key on each call, so the statements are never textually identical and its repeated-query detection does not group them.

<details>
<summary>Output — <code>run_query_doctor.py core_page_index --size small</code></summary>

```console
core_page_index [small]  24 indexed_pages
  119 queries, 2.5 ms of database time under diagnosis
  25 prescription(s)

  CRITICAL  n_plus_one  (24 queries)
    N+1 detected: 24 queries for table "django_content_type" (field: content_type)
    fix: Add .select_related('content_type') to your queryset
    at src/wagtail_localize/synctree.py:75 in from_page_instance

  CRITICAL  n_plus_one  (24 queries)
    N+1 detected: 24 queries for table "wagtailcore_locale" (field: locale)
    fix: Add .select_related('locale') to your queryset
    at src/wagtail_localize/synctree.py:77 in from_page_instance
```

The remaining 23 prescriptions are 22 `duplicate_query` warnings of two to four queries each, and one informational note about a missing index on `depth` in Wagtail's `Page` model.

</details>

### 4. Measure again after the change

The same size difference now costs nothing. The two queries that remain are the bulk pass and the page queryset, and neither grows. Query Doctor drops to a single informational finding and reports no N+1.

<details>
<summary>Output — the same three commands after the change</summary>

```console
$ python benchmarks/run.py core_page_index --repeat 5
core_page_index [small]  2 queries  1.6 ms median (min 1.5, max 1.7, 5 repeats)  24 indexed_pages (expected 24)
core_page_index [large]  2 queries  2.8 ms median (min 2.6, max 2.8, 5 repeats)  64 indexed_pages (expected 64)
```

```console
$ python benchmarks/run_attribution.py core_page_index
core_page_index: 24 -> 64 indexed_pages
  small     2 queries  = 2 attributed + 0 outside execute_wrapper
  large     2 queries  = 2 attributed + 0 outside execute_wrapper

  Growth drivers (0 of 0 growing groups)
    none

  Largest fixed cost (2 of 2 constant groups)
         1 fixed       1 -> 1      synctree.py:158 in from_database
         1 fixed       1 -> 1      synctree.py:168 in from_database
```

```console
$ python benchmarks/run_query_doctor.py core_page_index --size small
core_page_index [small]  24 indexed_pages
  2 queries, 0.2 ms of database time under diagnosis
  1 prescription(s)
```

The one remaining prescription is the missing index on `depth`, which is present before the change as well and belongs to Wagtail's own `Page` model.

</details>

<details>
<summary>Environment and provenance</summary>

Python 3.12.13, Django 6.1, Wagtail 7.4.2, wagtail-localize 1.13, SQLite.

Both runs were adjacent, on the same machine, with the same repetition count and a clean working tree. The harness records the commit, branch, working-tree cleanliness and dependency versions alongside every reported number, and refuses to treat a run as a baseline unless all of them are in order.

</details>

## Tests

- Added a regression test that compares query counts before and after expanding the tree, asserting that the count remains constant rather than hard-coding an absolute number.
- Against the previous implementation the test fails with 33 queries for two pages and 233 for twenty-two.
- Ran `python testmanage.py test tests.test_synctree -v 1` and the full suite, `python testmanage.py test`, with 608 tests passing.
- Ran `ruff check` and `ruff format --check`.

## Trade-off

The bulk pass holds four columns of every page in the tree, aliases included, while the index is built. The index was already linear in memory — it holds one entry per page — so this changes what is held rather than introducing the cost, and the net effect is not obvious: the three mappings are new, but the locale lists they hold are now shared between entries instead of rebuilt for each one.

That effect is not measured here. Measuring it the same way, as bytes per indexed page across the two sizes, is a follow-up.

## AI usage

Used AI assistance to draft the fix, its regression test, and this description, and to run and interpret the benchmark measurements. I reviewed, tested and understood every change.