### PR TITLE
Handle removed fields when editing translations with draft source

### DIFF
--- a/src/wagtail_localize/views/edit_translation.py
+++ b/src/wagtail_localize/views/edit_translation.py
@@ -10,7 +10,7 @@ import polib
 from django.conf import settings
 from django.contrib.admin.utils import quote
 from django.contrib.auth import get_user_model
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import FieldDoesNotExist, PermissionDenied, ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models, transaction
 from django.http import Http404, HttpResponse
@@ -671,7 +671,7 @@ def edit_translation(request, translation: Translation, instance):
                 segment.context.path,
                 segment.context.get_field_path(source_instance),
             )
-        except FieldHasNoEditPanelError:
+        except (FieldHasNoEditPanelError, FieldDoesNotExist):
             continue
 
         segments.append(
@@ -701,7 +701,7 @@ def edit_translation(request, translation: Translation, instance):
                 segment.context.get_field_path(source_instance),
                 widget=True,
             )
-        except FieldHasNoEditPanelError:
+        except (FieldHasNoEditPanelError, FieldDoesNotExist):
             continue
 
         segments.append(
@@ -845,7 +845,7 @@ def edit_translation(request, translation: Translation, instance):
                 segment.context.path,
                 segment.context.get_field_path(source_instance),
             )
-        except FieldHasNoEditPanelError:
+        except (FieldHasNoEditPanelError, FieldDoesNotExist):
             continue
 
         segments.append(

--- a/tests/test_edit_translation.py
+++ b/tests/test_edit_translation.py
@@ -49,6 +49,7 @@ from wagtail_localize.models import (
     OverridableSegment,
     SegmentOverride,
     String,
+    StringSegment,
     StringTranslation,
     Translation,
     TranslationContext,
@@ -500,6 +501,41 @@ class TestGetEditTranslationView(EditTranslationTestData, TestCase):
             related_object_segment["translationProgress"],
             {"totalSegments": 1, "translatedSegments": 0},
         )
+
+    def test_edit_page_translation_with_removed_field(self):
+        # Simulates a segment referencing a field that was removed/renamed by a
+        # migration after translations were created. This should be skipped
+        # instead of raising FieldDoesNotExist. See wagtail-localize#590.
+        StringSegment.objects.create(
+            source=self.page_source,
+            context=TranslationContext.objects.create(
+                object=self.page_source.object,
+                path="removed_string_field",
+                field_path="removed_string_field",
+            ),
+            order=0,
+            string=String.from_value(self.page.locale, StringValue("Old field")),
+        )
+        OverridableSegment.objects.create(
+            source=self.page_source,
+            context=TranslationContext.objects.create(
+                object=self.page_source.object,
+                path="removed_override_field",
+                field_path="removed_override_field",
+            ),
+            order=0,
+            data_json='"foo"',
+        )
+
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[self.fr_page.id])
+        )
+        self.assertEqual(response.status_code, 200)
+
+        props = json.loads(response.context["props"])
+        content_paths = [segment["contentPath"] for segment in props["segments"]]
+        self.assertNotIn("removed_string_field", content_paths)
+        self.assertNotIn("removed_override_field", content_paths)
 
     def test_page_chooser_widgets(self):
         home_page_with_specific_type = self.home_page.add_child(


### PR DESCRIPTION
## Description

Fixes #590 — `FieldDoesNotExist` error when editing a translation whose source page has unpublished draft changes after a migration removes/renames a field.

It felt safe to ignore those now-removed fields as part of this process. The alternative would be to show a warning asking the user to do a sync first.

<details>
<summary>AI details</summary>

The translation editor calls `get_segment_location_info()`, which does `source_instance._meta.get_field(field_path[0])` (edit_translation.py:279). When a migration renames/removes a field that an existing draft segment still references, this raises `FieldDoesNotExist`, crashing the editor with a 500.

## Changes

- Catch `FieldDoesNotExist` alongside `FieldHasNoEditPanelError` at all three call sites in `edit_translation()` (lines 674, 704, 848), so stale segments referencing removed fields are skipped instead of crashing.
- Add a regression test that creates stale `StringSegment`/`OverridableSegment` records pointing at a nonexistent field and asserts the editor returns 200 and omits those segments.

Note: this gracefully handles the stale segments (the symptom); the underlying schema-out-of-date cleanup in the data model is out of scope.

</details>

## Testing

- `testmanage.py test tests.test_edit_translation` — 88 tests pass
- `ruff check` and `ruff format` clean
- Open Code Review: 0 findings
