### PR TITLE
Use the current mkdocstrings options key in the models reference pages

### DIFF
--- a/docs/ref/models/overridable-segments.md
+++ b/docs/ref/models/overridable-segments.md
@@ -19,7 +19,7 @@ style E stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models
-    selection:
+    options:
         members:
             - SegmentOverride
             - OverridableSegment

--- a/docs/ref/models/settings.md
+++ b/docs/ref/models/settings.md
@@ -12,7 +12,7 @@ style B stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models
-    selection:
+    options:
         members:
             - LocaleSynchronization
         filters:

--- a/docs/ref/models/translatable-segments.md
+++ b/docs/ref/models/translatable-segments.md
@@ -22,7 +22,7 @@ style I stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models
-    selection:
+    options:
         members:
             - SegmentOverride
             - StringSegment

--- a/docs/ref/models/translation-management.md
+++ b/docs/ref/models/translation-management.md
@@ -18,7 +18,7 @@ style F stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models
-    selection:
+    options:
         members:
             - TranslatableObject
             - TranslationSource

--- a/docs/ref/models/translation-memory.md
+++ b/docs/ref/models/translation-memory.md
@@ -16,7 +16,7 @@ style E stroke-dasharray: 5 5
 ```
 
 ::: wagtail_localize.models
-    selection:
+    options:
         members:
             - String
             - TranslationContext


### PR DESCRIPTION
Fixes #957

### Description

The five pages under `docs/ref/models/` declare their members under `selection:`, which mkdocstrings removed in 0.23. Renaming it to `options:` is the whole change — the `members` and `filters` lists are untouched.

Checked with a local build: each page now renders exactly what it declares — 4, 4, 5, 2 and 1 members respectively, against 24 on every page before.

### AI usage

Used AI assistance to investigate the cause, apply the rename across the files, and draft this description. I reproduced the bug and verified the result with a local build myself.